### PR TITLE
feat: [rust] Dynamically add `uuid` crate only if used

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -38,11 +38,10 @@ import org.openapitools.codegen.CodegenConfig;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
 import org.openapitools.codegen.SupportingFile;
-import org.openapitools.codegen.VendorExtension;
 import org.openapitools.codegen.meta.features.ClientModificationFeature;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.GlobalFeature;
@@ -109,6 +108,10 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
     protected String modelDocPath = "docs/";
     protected String apiFolder = "src/apis";
     protected String modelFolder = "src/models";
+    // The API has at least one UUID type.
+    // If the API does not contain any UUIDs we do not need depend on the `uuid` crate
+    private boolean hasUUIDs = false;
+
 
     @Override
     public CodegenType getTag() {
@@ -252,6 +255,7 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
         supportedLibraries.put(HYPER0X_LIBRARY, "HTTP client: Hyper (v0.x).");
         supportedLibraries.put(REQWEST_LIBRARY, "HTTP client: Reqwest.");
         supportedLibraries.put(REQWEST_TRAIT_LIBRARY, "HTTP client: Reqwest (trait based).");
+
 
         CliOption libraryOption = new CliOption(CodegenConstants.LIBRARY, "library template (sub-template) to use.");
         libraryOption.setEnum(supportedLibraries);
@@ -642,6 +646,13 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 }
             }
 
+            for (var param : operation.allParams) {
+                if (!hasUUIDs && param.isUuid) {
+                    hasUUIDs = true;
+                    break;
+                }
+            }
+
             // http method verb conversion, depending on client library (e.g. Hyper: PUT => Put, Reqwest: PUT => put)
             if (HYPER_LIBRARY.equals(getLibrary())) {
                 operation.httpMethod = StringUtils.camelize(operation.httpMethod.toLowerCase(Locale.ROOT));
@@ -705,7 +716,41 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
             }*/
         }
 
+        if (!hasUUIDs) {
+            for (var map : allModels) {
+                CodegenModel m = map.getModel();
+                if (m.getIsUuid() || hasUuidInProperties(m.vars)) {
+                    hasUUIDs = true;
+                    LOGGER.debug("found UUID in model: " + m.name);
+                    break;
+                }
+            }
+        }
+
+        this.additionalProperties.put("hasUUIDs", hasUUIDs);
         return objs;
+    }
+
+    /**
+     * Recursively searches for a model's properties for a UUID type field.
+     */
+    private boolean hasUuidInProperties(List<CodegenProperty> properties) {
+        for (CodegenProperty property : properties) {
+            if (property.isUuid) {
+                return true;
+            }
+            // Check nested properties
+            if (property.items != null && hasUuidInProperties(Collections.singletonList(property.items))) {
+                return true;
+            }
+            if (property.additionalProperties != null && hasUuidInProperties(Collections.singletonList(property.additionalProperties))) {
+                return true;
+            }
+            if (property.vars != null && hasUuidInProperties(property.vars)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -39,7 +39,9 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
+{{#hasUUIDs}}
 uuid = { version = "^1.8", features = ["serde", "v4"] }
+{{/hasUUIDs}}
 {{#hyper}}
 {{#hyper0x}}
 hyper = { version = "~0.14", features = ["full"] }

--- a/samples/client/others/rust/hyper/api-with-ref-param/Cargo.toml
+++ b/samples/client/others/rust/hyper/api-with-ref-param/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }

--- a/samples/client/others/rust/hyper/composed-oneof/Cargo.toml
+++ b/samples/client/others/rust/hyper/composed-oneof/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }

--- a/samples/client/others/rust/hyper/emptyObject/Cargo.toml
+++ b/samples/client/others/rust/hyper/emptyObject/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }

--- a/samples/client/others/rust/hyper/oneOf-array-map/Cargo.toml
+++ b/samples/client/others/rust/hyper/oneOf-array-map/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/Cargo.toml
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/Cargo.toml
@@ -11,7 +11,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }

--- a/samples/client/others/rust/hyper/oneOf/Cargo.toml
+++ b/samples/client/others/rust/hyper/oneOf/Cargo.toml
@@ -12,7 +12,6 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 hyper = { version = "^1.3.1", features = ["full"] }
 hyper-util = { version = "0.1.5", features = ["client", "client-legacy", "http1", "http2"] }
 http-body-util = { version = "0.1.2" }

--- a/samples/client/others/rust/reqwest-regression-16119/Cargo.toml
+++ b/samples/client/others/rust/reqwest-regression-16119/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/api-with-ref-param/Cargo.toml
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "multipart"] }

--- a/samples/client/others/rust/reqwest/composed-oneof/Cargo.toml
+++ b/samples/client/others/rust/reqwest/composed-oneof/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/emptyObject/Cargo.toml
+++ b/samples/client/others/rust/reqwest/emptyObject/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/oneOf-array-map/Cargo.toml
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/Cargo.toml
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/Cargo.toml
@@ -11,5 +11,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/oneOf/Cargo.toml
+++ b/samples/client/others/rust/reqwest/oneOf/Cargo.toml
@@ -12,5 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/name-mapping/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/name-mapping/Cargo.toml
@@ -11,5 +11,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-uuid = { version = "^1.8", features = ["serde", "v4"] }
 reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR adds logic to check if an API has at least one UUID type property and only add the uuid crate to the `Cargo.toml` if a UUID is found.

The motivation for this is to reduce un-needed dependencies and improve compile times.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro
