### PR TITLE
[JavaSpring, kotlin-spring] attahc sources when maven and interfaceOnly=true is used

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom-sb3.mustache
@@ -57,9 +57,8 @@
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
-        {{^interfaceOnly}}
         <plugins>
-            <plugin>
+            {{^interfaceOnly}}<plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
@@ -75,7 +74,19 @@
                   </excludes>
                     {{/lombok}}
                 </configuration>
-            </plugin>
+            </plugin>{{/interfaceOnly}}
+            {{#interfaceOnly}}<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>{{/interfaceOnly}}
             {{#apiFirst}}
             <plugin>
                 <groupId>org.openapitools</groupId>
@@ -109,7 +120,6 @@
             </plugin>
             {{/apiFirst}}
         </plugins>
-        {{/interfaceOnly}}
     </build>
     <dependencies>
         <dependency>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-boot/pom.mustache
@@ -50,9 +50,8 @@
 {{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
-        {{^interfaceOnly}}
         <plugins>
-            <plugin>
+            {{^interfaceOnly}}<plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
@@ -68,7 +67,19 @@
                     </excludes>
                 {{/lombok}}
                 </configuration>
-            </plugin>
+            </plugin>{{/interfaceOnly}}
+            {{#interfaceOnly}}<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>{{/interfaceOnly}}
             {{#apiFirst}}
             <plugin>
                 <groupId>org.openapitools</groupId>
@@ -102,7 +113,6 @@
             </plugin>
             {{/apiFirst}}
         </plugins>
-        {{/interfaceOnly}}
     </build>
     <dependencies>
         <dependency>

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom-sb3.mustache
@@ -45,6 +45,20 @@
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        {{#interfaceOnly}}<plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>{{/interfaceOnly}}
     </build>
 
 {{^parentOverridden}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/pom.mustache
@@ -44,6 +44,20 @@
 {{/parentOverridden}}
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        {{#interfaceOnly}}<plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>{{/interfaceOnly}}
     </build>
 
 {{^parentOverridden}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom-sb3.mustache
@@ -52,6 +52,18 @@
                     </execution>
                 </executions>
             </plugin>{{/interfaceOnly}}
+            {{#interfaceOnly}}<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>{{/interfaceOnly}}
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
@@ -39,6 +39,18 @@
                     </execution>
                 </executions>
             </plugin>{{/interfaceOnly}}
+            {{#interfaceOnly}}<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>{{/interfaceOnly}}
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom-sb3.mustache
@@ -69,6 +69,18 @@
                     </execution>
                 </executions>
             </plugin>{{/interfaceOnly}}
+            {{#interfaceOnly}}<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>{{/interfaceOnly}}
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
@@ -49,6 +49,18 @@
                     </execution>
                 </executions>
             </plugin>{{/interfaceOnly}}
+            {{#interfaceOnly}}<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>{{/interfaceOnly}}
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/client/petstore/spring-cloud-auth/pom.xml
+++ b/samples/client/petstore/spring-cloud-auth/pom.xml
@@ -19,6 +19,7 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/client/petstore/spring-cloud-date-time/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/client/petstore/spring-cloud-deprecated/pom.xml
+++ b/samples/client/petstore/spring-cloud-deprecated/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
+++ b/samples/client/petstore/spring-cloud-feign-without-url/pom.xml
@@ -20,6 +20,7 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/client/petstore/spring-cloud-tags/pom.xml
+++ b/samples/client/petstore/spring-cloud-tags/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/client/petstore/spring-cloud/pom.xml
+++ b/samples/client/petstore/spring-cloud/pom.xml
@@ -20,6 +20,7 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/pom.xml
@@ -28,6 +28,7 @@
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-3/pom.xml
@@ -29,6 +29,7 @@
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-async/pom.xml
@@ -20,6 +20,7 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/pom.xml
@@ -20,6 +20,7 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-cloud/pom.xml
+++ b/samples/openapi3/client/petstore/spring-cloud/pom.xml
@@ -20,6 +20,20 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/pom.xml
@@ -21,6 +21,21 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/samples/openapi3/client/petstore/spring-stubs/pom.xml
+++ b/samples/openapi3/client/petstore/spring-stubs/pom.xml
@@ -21,6 +21,21 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/pom.xml
@@ -27,6 +27,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/openapi3/server/petstore/springboot-3/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-3/pom.xml
@@ -43,6 +43,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/openapi3/server/petstore/springboot-delegate/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-delegate/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/openapi3/server/petstore/springboot-source/pom.xml
+++ b/samples/openapi3/server/petstore/springboot-source/pom.xml
@@ -27,6 +27,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/openapi3/server/petstore/springboot/pom.xml
+++ b/samples/openapi3/server/petstore/springboot/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/kotlin-spring-cloud/pom.xml
+++ b/samples/server/petstore/kotlin-spring-cloud/pom.xml
@@ -33,6 +33,18 @@
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <version>${kotlin.version}</version>

--- a/samples/server/petstore/kotlin-spring-default/pom.xml
+++ b/samples/server/petstore/kotlin-spring-default/pom.xml
@@ -34,6 +34,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-3/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-3/pom.xml
@@ -46,6 +46,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/pom.xml
@@ -34,6 +34,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/pom.xml
@@ -47,6 +47,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-delegate/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-delegate/pom.xml
@@ -34,6 +34,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-integer-enum/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-integer-enum/pom.xml
@@ -36,6 +36,18 @@
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <version>${kotlin.version}</version>

--- a/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
@@ -34,6 +34,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/pom.xml
@@ -34,6 +34,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/pom.xml
@@ -35,6 +35,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-reactive/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-reactive/pom.xml
@@ -35,6 +35,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-request-cookie/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-request-cookie/pom.xml
@@ -37,6 +37,18 @@
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <version>${kotlin.version}</version>

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/pom.xml
@@ -35,6 +35,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/pom.xml
@@ -35,6 +35,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot-springfox/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-springfox/pom.xml
@@ -35,6 +35,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/kotlin-springboot/pom.xml
+++ b/samples/server/petstore/kotlin-springboot/pom.xml
@@ -33,6 +33,7 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/pom.xml
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/pom.xml
@@ -21,6 +21,21 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/samples/server/petstore/spring-boot-nullable-set/pom.xml
+++ b/samples/server/petstore/spring-boot-nullable-set/pom.xml
@@ -21,6 +21,21 @@
     </parent>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-beanvalidation/pom.xml
+++ b/samples/server/petstore/springboot-beanvalidation/pom.xml
@@ -27,6 +27,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-delegate-j8/pom.xml
+++ b/samples/server/petstore/springboot-delegate-j8/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-delegate-no-response-entity/pom.xml
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-delegate/pom.xml
+++ b/samples/server/petstore/springboot-delegate/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-file-delegate-optional/pom.xml
+++ b/samples/server/petstore/springboot-file-delegate-optional/pom.xml
@@ -43,6 +43,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/pom.xml
@@ -26,6 +26,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-implicitHeaders/pom.xml
+++ b/samples/server/petstore/springboot-implicitHeaders/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-lombok-data/pom.xml
+++ b/samples/server/petstore/springboot-lombok-data/pom.xml
@@ -34,6 +34,7 @@
                     </excludes>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-lombok-tostring/pom.xml
+++ b/samples/server/petstore/springboot-lombok-tostring/pom.xml
@@ -49,6 +49,7 @@
                   </excludes>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/pom.xml
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-reactive/pom.xml
+++ b/samples/server/petstore/springboot-reactive/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-spring-pageable/pom.xml
+++ b/samples/server/petstore/springboot-spring-pageable/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-spring-provide-args/pom.xml
+++ b/samples/server/petstore/springboot-spring-provide-args/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-useoptional/pom.xml
+++ b/samples/server/petstore/springboot-useoptional/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot-virtualan/pom.xml
+++ b/samples/server/petstore/springboot-virtualan/pom.xml
@@ -29,6 +29,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>

--- a/samples/server/petstore/springboot/pom.xml
+++ b/samples/server/petstore/springboot/pom.xml
@@ -28,6 +28,7 @@
                 <configuration>
                 </configuration>
             </plugin>
+            
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When using interfaceOnly, the configuration effectively generates only API interfaces and DTOs. The generated sources can be packaged up and published to a maven repository to be used as an "SDK" for both client and server development.

For these generated libraries, when the developer navigates to definitions, the decomplied code is not easily readable, especially true in case of decompiled kotlin files.

Closes #15659 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

JavaSpring @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)

kotlin-spring @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)
