### PR TITLE
Added HTTP method+path to JavaDocs in kotlin clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-ktor/api.mustache
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 
     {{#operation}}
         /**
+        * {{{httpMethod}}} {{{path}}}
         * {{summary}}
         * {{notes}}
         {{#allParams}} * @param {{{paramName}}} {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -123,6 +123,7 @@ import {{packageName}}.infrastructure.toMultiValue
     {{/isEnum}}
     {{/allParams}}
     /**
+     * {{{httpMethod}}} {{{path}}}
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
@@ -160,6 +161,7 @@ import {{packageName}}.infrastructure.toMultiValue
     }
 
     /**
+     * {{{httpMethod}}} {{{path}}}
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-retrofit2/api.mustache
@@ -131,6 +131,7 @@ import okhttp3.MultipartBody
     {{/isEnum}}
     {{/allParams}}
     /**
+     * {{{httpMethod}}} {{{path}}}
      * {{summary}}
      * {{notes}}
      * Responses:{{#responses}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-vertx/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-vertx/api.mustache
@@ -88,6 +88,7 @@ import {{packageName}}.infrastructure.*
     {{/isEnum}}
     {{/allParams}}
     /**
+     * {{{httpMethod}}} {{{path}}}
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}
@@ -122,6 +123,7 @@ import {{packageName}}.infrastructure.*
     }
 
     /**
+     * {{{httpMethod}}} {{{path}}}
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-volley/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-volley/api.mustache
@@ -37,6 +37,7 @@ import {{packageName}}.infrastructure.CollectionFormats.*
 
     {{#operation}}
     /**
+     * {{{httpMethod}}} {{{path}}}
      * {{summary}}
      * {{notes}}
      {{#allParams}}* @param {{{paramName}}} {{description}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#required}}{{#defaultValue}} (default to {{{.}}}){{/defaultValue}}{{/required}}

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/AuthApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/AuthApi.kt
@@ -45,6 +45,7 @@ class AuthApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /auth/http/basic
      * To test HTTP basic authentication
      * To test HTTP basic authentication
      * @return kotlin.String
@@ -75,6 +76,7 @@ class AuthApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /auth/http/basic
      * To test HTTP basic authentication
      * To test HTTP basic authentication
      * @return ApiResponse<kotlin.String?>
@@ -113,6 +115,7 @@ class AuthApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /auth/http/bearer
      * To test HTTP bearer authentication
      * To test HTTP bearer authentication
      * @return kotlin.String
@@ -143,6 +146,7 @@ class AuthApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /auth/http/bearer
      * To test HTTP bearer authentication
      * To test HTTP bearer authentication
      * @return ApiResponse<kotlin.String?>

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
@@ -47,6 +47,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /binary/gif
      * Test binary (gif) response body
      * Test binary (gif) response body
      * @return java.io.File
@@ -77,6 +78,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /binary/gif
      * Test binary (gif) response body
      * Test binary (gif) response body
      * @return ApiResponse<java.io.File?>
@@ -114,6 +116,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /body/application/octetstream/binary
      * Test body parameter(s)
      * Test body parameter(s)
      * @param body  (optional)
@@ -145,6 +148,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /body/application/octetstream/binary
      * Test body parameter(s)
      * Test body parameter(s)
      * @param body  (optional)
@@ -186,6 +190,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /body/application/octetstream/array_of_binary
      * Test array of binary in multipart mime
      * Test array of binary in multipart mime
      * @param files 
@@ -217,6 +222,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /body/application/octetstream/array_of_binary
      * Test array of binary in multipart mime
      * Test array of binary in multipart mime
      * @param files 
@@ -258,6 +264,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /body/application/octetstream/single_binary
      * Test single binary in multipart mime
      * Test single binary in multipart mime
      * @param myFile  (optional)
@@ -289,6 +296,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /body/application/octetstream/single_binary
      * Test single binary in multipart mime
      * Test single binary in multipart mime
      * @param myFile  (optional)
@@ -330,6 +338,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/FreeFormObject/response_string
      * Test free form object
      * Test free form object
      * @param body Free form object (optional)
@@ -361,6 +370,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/FreeFormObject/response_string
      * Test free form object
      * Test free form object
      * @param body Free form object (optional)
@@ -402,6 +412,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/Pet
      * Test body parameter(s)
      * Test body parameter(s)
      * @param apiPet Pet object that needs to be added to the store (optional)
@@ -433,6 +444,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/Pet
      * Test body parameter(s)
      * Test body parameter(s)
      * @param apiPet Pet object that needs to be added to the store (optional)
@@ -474,6 +486,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/Pet/response_string
      * Test empty response body
      * Test empty response body
      * @param apiPet Pet object that needs to be added to the store (optional)
@@ -505,6 +518,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/Pet/response_string
      * Test empty response body
      * Test empty response body
      * @param apiPet Pet object that needs to be added to the store (optional)
@@ -546,6 +560,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/Tag/response_string
      * Test empty json (request body)
      * Test empty json (request body)
      * @param apiTag Tag object (optional)
@@ -577,6 +592,7 @@ class BodyApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /echo/body/Tag/response_string
      * Test empty json (request body)
      * Test empty json (request body)
      * @param apiTag Tag object (optional)

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/FormApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/FormApi.kt
@@ -45,6 +45,7 @@ class FormApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /form/integer/boolean/string
      * Test form parameter(s)
      * Test form parameter(s)
      * @param integerForm  (optional)
@@ -78,6 +79,7 @@ class FormApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /form/integer/boolean/string
      * Test form parameter(s)
      * Test form parameter(s)
      * @param integerForm  (optional)
@@ -125,6 +127,7 @@ class FormApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /form/oneof
      * Test form parameter(s) for oneOf schema
      * Test form parameter(s) for oneOf schema
      * @param form1  (optional)
@@ -161,6 +164,7 @@ class FormApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /form/oneof
      * Test form parameter(s) for oneOf schema
      * Test form parameter(s) for oneOf schema
      * @param form1  (optional)

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
@@ -64,6 +64,7 @@ class HeaderApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory 
      }
 
     /**
+     * GET /header/integer/boolean/string/enums
      * Test header parameter(s)
      * Test header parameter(s)
      * @param integerHeader  (optional)
@@ -99,6 +100,7 @@ class HeaderApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory 
     }
 
     /**
+     * GET /header/integer/boolean/string/enums
      * Test header parameter(s)
      * Test header parameter(s)
      * @param integerHeader  (optional)

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/PathApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/PathApi.kt
@@ -64,6 +64,7 @@ class PathApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
      }
 
     /**
+     * GET /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}
      * Test path parameter(s)
      * Test path parameter(s)
      * @param pathString 
@@ -98,6 +99,7 @@ class PathApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}
      * Test path parameter(s)
      * Test path parameter(s)
      * @param pathString 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
@@ -66,6 +66,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
      }
 
     /**
+     * GET /query/enum_ref_string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param enumNonrefStringQuery  (optional)
@@ -98,6 +99,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/enum_ref_string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param enumNonrefStringQuery  (optional)
@@ -148,6 +150,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/datetime/date/string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param datetimeQuery  (optional)
@@ -181,6 +184,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/datetime/date/string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param datetimeQuery  (optional)
@@ -236,6 +240,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/integer/boolean/string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param integerQuery  (optional)
@@ -269,6 +274,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/integer/boolean/string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param integerQuery  (optional)
@@ -324,6 +330,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/style_deepObject/explode_true/object
      * Test query parameter(s)
      * Test query parameter(s)
      * @param queryObject  (optional)
@@ -355,6 +362,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/style_deepObject/explode_true/object
      * Test query parameter(s)
      * Test query parameter(s)
      * @param queryObject  (optional)
@@ -400,6 +408,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/style_form/explode_true/array_string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param queryObject  (optional)
@@ -431,6 +440,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/style_form/explode_true/array_string
      * Test query parameter(s)
      * Test query parameter(s)
      * @param queryObject  (optional)
@@ -476,6 +486,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/style_form/explode_true/object
      * Test query parameter(s)
      * Test query parameter(s)
      * @param queryObject  (optional)
@@ -507,6 +518,7 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /query/style_form/explode_true/object
      * Test query parameter(s)
      * Test query parameter(s)
      * @param queryObject  (optional)

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/AuthApi.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/AuthApi.kt
@@ -9,6 +9,7 @@ import com.google.gson.annotations.SerializedName
 
 interface AuthApi {
     /**
+     * POST auth/http/basic
      * To test HTTP basic authentication
      * To test HTTP basic authentication
      * Responses:
@@ -20,6 +21,7 @@ interface AuthApi {
     suspend fun testAuthHttpBasic(): Response<kotlin.String>
 
     /**
+     * POST auth/http/bearer
      * To test HTTP bearer authentication
      * To test HTTP bearer authentication
      * Responses:

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
@@ -14,6 +14,7 @@ import okhttp3.MultipartBody
 
 interface BodyApi {
     /**
+     * POST binary/gif
      * Test binary (gif) response body
      * Test binary (gif) response body
      * Responses:
@@ -25,6 +26,7 @@ interface BodyApi {
     suspend fun testBinaryGif(): Response<ResponseBody>
 
     /**
+     * POST body/application/octetstream/binary
      * Test body parameter(s)
      * Test body parameter(s)
      * Responses:
@@ -37,6 +39,7 @@ interface BodyApi {
     suspend fun testBodyApplicationOctetstreamBinary(@Body body: RequestBody? = null): Response<kotlin.String>
 
     /**
+     * POST body/application/octetstream/array_of_binary
      * Test array of binary in multipart mime
      * Test array of binary in multipart mime
      * Responses:
@@ -50,6 +53,7 @@ interface BodyApi {
     suspend fun testBodyMultipartFormdataArrayOfBinary(@Part files: MultipartBody.Part): Response<kotlin.String>
 
     /**
+     * POST body/application/octetstream/single_binary
      * Test single binary in multipart mime
      * Test single binary in multipart mime
      * Responses:
@@ -63,6 +67,7 @@ interface BodyApi {
     suspend fun testBodyMultipartFormdataSingleBinary(@Part myFile: MultipartBody.Part? = null): Response<kotlin.String>
 
     /**
+     * POST echo/body/FreeFormObject/response_string
      * Test free form object
      * Test free form object
      * Responses:
@@ -75,6 +80,7 @@ interface BodyApi {
     suspend fun testEchoBodyFreeFormObjectResponseString(@Body body: kotlin.Any? = null): Response<kotlin.String>
 
     /**
+     * POST echo/body/Pet
      * Test body parameter(s)
      * Test body parameter(s)
      * Responses:
@@ -87,6 +93,7 @@ interface BodyApi {
     suspend fun testEchoBodyPet(@Body apiPet: ApiPet? = null): Response<ApiPet>
 
     /**
+     * POST echo/body/Pet/response_string
      * Test empty response body
      * Test empty response body
      * Responses:
@@ -99,6 +106,7 @@ interface BodyApi {
     suspend fun testEchoBodyPetResponseString(@Body apiPet: ApiPet? = null): Response<kotlin.String>
 
     /**
+     * POST echo/body/Tag/response_string
      * Test empty json (request body)
      * Test empty json (request body)
      * Responses:

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/FormApi.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/FormApi.kt
@@ -9,6 +9,7 @@ import com.google.gson.annotations.SerializedName
 
 interface FormApi {
     /**
+     * POST form/integer/boolean/string
      * Test form parameter(s)
      * Test form parameter(s)
      * Responses:
@@ -24,6 +25,7 @@ interface FormApi {
     suspend fun testFormIntegerBooleanString(@Field("integer_form") integerForm: kotlin.Int? = null, @Field("boolean_form") booleanForm: kotlin.Boolean? = null, @Field("string_form") stringForm: kotlin.String? = null): Response<kotlin.String>
 
     /**
+     * POST form/oneof
      * Test form parameter(s) for oneOf schema
      * Test form parameter(s) for oneOf schema
      * Responses:

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
@@ -20,6 +20,7 @@ interface HeaderApi {
     }
 
     /**
+     * GET header/integer/boolean/string/enums
      * Test header parameter(s)
      * Test header parameter(s)
      * Responses:

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/PathApi.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/PathApi.kt
@@ -20,6 +20,7 @@ interface PathApi {
     }
 
     /**
+     * GET path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}
      * Test path parameter(s)
      * Test path parameter(s)
      * Responses:

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
@@ -24,6 +24,7 @@ interface QueryApi {
     }
 
     /**
+     * GET query/enum_ref_string
      * Test query parameter(s)
      * Test query parameter(s)
      * Responses:
@@ -37,6 +38,7 @@ interface QueryApi {
     suspend fun testEnumRefString(@Query("enum_nonref_string_query") enumNonrefStringQuery: EnumNonrefStringQueryTestEnumRefString? = null, @Query("enum_ref_string_query") enumRefStringQuery: ApiStringEnumRef? = null): Response<kotlin.String>
 
     /**
+     * GET query/datetime/date/string
      * Test query parameter(s)
      * Test query parameter(s)
      * Responses:
@@ -51,6 +53,7 @@ interface QueryApi {
     suspend fun testQueryDatetimeDateString(@Query("datetime_query") datetimeQuery: java.time.OffsetDateTime? = null, @Query("date_query") dateQuery: java.time.LocalDate? = null, @Query("string_query") stringQuery: kotlin.String? = null): Response<kotlin.String>
 
     /**
+     * GET query/integer/boolean/string
      * Test query parameter(s)
      * Test query parameter(s)
      * Responses:
@@ -65,6 +68,7 @@ interface QueryApi {
     suspend fun testQueryIntegerBooleanString(@Query("integer_query") integerQuery: kotlin.Int? = null, @Query("boolean_query") booleanQuery: kotlin.Boolean? = null, @Query("string_query") stringQuery: kotlin.String? = null): Response<kotlin.String>
 
     /**
+     * GET query/style_deepObject/explode_true/object
      * Test query parameter(s)
      * Test query parameter(s)
      * Responses:
@@ -77,6 +81,7 @@ interface QueryApi {
     suspend fun testQueryStyleDeepObjectExplodeTrueObject(@Query("query_object") queryObject: ApiPet? = null): Response<kotlin.String>
 
     /**
+     * GET query/style_form/explode_true/array_string
      * Test query parameter(s)
      * Test query parameter(s)
      * Responses:
@@ -89,6 +94,7 @@ interface QueryApi {
     suspend fun testQueryStyleFormExplodeTrueArrayString(@Query("values") values: kotlin.collections.List<kotlin.String>? = null): Response<kotlin.String>
 
     /**
+     * GET query/style_form/explode_true/object
      * Test query parameter(s)
      * Test query parameter(s)
      * Responses:

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -78,6 +79,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -119,6 +121,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -150,6 +153,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -209,6 +213,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -240,6 +245,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -283,6 +289,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -316,6 +323,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -362,6 +370,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -393,6 +402,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -433,6 +443,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -464,6 +475,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -505,6 +517,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -537,6 +550,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -581,6 +595,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -614,6 +629,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet

--- a/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-non-ascii-headers/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -115,6 +117,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -145,6 +148,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -184,6 +188,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -214,6 +219,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -253,6 +259,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -283,6 +290,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -321,6 +329,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -352,6 +361,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -392,6 +402,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -424,6 +435,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -470,6 +482,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -499,6 +512,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -535,6 +549,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -566,6 +581,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -99,6 +99,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
      }
 
     /**
+     * GET /test/parameters/{path_default}/{path_nullable}
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param pathDefault path default
@@ -143,6 +144,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * GET /test/parameters/{path_default}/{path_nullable}
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param pathDefault path default

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/apis/BirdApi.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/apis/BirdApi.kt
@@ -46,6 +46,7 @@ class BirdApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /v1/bird/{id}
      * 
      * 
      * @param id 
@@ -77,6 +78,7 @@ class BirdApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /v1/bird/{id}
      * 
      * 
      * @param id 

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -45,6 +45,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * GET /{ids}
      * 
      * 
      * @param ids 
@@ -75,6 +76,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * GET /{ids}
      * 
      * 
      * @param ids 

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-volley/src/main/java/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-volley/src/main/java/org/openapitools/client/apis/DefaultApi.kt
@@ -33,6 +33,7 @@ class DefaultApi (
     private val postProcessors :List <(Request<*>) -> Unit> = listOf()) {
 
     /**
+     * GET /{ids}
      * 
      * 
      * @param ids 

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -46,6 +46,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * POST /test
      * 
      * 
      * @param apa 
@@ -76,6 +77,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * POST /test
      * 
      * 
      * @param apa 

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -45,6 +45,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * POST /test
      * Tests default values
      * Tests default values of different parameters
      * @param pi0  (default to 10)
@@ -103,6 +104,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * POST /test
      * Tests default values
      * Tests default values of different parameters
      * @param pi0  (default to 10)

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -9,6 +9,7 @@ import com.squareup.moshi.Json
 
 interface DefaultApi {
     /**
+     * POST test
      * Tests default values
      * Tests default values of different parameters
      * Responses:

--- a/samples/client/petstore/kotlin-default-values-jvm-volley/src/main/java/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-volley/src/main/java/org/openapitools/client/apis/DefaultApi.kt
@@ -33,6 +33,7 @@ class DefaultApi (
     private val postProcessors :List <(Request<*>) -> Unit> = listOf()) {
 
     /**
+     * POST /test
      * Tests default values
      * Tests default values of different parameters
      * @param pi0  (default to 10)

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -46,6 +46,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * GET /
      * 
      * 
      * @return ModelWithEnumPropertyHavingDefault
@@ -76,6 +77,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory
     }
 
     /**
+     * GET /
      * 
      * 
      * @return ApiResponse<ModelWithEnumPropertyHavingDefault?>

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ public class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fact
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ public class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-explicit/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ public class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Fac
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -207,6 +211,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -238,6 +243,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -281,6 +287,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -314,6 +321,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -360,6 +368,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -391,6 +400,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -431,6 +441,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -461,6 +472,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -500,6 +512,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -532,6 +545,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -576,6 +590,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -609,6 +624,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -48,6 +48,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -78,6 +79,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -117,6 +119,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -148,6 +151,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -189,6 +193,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -222,6 +227,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -268,6 +274,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/getAll
      * Get all pets
      * 
      * @param lastUpdated When this endpoint was hit last to help identify if the client already has the latest copy. (optional)
@@ -299,6 +306,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/getAll
      * Get all pets
      * 
      * @param lastUpdated When this endpoint was hit last to help identify if the client already has the latest copy. (optional)
@@ -344,6 +352,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -375,6 +384,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -415,6 +425,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -445,6 +456,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -484,6 +496,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -516,6 +529,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -560,6 +574,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -593,6 +608,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -47,6 +47,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -77,6 +78,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -115,6 +117,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -145,6 +148,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -183,6 +187,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -214,6 +219,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -254,6 +260,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -285,6 +292,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -47,6 +47,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -77,6 +78,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -115,6 +117,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -145,6 +148,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -183,6 +187,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -213,6 +218,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -251,6 +257,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -281,6 +288,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -319,6 +327,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -350,6 +359,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -390,6 +400,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -422,6 +433,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -468,6 +480,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -497,6 +510,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -533,6 +547,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -564,6 +579,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 
 interface PetApi {
     /**
+     * POST pet
      * Add a new pet to the store
      * 
      * Responses:
@@ -26,6 +27,7 @@ interface PetApi {
     fun addPet(@Body pet: Pet): Call<Pet>
 
     /**
+     * DELETE pet/{petId}
      * Deletes a pet
      * 
      * Responses:
@@ -49,6 +51,7 @@ interface PetApi {
     }
 
     /**
+     * GET pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * Responses:
@@ -62,6 +65,7 @@ interface PetApi {
     fun findPetsByStatus(@Query("status") status: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Responses:
@@ -76,6 +80,7 @@ interface PetApi {
     fun findPetsByTags(@Query("tags") tags: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * Responses:
@@ -90,6 +95,7 @@ interface PetApi {
     fun getPetById(@Path("petId") petId: kotlin.Long): Call<Pet>
 
     /**
+     * PUT pet
      * Update an existing pet
      * 
      * Responses:
@@ -105,6 +111,7 @@ interface PetApi {
     fun updatePet(@Body pet: Pet): Call<Pet>
 
     /**
+     * POST pet/{petId}
      * Updates a pet in the store with form data
      * 
      * Responses:
@@ -120,6 +127,7 @@ interface PetApi {
     fun updatePetWithForm(@Path("petId") petId: kotlin.Long, @Field("name") name: kotlin.String? = null, @Field("status") status: kotlin.String? = null): Call<Unit>
 
     /**
+     * POST pet/{petId}/uploadImage
      * uploads an image
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.Order
 
 interface StoreApi {
     /**
+     * DELETE store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * Responses:
@@ -23,6 +24,7 @@ interface StoreApi {
     fun deleteOrder(@Path("orderId") orderId: kotlin.String): Call<Unit>
 
     /**
+     * GET store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * Responses:
@@ -34,6 +36,7 @@ interface StoreApi {
     fun getInventory(): Call<kotlin.collections.Map<kotlin.String, kotlin.Int>>
 
     /**
+     * GET store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * Responses:
@@ -48,6 +51,7 @@ interface StoreApi {
     fun getOrderById(@Path("orderId") orderId: kotlin.Long): Call<Order>
 
     /**
+     * POST store/order
      * Place an order for a pet
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.User
 
 interface UserApi {
     /**
+     * POST user
      * Create user
      * This can only be done by the logged in user.
      * Responses:
@@ -22,6 +23,7 @@ interface UserApi {
     fun createUser(@Body user: User): Call<Unit>
 
     /**
+     * POST user/createWithArray
      * Creates list of users with given input array
      * 
      * Responses:
@@ -34,6 +36,7 @@ interface UserApi {
     fun createUsersWithArrayInput(@Body user: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * POST user/createWithList
      * Creates list of users with given input array
      * 
      * Responses:
@@ -46,6 +49,7 @@ interface UserApi {
     fun createUsersWithListInput(@Body user: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * DELETE user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * Responses:
@@ -59,6 +63,7 @@ interface UserApi {
     fun deleteUser(@Path("username") username: kotlin.String): Call<Unit>
 
     /**
+     * GET user/{username}
      * Get user by user name
      * 
      * Responses:
@@ -73,6 +78,7 @@ interface UserApi {
     fun getUserByName(@Path("username") username: kotlin.String): Call<User>
 
     /**
+     * GET user/login
      * Logs user into the system
      * 
      * Responses:
@@ -87,6 +93,7 @@ interface UserApi {
     fun loginUser(@Query("username") username: kotlin.String, @Query("password") password: kotlin.String): Call<kotlin.String>
 
     /**
+     * GET user/logout
      * Logs out current logged in user session
      * 
      * Responses:
@@ -98,6 +105,7 @@ interface UserApi {
     fun logoutUser(): Call<Unit>
 
     /**
+     * PUT user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * Responses:

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -40,6 +40,7 @@ import java.text.DateFormat
     ) {
 
         /**
+        * POST /pet
         * Add a new pet to the store
         * 
          * @param body Pet object that needs to be added to the store 
@@ -71,6 +72,7 @@ import java.text.DateFormat
             }
 
         /**
+        * DELETE /pet/{petId}
         * Deletes a pet
         * 
          * @param petId Pet id to delete 
@@ -105,6 +107,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /pet/findByStatus
         * Finds Pets by status
         * Multiple status values can be provided with comma separated strings
          * @param status Status values that need to be considered for filter 
@@ -139,6 +142,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /pet/findByTags
         * Finds Pets by tags
         * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @param tags Tags to filter by 
@@ -173,6 +177,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /pet/{petId}
         * Find pet by ID
         * Returns a single pet
          * @param petId ID of pet to return 
@@ -206,6 +211,7 @@ import java.text.DateFormat
             }
 
         /**
+        * PUT /pet
         * Update an existing pet
         * 
          * @param body Pet object that needs to be added to the store 
@@ -237,6 +243,7 @@ import java.text.DateFormat
             }
 
         /**
+        * POST /pet/{petId}
         * Updates a pet in the store with form data
         * 
          * @param petId ID of pet that needs to be updated 
@@ -274,6 +281,7 @@ import java.text.DateFormat
             }
 
         /**
+        * POST /pet/{petId}/uploadImage
         * uploads an image
         * 
          * @param petId ID of pet to update 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -39,6 +39,7 @@ import java.text.DateFormat
     ) {
 
         /**
+        * DELETE /store/order/{orderId}
         * Delete purchase order by ID
         * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
          * @param orderId ID of the order that needs to be deleted 
@@ -71,6 +72,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /store/inventory
         * Returns pet inventories by status
         * Returns a map of status codes to quantities
          * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -103,6 +105,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /store/order/{orderId}
         * Find purchase order by ID
         * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
          * @param orderId ID of pet that needs to be fetched 
@@ -136,6 +139,7 @@ import java.text.DateFormat
             }
 
         /**
+        * POST /store/order
         * Place an order for a pet
         * 
          * @param body order placed for purchasing the pet 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -39,6 +39,7 @@ import java.text.DateFormat
     ) {
 
         /**
+        * POST /user
         * Create user
         * This can only be done by the logged in user.
          * @param body Created user object 
@@ -70,6 +71,7 @@ import java.text.DateFormat
             }
 
         /**
+        * POST /user/createWithArray
         * Creates list of users with given input array
         * 
          * @param body List of user object 
@@ -101,6 +103,7 @@ import java.text.DateFormat
             }
 
         /**
+        * POST /user/createWithList
         * Creates list of users with given input array
         * 
          * @param body List of user object 
@@ -132,6 +135,7 @@ import java.text.DateFormat
             }
 
         /**
+        * DELETE /user/{username}
         * Delete user
         * This can only be done by the logged in user.
          * @param username The name that needs to be deleted 
@@ -164,6 +168,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /user/{username}
         * Get user by user name
         * 
          * @param username The name that needs to be fetched. Use user1 for testing. 
@@ -197,6 +202,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /user/login
         * Logs user into the system
         * 
          * @param username The user name for login 
@@ -233,6 +239,7 @@ import java.text.DateFormat
             }
 
         /**
+        * GET /user/logout
         * Logs out current logged in user session
         * 
          * @return void
@@ -264,6 +271,7 @@ import java.text.DateFormat
             }
 
         /**
+        * PUT /user/{username}
         * Updated user
         * This can only be done by the logged in user.
          * @param username name that need to be deleted 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
     ) {
 
         /**
+        * POST /pet
         * Add a new pet to the store
         * 
          * @param body Pet object that needs to be added to the store 
@@ -69,6 +70,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * DELETE /pet/{petId}
         * Deletes a pet
         * 
          * @param petId Pet id to delete 
@@ -103,6 +105,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /pet/findByStatus
         * Finds Pets by status
         * Multiple status values can be provided with comma separated strings
          * @param status Status values that need to be considered for filter 
@@ -137,6 +140,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /pet/findByTags
         * Finds Pets by tags
         * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @param tags Tags to filter by 
@@ -171,6 +175,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /pet/{petId}
         * Find pet by ID
         * Returns a single pet
          * @param petId ID of pet to return 
@@ -204,6 +209,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * PUT /pet
         * Update an existing pet
         * 
          * @param body Pet object that needs to be added to the store 
@@ -235,6 +241,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * POST /pet/{petId}
         * Updates a pet in the store with form data
         * 
          * @param petId ID of pet that needs to be updated 
@@ -272,6 +279,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * POST /pet/{petId}/uploadImage
         * uploads an image
         * 
          * @param petId ID of pet to update 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
     ) {
 
         /**
+        * DELETE /store/order/{orderId}
         * Delete purchase order by ID
         * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
          * @param orderId ID of the order that needs to be deleted 
@@ -69,6 +70,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /store/inventory
         * Returns pet inventories by status
         * Returns a map of status codes to quantities
          * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -101,6 +103,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /store/order/{orderId}
         * Find purchase order by ID
         * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
          * @param orderId ID of pet that needs to be fetched 
@@ -134,6 +137,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * POST /store/order
         * Place an order for a pet
         * 
          * @param body order placed for purchasing the pet 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
     ) {
 
         /**
+        * POST /user
         * Create user
         * This can only be done by the logged in user.
          * @param body Created user object 
@@ -68,6 +69,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * POST /user/createWithArray
         * Creates list of users with given input array
         * 
          * @param body List of user object 
@@ -99,6 +101,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * POST /user/createWithList
         * Creates list of users with given input array
         * 
          * @param body List of user object 
@@ -130,6 +133,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * DELETE /user/{username}
         * Delete user
         * This can only be done by the logged in user.
          * @param username The name that needs to be deleted 
@@ -162,6 +166,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /user/{username}
         * Get user by user name
         * 
          * @param username The name that needs to be fetched. Use user1 for testing. 
@@ -195,6 +200,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /user/login
         * Logs user into the system
         * 
          * @param username The user name for login 
@@ -231,6 +237,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * GET /user/logout
         * Logs out current logged in user session
         * 
          * @return void
@@ -262,6 +269,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
             }
 
         /**
+        * PUT /user/{username}
         * Updated user
         * This can only be done by the logged in user.
          * @param username name that need to be deleted 

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -35,6 +35,7 @@ import io.ktor.http.ParametersBuilder
     ) {
 
         /**
+        * POST /pet
         * Add a new pet to the store
         * 
          * @param pet Pet object that needs to be added to the store 
@@ -67,6 +68,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * DELETE /pet/{petId}
         * Deletes a pet
         * 
          * @param petId Pet id to delete 
@@ -101,6 +103,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /pet/findByStatus
         * Finds Pets by status
         * Multiple status values can be provided with comma separated strings
          * @param status Status values that need to be considered for filter 
@@ -135,6 +138,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /pet/findByTags
         * Finds Pets by tags
         * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
          * @param tags Tags to filter by 
@@ -169,6 +173,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /pet/{petId}
         * Find pet by ID
         * Returns a single pet
          * @param petId ID of pet to return 
@@ -202,6 +207,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * PUT /pet
         * Update an existing pet
         * 
          * @param pet Pet object that needs to be added to the store 
@@ -234,6 +240,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * POST /pet/{petId}
         * Updates a pet in the store with form data
         * 
          * @param petId ID of pet that needs to be updated 
@@ -271,6 +278,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * POST /pet/{petId}/uploadImage
         * uploads an image
         * 
          * @param petId ID of pet to update 

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -34,6 +34,7 @@ import io.ktor.http.ParametersBuilder
     ) {
 
         /**
+        * DELETE /store/order/{orderId}
         * Delete purchase order by ID
         * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
          * @param orderId ID of the order that needs to be deleted 
@@ -66,6 +67,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /store/inventory
         * Returns pet inventories by status
         * Returns a map of status codes to quantities
          * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -98,6 +100,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /store/order/{orderId}
         * Find purchase order by ID
         * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
          * @param orderId ID of pet that needs to be fetched 
@@ -131,6 +134,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * POST /store/order
         * Place an order for a pet
         * 
          * @param order order placed for purchasing the pet 

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -34,6 +34,7 @@ import io.ktor.http.ParametersBuilder
     ) {
 
         /**
+        * POST /user
         * Create user
         * This can only be done by the logged in user.
          * @param user Created user object 
@@ -65,6 +66,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * POST /user/createWithArray
         * Creates list of users with given input array
         * 
          * @param user List of user object 
@@ -96,6 +98,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * POST /user/createWithList
         * Creates list of users with given input array
         * 
          * @param user List of user object 
@@ -127,6 +130,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * DELETE /user/{username}
         * Delete user
         * This can only be done by the logged in user.
          * @param username The name that needs to be deleted 
@@ -159,6 +163,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /user/{username}
         * Get user by user name
         * 
          * @param username The name that needs to be fetched. Use user1 for testing. 
@@ -192,6 +197,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /user/login
         * Logs user into the system
         * 
          * @param username The user name for login 
@@ -228,6 +234,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * GET /user/logout
         * Logs out current logged in user session
         * 
          * @return void
@@ -259,6 +266,7 @@ import io.ktor.http.ParametersBuilder
             }
 
         /**
+        * PUT /user/{username}
         * Updated user
         * This can only be done by the logged in user.
          * @param username name that need to be deleted 

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -49,6 +49,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -79,6 +80,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -118,6 +120,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -149,6 +152,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -208,6 +212,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -239,6 +244,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -282,6 +288,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -315,6 +322,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -361,6 +369,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -392,6 +401,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -432,6 +442,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -462,6 +473,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -501,6 +513,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -533,6 +546,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -577,6 +591,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -610,6 +625,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -48,6 +48,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -78,6 +79,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -116,6 +118,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -146,6 +149,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -184,6 +188,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -215,6 +220,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -255,6 +261,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -286,6 +293,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -48,6 +48,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -78,6 +79,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -116,6 +118,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -146,6 +149,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -184,6 +188,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -214,6 +219,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -252,6 +258,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -282,6 +289,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -320,6 +328,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -351,6 +360,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -391,6 +401,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -423,6 +434,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -469,6 +481,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -498,6 +511,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -534,6 +548,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -565,6 +580,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -37,6 +37,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -68,6 +69,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -104,6 +106,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -135,6 +138,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -177,6 +181,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -208,6 +213,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -242,6 +248,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -274,6 +281,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -309,6 +317,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -340,6 +349,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -377,6 +387,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -408,6 +419,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -444,6 +456,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -476,6 +489,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -513,6 +527,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -546,6 +561,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -36,6 +36,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -66,6 +67,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -95,6 +97,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -125,6 +128,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -161,6 +165,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -192,6 +197,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -222,6 +228,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet
@@ -253,6 +260,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -36,6 +36,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -66,6 +67,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -104,6 +106,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -134,6 +137,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -172,6 +176,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -202,6 +207,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -240,6 +246,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -270,6 +277,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -306,6 +314,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -337,6 +346,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -367,6 +377,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -399,6 +410,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -432,6 +444,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -461,6 +474,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -496,6 +510,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -527,6 +542,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -41,6 +41,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -72,6 +73,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -108,6 +110,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -139,6 +142,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -181,6 +185,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -212,6 +217,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -246,6 +252,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -278,6 +285,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +321,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -344,6 +353,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -381,6 +391,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -412,6 +423,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -448,6 +460,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -480,6 +493,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -517,6 +531,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -550,6 +565,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -40,6 +40,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -70,6 +71,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -99,6 +101,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -129,6 +132,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -165,6 +169,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -196,6 +201,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -226,6 +232,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet
@@ -257,6 +264,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -40,6 +40,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -70,6 +71,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -108,6 +110,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -138,6 +141,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -176,6 +180,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -206,6 +211,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -244,6 +250,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -274,6 +281,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -310,6 +318,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -341,6 +350,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -371,6 +381,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -403,6 +414,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -436,6 +448,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -465,6 +478,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -500,6 +514,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -531,6 +546,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -37,6 +37,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -68,6 +69,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -104,6 +106,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -135,6 +138,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -177,6 +181,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -208,6 +213,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -242,6 +248,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -274,6 +281,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -309,6 +317,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -340,6 +349,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -377,6 +387,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -408,6 +419,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -444,6 +456,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -476,6 +489,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -513,6 +527,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -546,6 +561,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -36,6 +36,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -66,6 +67,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -95,6 +97,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -125,6 +128,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -161,6 +165,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -192,6 +197,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -222,6 +228,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet
@@ -253,6 +260,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -36,6 +36,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -66,6 +67,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -104,6 +106,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -134,6 +137,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -172,6 +176,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -202,6 +207,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -240,6 +246,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -270,6 +277,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -306,6 +314,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -337,6 +346,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -367,6 +377,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -399,6 +410,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -432,6 +444,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -461,6 +474,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -496,6 +510,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -527,6 +542,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -36,6 +36,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -67,6 +68,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param pet Pet object that needs to be added to the store
@@ -103,6 +105,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -134,6 +137,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -176,6 +180,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -207,6 +212,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -241,6 +247,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -273,6 +280,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -308,6 +316,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -339,6 +348,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -376,6 +386,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -407,6 +418,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param pet Pet object that needs to be added to the store
@@ -443,6 +455,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -475,6 +488,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -512,6 +526,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -545,6 +560,7 @@ class PetApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: S
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -35,6 +35,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -65,6 +66,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -94,6 +96,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -124,6 +127,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -160,6 +164,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -191,6 +196,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -221,6 +227,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet
@@ -252,6 +259,7 @@ class StoreApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken:
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param order order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -35,6 +35,7 @@ import org.openapitools.client.infrastructure.*
 @Suppress ("UNUSED")
 class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: String? = null, apiKey: MutableMap<String, String> = mutableMapOf(), apiKeyPrefix: MutableMap<String, String> = mutableMapOf(), username: String? = null, password: String? = null, vertx: Vertx): ApiClient(basePath, accessToken, apiKey, apiKeyPrefix, username, password, vertx) {
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -65,6 +66,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param user Created user object
@@ -103,6 +105,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -133,6 +136,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -171,6 +175,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -201,6 +206,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param user List of user object
@@ -239,6 +245,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -269,6 +276,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -305,6 +313,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -336,6 +345,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -366,6 +376,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -398,6 +409,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -431,6 +443,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -460,6 +473,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -495,6 +509,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -526,6 +541,7 @@ class UserApi(basePath: kotlin.String = ApiClient.defaultBasePath, accessToken: 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/apis/PetApi.kt
@@ -35,6 +35,7 @@ class PetApi (
     private val postProcessors :List <(Request<*>) -> Unit> = listOf()) {
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -96,6 +97,7 @@ class PetApi (
         }
     }
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -160,6 +162,7 @@ class PetApi (
         }
     }
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -223,6 +226,7 @@ class PetApi (
         }
     }
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -287,6 +291,7 @@ class PetApi (
         }
     }
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -348,6 +353,7 @@ class PetApi (
         }
     }
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -409,6 +415,7 @@ class PetApi (
         }
     }
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -475,6 +482,7 @@ class PetApi (
         }
     }
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/apis/StoreApi.kt
@@ -34,6 +34,7 @@ class StoreApi (
     private val postProcessors :List <(Request<*>) -> Unit> = listOf()) {
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -95,6 +96,7 @@ class StoreApi (
         }
     }
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -155,6 +157,7 @@ class StoreApi (
         }
     }
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -216,6 +219,7 @@ class StoreApi (
         }
     }
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-volley/src/main/java/org/openapitools/client/apis/UserApi.kt
@@ -34,6 +34,7 @@ class UserApi (
     private val postProcessors :List <(Request<*>) -> Unit> = listOf()) {
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -95,6 +96,7 @@ class UserApi (
         }
     }
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -156,6 +158,7 @@ class UserApi (
         }
     }
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -217,6 +220,7 @@ class UserApi (
         }
     }
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -278,6 +282,7 @@ class UserApi (
         }
     }
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -339,6 +344,7 @@ class UserApi (
         }
     }
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -404,6 +410,7 @@ class UserApi (
         }
     }
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -464,6 +471,7 @@ class UserApi (
         }
     }
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/FakeApi.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/FakeApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.ApiAnnotation
 
 interface FakeApi {
     /**
+     * POST fake/annotations
      * annotate
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 
 interface PetApi {
     /**
+     * POST pet
      * Add a new pet to the store
      * 
      * Responses:
@@ -26,6 +27,7 @@ interface PetApi {
     suspend fun addPet(@Body apiPet: ApiPet): Response<ApiPet>
 
     /**
+     * DELETE pet/{petId}
      * Deletes a pet
      * 
      * Responses:
@@ -49,6 +51,7 @@ interface PetApi {
     }
 
     /**
+     * GET pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * Responses:
@@ -62,6 +65,7 @@ interface PetApi {
     suspend fun findPetsByStatus(@Query("status") status: CSVParams): Response<kotlin.collections.List<ApiPet>>
 
     /**
+     * GET pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Responses:
@@ -76,6 +80,7 @@ interface PetApi {
     suspend fun findPetsByTags(@Query("tags") tags: CSVParams): Response<kotlin.collections.List<ApiPet>>
 
     /**
+     * GET pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * Responses:
@@ -90,6 +95,7 @@ interface PetApi {
     suspend fun getPetById(@Path("petId") petId: kotlin.Long): Response<ApiPet>
 
     /**
+     * PUT pet
      * Update an existing pet
      * 
      * Responses:
@@ -105,6 +111,7 @@ interface PetApi {
     suspend fun updatePet(@Body apiPet: ApiPet): Response<ApiPet>
 
     /**
+     * POST pet/{petId}
      * Updates a pet in the store with form data
      * 
      * Responses:
@@ -120,6 +127,7 @@ interface PetApi {
     suspend fun updatePetWithForm(@Path("petId") petId: kotlin.Long, @Field("name") name: kotlin.String? = null, @Field("status") status: kotlin.String? = null): Response<Unit>
 
     /**
+     * POST pet/{petId}/uploadImage
      * uploads an image
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.ApiOrder
 
 interface StoreApi {
     /**
+     * DELETE store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * Responses:
@@ -23,6 +24,7 @@ interface StoreApi {
     suspend fun deleteOrder(@Path("orderId") orderId: kotlin.String): Response<Unit>
 
     /**
+     * GET store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * Responses:
@@ -34,6 +36,7 @@ interface StoreApi {
     suspend fun getInventory(): Response<kotlin.collections.Map<kotlin.String, kotlin.Int>>
 
     /**
+     * GET store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * Responses:
@@ -48,6 +51,7 @@ interface StoreApi {
     suspend fun getOrderById(@Path("orderId") orderId: kotlin.Long): Response<ApiOrder>
 
     /**
+     * POST store/order
      * Place an order for a pet
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.ApiUser
 
 interface UserApi {
     /**
+     * POST user
      * Create user
      * This can only be done by the logged in user.
      * Responses:
@@ -22,6 +23,7 @@ interface UserApi {
     suspend fun createUser(@Body apiUser: ApiUser): Response<Unit>
 
     /**
+     * POST user/createWithArray
      * Creates list of users with given input array
      * 
      * Responses:
@@ -34,6 +36,7 @@ interface UserApi {
     suspend fun createUsersWithArrayInput(@Body apiUser: kotlin.collections.List<ApiUser>): Response<Unit>
 
     /**
+     * POST user/createWithList
      * Creates list of users with given input array
      * 
      * Responses:
@@ -46,6 +49,7 @@ interface UserApi {
     suspend fun createUsersWithListInput(@Body apiUser: kotlin.collections.List<ApiUser>): Response<Unit>
 
     /**
+     * DELETE user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * Responses:
@@ -59,6 +63,7 @@ interface UserApi {
     suspend fun deleteUser(@Path("username") username: kotlin.String): Response<Unit>
 
     /**
+     * GET user/{username}
      * Get user by user name
      * 
      * Responses:
@@ -73,6 +78,7 @@ interface UserApi {
     suspend fun getUserByName(@Path("username") username: kotlin.String): Response<ApiUser>
 
     /**
+     * GET user/login
      * Logs user into the system
      * 
      * Responses:
@@ -87,6 +93,7 @@ interface UserApi {
     suspend fun loginUser(@Query("username") username: kotlin.String, @Query("password") password: kotlin.String): Response<kotlin.String>
 
     /**
+     * GET user/logout
      * Logs out current logged in user session
      * 
      * Responses:
@@ -98,6 +105,7 @@ interface UserApi {
     suspend fun logoutUser(): Response<Unit>
 
     /**
+     * PUT user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * Responses:

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.MutableMap<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.MutableMap<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/apis/FakeApi.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/apis/FakeApi.kt
@@ -46,6 +46,7 @@ class FakeApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /fake/parameter-name-mapping
      * parameter name mapping test
      * 
      * @param underscoreType _type
@@ -80,6 +81,7 @@ class FakeApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /fake/parameter-name-mapping
      * parameter name mapping test
      * 
      * @param underscoreType _type

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ internal class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Fa
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ internal class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ internal class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.F
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int> or null
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 
 interface PetApi {
     /**
+     * POST pet
      * Add a new pet to the store
      * 
      * Responses:
@@ -26,6 +27,7 @@ interface PetApi {
     fun addPet(@Body pet: Pet): Call<Pet>
 
     /**
+     * DELETE pet/{petId}
      * Deletes a pet
      * 
      * Responses:
@@ -49,6 +51,7 @@ interface PetApi {
     }
 
     /**
+     * GET pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * Responses:
@@ -62,6 +65,7 @@ interface PetApi {
     fun findPetsByStatus(@Query("status") status: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Responses:
@@ -76,6 +80,7 @@ interface PetApi {
     fun findPetsByTags(@Query("tags") tags: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * Responses:
@@ -90,6 +95,7 @@ interface PetApi {
     fun getPetById(@Path("petId") petId: kotlin.Long): Call<Pet>
 
     /**
+     * PUT pet
      * Update an existing pet
      * 
      * Responses:
@@ -105,6 +111,7 @@ interface PetApi {
     fun updatePet(@Body pet: Pet): Call<Pet>
 
     /**
+     * POST pet/{petId}
      * Updates a pet in the store with form data
      * 
      * Responses:
@@ -120,6 +127,7 @@ interface PetApi {
     fun updatePetWithForm(@Path("petId") petId: kotlin.Long, @Field("name") name: kotlin.String? = null, @Field("status") status: kotlin.String? = null): Call<Unit>
 
     /**
+     * POST pet/{petId}/uploadImage
      * uploads an image
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.Order
 
 interface StoreApi {
     /**
+     * DELETE store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * Responses:
@@ -23,6 +24,7 @@ interface StoreApi {
     fun deleteOrder(@Path("orderId") orderId: kotlin.String): Call<Unit>
 
     /**
+     * GET store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * Responses:
@@ -34,6 +36,7 @@ interface StoreApi {
     fun getInventory(): Call<kotlin.collections.Map<kotlin.String, kotlin.Int>>
 
     /**
+     * GET store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * Responses:
@@ -48,6 +51,7 @@ interface StoreApi {
     fun getOrderById(@Path("orderId") orderId: kotlin.Long): Call<Order>
 
     /**
+     * POST store/order
      * Place an order for a pet
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.User
 
 interface UserApi {
     /**
+     * POST user
      * Create user
      * This can only be done by the logged in user.
      * Responses:
@@ -22,6 +23,7 @@ interface UserApi {
     fun createUser(@Body user: User): Call<Unit>
 
     /**
+     * POST user/createWithArray
      * Creates list of users with given input array
      * 
      * Responses:
@@ -34,6 +36,7 @@ interface UserApi {
     fun createUsersWithArrayInput(@Body user: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * POST user/createWithList
      * Creates list of users with given input array
      * 
      * Responses:
@@ -46,6 +49,7 @@ interface UserApi {
     fun createUsersWithListInput(@Body user: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * DELETE user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * Responses:
@@ -59,6 +63,7 @@ interface UserApi {
     fun deleteUser(@Path("username") username: kotlin.String): Call<Unit>
 
     /**
+     * GET user/{username}
      * Get user by user name
      * 
      * Responses:
@@ -73,6 +78,7 @@ interface UserApi {
     fun getUserByName(@Path("username") username: kotlin.String): Call<User>
 
     /**
+     * GET user/login
      * Logs user into the system
      * 
      * Responses:
@@ -87,6 +93,7 @@ interface UserApi {
     fun loginUser(@Query("username") username: kotlin.String, @Query("password") password: kotlin.String): Call<kotlin.String>
 
     /**
+     * GET user/logout
      * Logs out current logged in user session
      * 
      * Responses:
@@ -98,6 +105,7 @@ interface UserApi {
     fun logoutUser(): Call<Unit>
 
     /**
+     * PUT user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -14,6 +14,7 @@ import okhttp3.MultipartBody
 
 interface PetApi {
     /**
+     * POST pet
      * Add a new pet to the store
      * 
      * Responses:
@@ -26,6 +27,7 @@ interface PetApi {
     fun addPet(@Body body: Pet): Call<Unit>
 
     /**
+     * DELETE pet/{petId}
      * Deletes a pet
      * 
      * Responses:
@@ -49,6 +51,7 @@ interface PetApi {
     }
 
     /**
+     * GET pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * Responses:
@@ -62,6 +65,7 @@ interface PetApi {
     fun findPetsByStatus(@Query("status") status: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Responses:
@@ -76,6 +80,7 @@ interface PetApi {
     fun findPetsByTags(@Query("tags") tags: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * Responses:
@@ -90,6 +95,7 @@ interface PetApi {
     fun getPetById(@Path("petId") petId: kotlin.Long): Call<Pet>
 
     /**
+     * PUT pet
      * Update an existing pet
      * 
      * Responses:
@@ -104,6 +110,7 @@ interface PetApi {
     fun updatePet(@Body body: Pet): Call<Unit>
 
     /**
+     * POST pet/{petId}
      * Updates a pet in the store with form data
      * 
      * Responses:
@@ -119,6 +126,7 @@ interface PetApi {
     fun updatePetWithForm(@Path("petId") petId: kotlin.Long, @Field("name") name: kotlin.String? = null, @Field("status") status: kotlin.String? = null): Call<Unit>
 
     /**
+     * POST pet/{petId}/uploadImage
      * uploads an image
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -11,6 +11,7 @@ import org.openapitools.client.models.Order
 
 interface StoreApi {
     /**
+     * DELETE store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * Responses:
@@ -24,6 +25,7 @@ interface StoreApi {
     fun deleteOrder(@Path("orderId") orderId: kotlin.String): Call<Unit>
 
     /**
+     * GET store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * Responses:
@@ -35,6 +37,7 @@ interface StoreApi {
     fun getInventory(): Call<kotlin.collections.Map<kotlin.String, kotlin.Int>>
 
     /**
+     * GET store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * Responses:
@@ -49,6 +52,7 @@ interface StoreApi {
     fun getOrderById(@Path("orderId") orderId: kotlin.Long): Call<Order>
 
     /**
+     * POST store/order
      * Place an order for a pet
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -11,6 +11,7 @@ import org.openapitools.client.models.User
 
 interface UserApi {
     /**
+     * POST user
      * Create user
      * This can only be done by the logged in user.
      * Responses:
@@ -23,6 +24,7 @@ interface UserApi {
     fun createUser(@Body body: User): Call<Unit>
 
     /**
+     * POST user/createWithArray
      * Creates list of users with given input array
      * 
      * Responses:
@@ -35,6 +37,7 @@ interface UserApi {
     fun createUsersWithArrayInput(@Body body: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * POST user/createWithList
      * Creates list of users with given input array
      * 
      * Responses:
@@ -47,6 +50,7 @@ interface UserApi {
     fun createUsersWithListInput(@Body body: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * DELETE user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * Responses:
@@ -60,6 +64,7 @@ interface UserApi {
     fun deleteUser(@Path("username") username: kotlin.String): Call<Unit>
 
     /**
+     * GET user/{username}
      * Get user by user name
      * 
      * Responses:
@@ -74,6 +79,7 @@ interface UserApi {
     fun getUserByName(@Path("username") username: kotlin.String): Call<User>
 
     /**
+     * GET user/login
      * Logs user into the system
      * 
      * Responses:
@@ -88,6 +94,7 @@ interface UserApi {
     fun loginUser(@Query("username") username: kotlin.String, @Query("password") password: kotlin.String): Call<kotlin.String>
 
     /**
+     * GET user/logout
      * Logs out current logged in user session
      * 
      * Responses:
@@ -99,6 +106,7 @@ interface UserApi {
     fun logoutUser(): Call<Unit>
 
     /**
+     * PUT user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -14,6 +14,7 @@ import okhttp3.MultipartBody
 
 interface PetApi {
     /**
+     * POST pet
      * Add a new pet to the store
      * 
      * Responses:
@@ -26,6 +27,7 @@ interface PetApi {
     fun addPet(@Body body: Pet): Completable
 
     /**
+     * DELETE pet/{petId}
      * Deletes a pet
      * 
      * Responses:
@@ -49,6 +51,7 @@ interface PetApi {
     }
 
     /**
+     * GET pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * Responses:
@@ -62,6 +65,7 @@ interface PetApi {
     fun findPetsByStatus(@Query("status") status: CSVParams): Single<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Responses:
@@ -76,6 +80,7 @@ interface PetApi {
     fun findPetsByTags(@Query("tags") tags: CSVParams): Single<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * Responses:
@@ -90,6 +95,7 @@ interface PetApi {
     fun getPetById(@Path("petId") petId: kotlin.Long): Single<Pet>
 
     /**
+     * PUT pet
      * Update an existing pet
      * 
      * Responses:
@@ -104,6 +110,7 @@ interface PetApi {
     fun updatePet(@Body body: Pet): Completable
 
     /**
+     * POST pet/{petId}
      * Updates a pet in the store with form data
      * 
      * Responses:
@@ -119,6 +126,7 @@ interface PetApi {
     fun updatePetWithForm(@Path("petId") petId: kotlin.Long, @Field("name") name: kotlin.String? = null, @Field("status") status: kotlin.String? = null): Completable
 
     /**
+     * POST pet/{petId}/uploadImage
      * uploads an image
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -11,6 +11,7 @@ import org.openapitools.client.models.Order
 
 interface StoreApi {
     /**
+     * DELETE store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * Responses:
@@ -24,6 +25,7 @@ interface StoreApi {
     fun deleteOrder(@Path("orderId") orderId: kotlin.String): Completable
 
     /**
+     * GET store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * Responses:
@@ -35,6 +37,7 @@ interface StoreApi {
     fun getInventory(): Single<kotlin.collections.Map<kotlin.String, kotlin.Int>>
 
     /**
+     * GET store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * Responses:
@@ -49,6 +52,7 @@ interface StoreApi {
     fun getOrderById(@Path("orderId") orderId: kotlin.Long): Single<Order>
 
     /**
+     * POST store/order
      * Place an order for a pet
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -11,6 +11,7 @@ import org.openapitools.client.models.User
 
 interface UserApi {
     /**
+     * POST user
      * Create user
      * This can only be done by the logged in user.
      * Responses:
@@ -23,6 +24,7 @@ interface UserApi {
     fun createUser(@Body body: User): Completable
 
     /**
+     * POST user/createWithArray
      * Creates list of users with given input array
      * 
      * Responses:
@@ -35,6 +37,7 @@ interface UserApi {
     fun createUsersWithArrayInput(@Body body: kotlin.collections.List<User>): Completable
 
     /**
+     * POST user/createWithList
      * Creates list of users with given input array
      * 
      * Responses:
@@ -47,6 +50,7 @@ interface UserApi {
     fun createUsersWithListInput(@Body body: kotlin.collections.List<User>): Completable
 
     /**
+     * DELETE user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * Responses:
@@ -60,6 +64,7 @@ interface UserApi {
     fun deleteUser(@Path("username") username: kotlin.String): Completable
 
     /**
+     * GET user/{username}
      * Get user by user name
      * 
      * Responses:
@@ -74,6 +79,7 @@ interface UserApi {
     fun getUserByName(@Path("username") username: kotlin.String): Single<User>
 
     /**
+     * GET user/login
      * Logs user into the system
      * 
      * Responses:
@@ -88,6 +94,7 @@ interface UserApi {
     fun loginUser(@Query("username") username: kotlin.String, @Query("password") password: kotlin.String): Single<kotlin.String>
 
     /**
+     * GET user/logout
      * Logs out current logged in user session
      * 
      * Responses:
@@ -99,6 +106,7 @@ interface UserApi {
     fun logoutUser(): Completable
 
     /**
+     * PUT user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 
 interface PetApi {
     /**
+     * POST pet
      * Add a new pet to the store
      * 
      * Responses:
@@ -25,6 +26,7 @@ interface PetApi {
     fun addPet(@Body body: Pet): Call<Unit>
 
     /**
+     * DELETE pet/{petId}
      * Deletes a pet
      * 
      * Responses:
@@ -48,6 +50,7 @@ interface PetApi {
     }
 
     /**
+     * GET pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * Responses:
@@ -61,6 +64,7 @@ interface PetApi {
     fun findPetsByStatus(@Query("status") status: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Responses:
@@ -75,6 +79,7 @@ interface PetApi {
     fun findPetsByTags(@Query("tags") tags: CSVParams): Call<kotlin.collections.List<Pet>>
 
     /**
+     * GET pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * Responses:
@@ -89,6 +94,7 @@ interface PetApi {
     fun getPetById(@Path("petId") petId: kotlin.Long): Call<Pet>
 
     /**
+     * PUT pet
      * Update an existing pet
      * 
      * Responses:
@@ -103,6 +109,7 @@ interface PetApi {
     fun updatePet(@Body body: Pet): Call<Unit>
 
     /**
+     * POST pet/{petId}
      * Updates a pet in the store with form data
      * 
      * Responses:
@@ -118,6 +125,7 @@ interface PetApi {
     fun updatePetWithForm(@Path("petId") petId: kotlin.Long, @Field("name") name: kotlin.String? = null, @Field("status") status: kotlin.String? = null): Call<Unit>
 
     /**
+     * POST pet/{petId}/uploadImage
      * uploads an image
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.Order
 
 interface StoreApi {
     /**
+     * DELETE store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * Responses:
@@ -23,6 +24,7 @@ interface StoreApi {
     fun deleteOrder(@Path("orderId") orderId: kotlin.String): Call<Unit>
 
     /**
+     * GET store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * Responses:
@@ -34,6 +36,7 @@ interface StoreApi {
     fun getInventory(): Call<kotlin.collections.Map<kotlin.String, kotlin.Int>>
 
     /**
+     * GET store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * Responses:
@@ -48,6 +51,7 @@ interface StoreApi {
     fun getOrderById(@Path("orderId") orderId: kotlin.Long): Call<Order>
 
     /**
+     * POST store/order
      * Place an order for a pet
      * 
      * Responses:

--- a/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-retrofit2/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -10,6 +10,7 @@ import org.openapitools.client.models.User
 
 interface UserApi {
     /**
+     * POST user
      * Create user
      * This can only be done by the logged in user.
      * Responses:
@@ -22,6 +23,7 @@ interface UserApi {
     fun createUser(@Body body: User): Call<Unit>
 
     /**
+     * POST user/createWithArray
      * Creates list of users with given input array
      * 
      * Responses:
@@ -34,6 +36,7 @@ interface UserApi {
     fun createUsersWithArrayInput(@Body body: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * POST user/createWithList
      * Creates list of users with given input array
      * 
      * Responses:
@@ -46,6 +49,7 @@ interface UserApi {
     fun createUsersWithListInput(@Body body: kotlin.collections.List<User>): Call<Unit>
 
     /**
+     * DELETE user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * Responses:
@@ -59,6 +63,7 @@ interface UserApi {
     fun deleteUser(@Path("username") username: kotlin.String): Call<Unit>
 
     /**
+     * GET user/{username}
      * Get user by user name
      * 
      * Responses:
@@ -73,6 +78,7 @@ interface UserApi {
     fun getUserByName(@Path("username") username: kotlin.String): Call<User>
 
     /**
+     * GET user/login
      * Logs user into the system
      * 
      * Responses:
@@ -87,6 +93,7 @@ interface UserApi {
     fun loginUser(@Query("username") username: kotlin.String, @Query("password") password: kotlin.String): Call<kotlin.String>
 
     /**
+     * GET user/logout
      * Logs out current logged in user session
      * 
      * Responses:
@@ -98,6 +105,7 @@ interface UserApi {
     fun logoutUser(): Call<Unit>
 
     /**
+     * PUT user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * Responses:

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param apiKey  (optional)
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param apiKey  (optional)
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/apis/EnumApi.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/apis/EnumApi.kt
@@ -47,6 +47,7 @@ class EnumApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /enum
      * Get enums
      * 
      * @return PetEnum
@@ -77,6 +78,7 @@ class EnumApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /enum
      * Get enums
      * 
      * @return ApiResponse<PetEnum?>

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -47,6 +47,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -77,6 +78,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet
      * Add a new pet to the store
      * 
      * @param body Pet object that needs to be added to the store
@@ -116,6 +118,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -147,6 +150,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * DELETE /pet/{petId}
      * Deletes a pet
      * 
      * @param petId Pet id to delete
@@ -206,6 +210,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
      }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -237,6 +242,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByStatus
      * Finds Pets by status
      * Multiple status values can be provided with comma separated strings
      * @param status Status values that need to be considered for filter
@@ -280,6 +286,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -313,6 +320,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/findByTags
      * Finds Pets by tags
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * @param tags Tags to filter by
@@ -359,6 +367,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -390,6 +399,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * GET /pet/{petId}
      * Find pet by ID
      * Returns a single pet
      * @param petId ID of pet to return
@@ -430,6 +440,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -460,6 +471,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * PUT /pet
      * Update an existing pet
      * 
      * @param body Pet object that needs to be added to the store
@@ -499,6 +511,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -531,6 +544,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}
      * Updates a pet in the store with form data
      * 
      * @param petId ID of pet that needs to be updated
@@ -575,6 +589,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update
@@ -608,6 +623,7 @@ class PetApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = A
     }
 
     /**
+     * POST /pet/{petId}/uploadImage
      * uploads an image
      * 
      * @param petId ID of pet to update

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -46,6 +46,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -76,6 +77,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * DELETE /store/order/{orderId}
      * Delete purchase order by ID
      * For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors
      * @param orderId ID of the order that needs to be deleted
@@ -114,6 +116,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return kotlin.collections.Map<kotlin.String, kotlin.Int>
@@ -144,6 +147,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/inventory
      * Returns pet inventories by status
      * Returns a map of status codes to quantities
      * @return ApiResponse<kotlin.collections.Map<kotlin.String, kotlin.Int>?>
@@ -182,6 +186,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -213,6 +218,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * GET /store/order/{orderId}
      * Find purchase order by ID
      * For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions
      * @param orderId ID of pet that needs to be fetched
@@ -253,6 +259,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet
@@ -284,6 +291,7 @@ class StoreApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
     }
 
     /**
+     * POST /store/order
      * Place an order for a pet
      * 
      * @param body order placed for purchasing the pet

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -46,6 +46,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -76,6 +77,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user
      * Create user
      * This can only be done by the logged in user.
      * @param body Created user object
@@ -114,6 +116,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -144,6 +147,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithArray
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -182,6 +186,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -212,6 +217,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * POST /user/createWithList
      * Creates list of users with given input array
      * 
      * @param body List of user object
@@ -250,6 +256,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -280,6 +287,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * DELETE /user/{username}
      * Delete user
      * This can only be done by the logged in user.
      * @param username The name that needs to be deleted
@@ -318,6 +326,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -349,6 +358,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/{username}
      * Get user by user name
      * 
      * @param username The name that needs to be fetched. Use user1 for testing.
@@ -389,6 +399,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -421,6 +432,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/login
      * Logs user into the system
      * 
      * @param username The user name for login
@@ -467,6 +479,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return void
@@ -496,6 +509,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * GET /user/logout
      * Logs out current logged in user session
      * 
      * @return ApiResponse<Unit?>
@@ -532,6 +546,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted
@@ -563,6 +578,7 @@ class UserApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory = 
     }
 
     /**
+     * PUT /user/{username}
      * Updated user
      * This can only be done by the logged in user.
      * @param username name that need to be deleted


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR is a QoL improvement that adds the HTTP method and path to the Javadoc for each operation in Kotlin clients.
The motivation it to make it more obvious which methods map to the HTTP endpoint. 

The changes are fairly trival and I broke out each client into a separate commit to making reviewing easier. 

Also I recently open a similar PR for the Rust clients for reference: #20591

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l