### PR TITLE
[rust] Added support for text/plain to reqwest clients

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -316,6 +316,24 @@ public class CodegenOperation {
     }
 
     /**
+     * Check if operation produces text/plain responses.
+     * NOTE: This does not mean it _only_ produces text/plain, just that it is one of the produces types.
+     *
+     * @return true if at least one produces is text/plain
+     */
+    public boolean producesTextPlain() {
+        if (produces != null) {
+            for (Map<String, String> produce : produces) {
+                if ("text/plain".equalsIgnoreCase(produce.get("mediaType").split(";")[0].trim())
+                        && "String".equals(returnType)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Get the substring except baseName from path
      *
      * @return the substring

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -817,17 +817,10 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         if (NATIVE.equals(getLibrary()) || APACHE.equals(getLibrary())) {
             OperationMap operations = objs.getOperations();
             List<CodegenOperation> operationList = operations.getOperation();
-            Pattern methodPattern = Pattern.compile("^(.*):([^:]*)$");
             for (CodegenOperation op : operationList) {
                 // add extension to indicate content type is `text/plain` and the response type is `String`
-                if (op.produces != null) {
-                    for (Map<String, String> produce : op.produces) {
-                        if ("text/plain".equalsIgnoreCase(produce.get("mediaType").split(";")[0].trim())
-                                && "String".equals(op.returnType)) {
-                            op.vendorExtensions.put("x-java-text-plain-string", true);
-                            continue;
-                        }
-                    }
+                if ("String".equals(op.returnType) && op.producesTextPlain()) {
+                    op.vendorExtensions.put("x-java-text-plain-string", true);
                 }
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -677,7 +677,7 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 operation.vendorExtensions.put("x-group-parameters", Boolean.TRUE);
             }
 
-            if ("String".equals(operation.returnType)) {
+            if (operation.producesTextPlain() && "String".equals(operation.returnType)) {
                 operation.vendorExtensions.put("x-supports-plain-text", Boolean.TRUE);
             }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -677,6 +677,10 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 operation.vendorExtensions.put("x-group-parameters", Boolean.TRUE);
             }
 
+            if ("String".equals(operation.returnType)) {
+                operation.vendorExtensions.put("x-supports-plain-text", Boolean.TRUE);
+            }
+
             // update return type to conform to rust standard
             /*
             if (operation.returnType != null) {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -337,6 +337,7 @@ impl {{classname}} for {{classname}}Client {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        {{^supportMultipleResponses}}
         {{#returnType}}
         let local_var_content_type = local_var_resp
             .headers()
@@ -345,6 +346,7 @@ impl {{classname}} for {{classname}}Client {
             .unwrap_or("application/octet-stream");
         let local_var_content_type = super::ContentType::from(local_var_content_type);
         {{/returnType}}
+        {{/supportMultipleResponses}}
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -337,12 +337,14 @@ impl {{classname}} for {{classname}}Client {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        {{#returnType}}
         let local_var_content_type = local_var_resp
             .headers()
             .get("content-type")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("application/octet-stream");
         let local_var_content_type = super::ContentType::from(local_var_content_type);
+        {{/returnType}}
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -7,9 +7,10 @@ use mockall::automock;
 {{/mockall}}
 use reqwest;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration};
+use crate::apis::ContentType;
 
 {{#mockall}}
 #[cfg_attr(feature = "mockall", automock)]
@@ -336,6 +337,12 @@ impl {{classname}} for {{classname}}Client {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -344,7 +351,16 @@ impl {{classname}} for {{classname}}Client {
             Ok(())
             {{/returnType}}
             {{#returnType}}
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                {{#vendorExtensions.x-supports-plain-text}}
+                ContentType::Text => return Ok(local_var_content),
+                {{/vendorExtensions.x-supports-plain-text}}
+                {{^vendorExtensions.x-supports-plain-text}}
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `{{returnType}}`"))),
+                {{/vendorExtensions.x-supports-plain-text}}
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `{{returnType}}`")))),
+            }
             {{/returnType}}
             {{/supportMultipleResponses}}
             {{#supportMultipleResponses}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api_mod.mustache
@@ -130,6 +130,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api_mod.mustache
@@ -128,6 +128,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 {{#apiInfo}}
 {{#apis}}
 pub mod {{{classFilename}}};

--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api_mod.mustache
@@ -141,7 +141,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -355,6 +355,7 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     let resp = configuration.client.execute(req){{#supportAsync}}.await{{/supportAsync}}?;
 
     let status = resp.status();
+    {{^supportMultipleResponses}}
     {{^isResponseFile}}
     {{#returnType}}
     let content_type = resp
@@ -365,6 +366,7 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     let content_type = super::ContentType::from(content_type);
     {{/returnType}}
     {{/isResponseFile}}
+    {{/supportMultipleResponses}}
 
     if !status.is_client_error() && !status.is_server_error() {
         {{^supportMultipleResponses}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -1,9 +1,9 @@
 {{>partial_header}}
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 {{#operations}}
 {{#operation}}
@@ -355,6 +355,16 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     let resp = configuration.client.execute(req){{#supportAsync}}.await{{/supportAsync}}?;
 
     let status = resp.status();
+    {{^isResponseFile}}
+    {{#returnType}}
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
+    {{/returnType}}
+    {{/isResponseFile}}
 
     if !status.is_client_error() && !status.is_server_error() {
         {{^supportMultipleResponses}}
@@ -367,7 +377,16 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
         {{/returnType}}
         {{#returnType}}
         let content = resp.text(){{#supportAsync}}.await{{/supportAsync}}?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            {{#vendorExtensions.x-supports-plain-text}}
+            ContentType::Text => return Ok(content),
+            {{/vendorExtensions.x-supports-plain-text}}
+            {{^vendorExtensions.x-supports-plain-text}}
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `{{returnType}}`"))),
+            {{/vendorExtensions.x-supports-plain-text}}
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `{{returnType}}`")))),
+        }
         {{/returnType}}
         {{/isResponseFile}}
         {{/supportMultipleResponses}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
@@ -134,6 +134,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 {{#apiInfo}}
 {{#apis}}
 pub mod {{{classFilename}}};

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
@@ -147,7 +147,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
@@ -136,6 +136,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
@@ -495,6 +495,10 @@ paths:
             application/json:
               schema:
                 type: string
+            text/plain:
+              schema:
+                type: string
+
         '400':
           description: Invalid username/password supplied
   /user/logout:

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/default_api.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/default_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`repro`]
@@ -36,10 +36,20 @@ pub fn repro(configuration: &configuration::Configuration, ) -> Result<models::P
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Parent`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Parent`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<ReproError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod default_api;
 
 pub mod configuration;

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/default_api.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/default_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`demo_color_get`]

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod default_api;
 
 pub mod configuration;

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/default_api.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/default_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`create_state`]
@@ -69,10 +69,20 @@ pub fn get_state(configuration: &configuration::Configuration, ) -> Result<model
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::GetState200Response`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::GetState200Response`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetStateError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod default_api;
 
 pub mod configuration;

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/default_api.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/default_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`endpoint_get`]
@@ -36,10 +36,20 @@ pub fn endpoint_get(configuration: &configuration::Configuration, ) -> Result<mo
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::EmptyObject`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::EmptyObject`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<EndpointGetError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod default_api;
 
 pub mod configuration;

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/default_api.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/default_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`root_get`]
@@ -43,10 +43,20 @@ pub fn root_get(configuration: &configuration::Configuration, ) -> Result<models
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Fruit`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Fruit`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<RootGetError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod default_api;
 
 pub mod configuration;

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/default_api.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/default_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`get_fruit`]
@@ -36,10 +36,20 @@ pub fn get_fruit(configuration: &configuration::Configuration, ) -> Result<model
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Fruit`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Fruit`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetFruitError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod default_api;
 
 pub mod configuration;

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/bar_api.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/bar_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`create_bar`]
@@ -39,10 +39,20 @@ pub fn create_bar(configuration: &configuration::Configuration, bar_create: mode
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Bar`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Bar`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<CreateBarError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/foo_api.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/foo_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`create_foo`]
@@ -46,10 +46,20 @@ pub fn create_foo(configuration: &configuration::Configuration, foo: Option<mode
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooRefOrValue`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooRefOrValue`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<CreateFooError> = serde_json::from_str(&content).ok();
@@ -70,10 +80,20 @@ pub fn get_all_foos(configuration: &configuration::Configuration, ) -> Result<Ve
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::FooRefOrValue&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::FooRefOrValue&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetAllFoosError> = serde_json::from_str(&content).ok();

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/mod.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod bar_api;
 pub mod foo_api;
 

--- a/samples/client/petstore/rust/hyper/petstore/docs/UserApi.md
+++ b/samples/client/petstore/rust/hyper/petstore/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/hyper0x/petstore/docs/UserApi.md
+++ b/samples/client/petstore/rust/hyper0x/petstore/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest-trait/petstore/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/fake_api.rs
@@ -69,12 +69,6 @@ impl FakeApi for FakeApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/fake_api.rs
@@ -14,9 +14,10 @@ use async_trait::async_trait;
 use mockall::automock;
 use reqwest;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration};
+use crate::apis::ContentType;
 
 #[cfg_attr(feature = "mockall", automock)]
 #[async_trait]
@@ -68,6 +69,12 @@ impl FakeApi for FakeApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/pet_api.rs
@@ -14,9 +14,10 @@ use async_trait::async_trait;
 use mockall::automock;
 use reqwest;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration};
+use crate::apis::ContentType;
 
 #[cfg_attr(feature = "mockall", automock)]
 #[async_trait]
@@ -90,10 +91,20 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+            }
         } else {
             let local_var_entity: Option<AddPetError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -124,6 +135,12 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -165,10 +182,20 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`")))),
+            }
         } else {
             let local_var_entity: Option<FindPetsByStatusError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -200,10 +227,20 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`")))),
+            }
         } else {
             let local_var_entity: Option<FindPetsByTagsError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -236,10 +273,20 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+            }
         } else {
             let local_var_entity: Option<GetPetByIdError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -268,10 +315,20 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+            }
         } else {
             let local_var_entity: Option<UpdatePetError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -307,6 +364,12 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -344,10 +407,20 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ApiResponse`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::ApiResponse`")))),
+            }
         } else {
             let local_var_entity: Option<UploadFileError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/pet_api.rs
@@ -135,12 +135,6 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -364,12 +358,6 @@ impl PetApi for PetApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/store_api.rs
@@ -14,9 +14,10 @@ use async_trait::async_trait;
 use mockall::automock;
 use reqwest;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration};
+use crate::apis::ContentType;
 
 #[cfg_attr(feature = "mockall", automock)]
 #[async_trait]
@@ -72,6 +73,12 @@ impl StoreApi for StoreApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -108,10 +115,20 @@ impl StoreApi for StoreApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`")))),
+            }
         } else {
             let local_var_entity: Option<GetInventoryError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -136,10 +153,20 @@ impl StoreApi for StoreApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Order`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::Order`")))),
+            }
         } else {
             let local_var_entity: Option<GetOrderByIdError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -165,10 +192,20 @@ impl StoreApi for StoreApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Order`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::Order`")))),
+            }
         } else {
             let local_var_entity: Option<PlaceOrderError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/store_api.rs
@@ -73,12 +73,6 @@ impl StoreApi for StoreApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/testing_api.rs
@@ -14,9 +14,10 @@ use async_trait::async_trait;
 use mockall::automock;
 use reqwest;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration};
+use crate::apis::ContentType;
 
 #[cfg_attr(feature = "mockall", automock)]
 #[async_trait]
@@ -63,10 +64,20 @@ impl TestingApi for TestingApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `std::path::PathBuf`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `std::path::PathBuf`")))),
+            }
         } else {
             let local_var_entity: Option<TestsFileResponseGetError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -90,10 +101,20 @@ impl TestingApi for TestingApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::TypeTesting`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::TypeTesting`")))),
+            }
         } else {
             let local_var_entity: Option<TestsTypeTestingGetError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/user_api.rs
@@ -14,9 +14,10 @@ use async_trait::async_trait;
 use mockall::automock;
 use reqwest;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration};
+use crate::apis::ContentType;
 
 #[cfg_attr(feature = "mockall", automock)]
 #[async_trait]
@@ -93,6 +94,12 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -130,6 +137,12 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -167,6 +180,12 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -203,6 +222,12 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -231,10 +256,20 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::User`"))),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `models::User`")))),
+            }
         } else {
             let local_var_entity: Option<GetUserByNameError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -261,10 +296,20 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-            serde_json::from_str(&local_var_content).map_err(Error::from)
+            match local_var_content_type {
+                ContentType::Json => serde_json::from_str(&local_var_content).map_err(Error::from),
+                ContentType::Text => return Ok(local_var_content),
+                ContentType::Unsupported(local_var_unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{local_var_unknown_type}` content type response that cannot be converted to `String`")))),
+            }
         } else {
             let local_var_entity: Option<LoginUserError> = serde_json::from_str(&local_var_content).ok();
             let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
@@ -297,6 +342,12 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -334,6 +385,12 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
+        let local_var_content_type = local_var_resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/octet-stream");
+        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/user_api.rs
@@ -94,12 +94,6 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -137,12 +131,6 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -180,12 +168,6 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -222,12 +204,6 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -342,12 +318,6 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
@@ -385,12 +355,6 @@ impl UserApi for UserApiClient {
         let local_var_resp = local_var_client.execute(local_var_req).await?;
 
         let local_var_status = local_var_resp.status();
-        let local_var_content_type = local_var_resp
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("application/octet-stream");
-        let local_var_content_type = super::ContentType::from(local_var_content_type);
         let local_var_content = local_var_resp.text().await?;
 
         if !local_var_status.is_client_error() && !local_var_status.is_server_error() {

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`get_parameter_name_mapping`]

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 
 pub mod configuration;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`test_nullable_required_param`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
@@ -112,7 +112,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
@@ -101,6 +101,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/mod.rs
@@ -99,6 +99,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
@@ -229,12 +229,6 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -306,12 +300,6 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -345,12 +333,6 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -385,12 +367,6 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -421,12 +397,6 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -499,12 +469,6 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]
@@ -229,6 +229,12 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -300,6 +306,12 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -333,6 +345,12 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -367,6 +385,12 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -397,6 +421,12 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -469,6 +499,12 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`delete_order`]
 #[derive(Clone, Debug)]
@@ -149,6 +149,12 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -175,6 +181,12 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -202,6 +214,12 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/store_api.rs
@@ -149,12 +149,6 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -181,12 +175,6 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -214,12 +202,6 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/testing_api.rs
@@ -82,12 +82,6 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed successes of method [`tests_file_response_get`]
@@ -82,6 +82,12 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/user_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`create_user`]
 #[derive(Clone, Debug)]
@@ -347,6 +347,12 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -375,6 +381,12 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/user_api.rs
@@ -347,12 +347,6 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -381,12 +375,6 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`test_nullable_required_param`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/mod.rs
@@ -93,6 +93,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/mod.rs
@@ -106,7 +106,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/mod.rs
@@ -95,6 +95,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
@@ -231,12 +231,6 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -312,12 +306,6 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -353,12 +341,6 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -390,12 +372,6 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -428,12 +404,6 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -510,12 +480,6 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]
@@ -231,6 +231,12 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -306,6 +312,12 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -341,6 +353,12 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -372,6 +390,12 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -404,6 +428,12 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -480,6 +510,12 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/store_api.rs
@@ -146,12 +146,6 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -178,12 +172,6 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -211,12 +199,6 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`delete_order`]
 #[derive(Clone, Debug)]
@@ -146,6 +146,12 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -172,6 +178,12 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -199,6 +211,12 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/testing_api.rs
@@ -82,12 +82,6 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed successes of method [`tests_file_response_get`]
@@ -82,6 +82,12 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/user_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`create_user`]
 #[derive(Clone, Debug)]
@@ -335,6 +335,12 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -363,6 +369,12 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/user_api.rs
@@ -335,12 +335,6 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -369,12 +363,6 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`test_nullable_required_param`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
@@ -229,12 +229,6 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -306,12 +300,6 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -345,12 +333,6 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -385,12 +367,6 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -421,12 +397,6 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -499,12 +469,6 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]
@@ -229,6 +229,12 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -300,6 +306,12 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -333,6 +345,12 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -367,6 +385,12 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -397,6 +421,12 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -469,6 +499,12 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`delete_order`]
 #[derive(Clone, Debug)]
@@ -149,6 +149,12 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -175,6 +181,12 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -202,6 +214,12 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/store_api.rs
@@ -149,12 +149,6 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -181,12 +175,6 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -214,12 +202,6 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/testing_api.rs
@@ -82,12 +82,6 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed successes of method [`tests_file_response_get`]
@@ -82,6 +82,12 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/user_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`create_user`]
 #[derive(Clone, Debug)]
@@ -347,6 +347,12 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -375,6 +381,12 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/user_api.rs
@@ -347,12 +347,6 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -381,12 +375,6 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`test_nullable_required_param`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
@@ -229,12 +229,6 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -306,12 +300,6 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -345,12 +333,6 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -385,12 +367,6 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -421,12 +397,6 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -499,12 +469,6 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]
@@ -229,6 +229,12 @@ pub async fn add_pet(configuration: &configuration::Configuration, params: AddPe
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -300,6 +306,12 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -333,6 +345,12 @@ pub async fn find_pets_by_tags(configuration: &configuration::Configuration, par
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -367,6 +385,12 @@ pub async fn get_pet_by_id(configuration: &configuration::Configuration, params:
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -397,6 +421,12 @@ pub async fn update_pet(configuration: &configuration::Configuration, params: Up
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -469,6 +499,12 @@ pub async fn upload_file(configuration: &configuration::Configuration, params: U
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`delete_order`]
 #[derive(Clone, Debug)]
@@ -149,6 +149,12 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -175,6 +181,12 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -202,6 +214,12 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/store_api.rs
@@ -149,12 +149,6 @@ pub async fn get_inventory(configuration: &configuration::Configuration) -> Resu
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -181,12 +175,6 @@ pub async fn get_order_by_id(configuration: &configuration::Configuration, param
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -214,12 +202,6 @@ pub async fn place_order(configuration: &configuration::Configuration, params: P
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/testing_api.rs
@@ -82,12 +82,6 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed successes of method [`tests_file_response_get`]
@@ -82,6 +82,12 @@ pub async fn tests_type_testing_get(configuration: &configuration::Configuration
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/user_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 /// struct for passing parameters to the method [`create_user`]
 #[derive(Clone, Debug)]
@@ -347,6 +347,12 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -375,6 +381,12 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/user_api.rs
@@ -347,12 +347,6 @@ pub async fn get_user_by_name(configuration: &configuration::Configuration, para
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;
@@ -381,12 +375,6 @@ pub async fn login_user(configuration: &configuration::Configuration, params: Lo
     let resp = configuration.client.execute(req).await?;
 
     let status = resp.status();
-    let content_type = resp
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/octet-stream");
-    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text().await?;

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`test_nullable_required_param`]

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
@@ -107,7 +107,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
@@ -96,6 +96,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
@@ -94,6 +94,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`add_pet`]
@@ -115,10 +115,20 @@ pub fn add_pet(configuration: &configuration::Configuration, pet: models::Pet) -
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<AddPetError> = serde_json::from_str(&content).ok();
@@ -215,10 +225,20 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<FindPetsByStatusError> = serde_json::from_str(&content).ok();
@@ -262,10 +282,20 @@ pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<FindPetsByTagsError> = serde_json::from_str(&content).ok();
@@ -310,10 +340,20 @@ pub fn get_pet_by_id(configuration: &configuration::Configuration, pet_id: i64) 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetPetByIdError> = serde_json::from_str(&content).ok();
@@ -354,10 +394,20 @@ pub fn update_pet(configuration: &configuration::Configuration, pet: models::Pet
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<UpdatePetError> = serde_json::from_str(&content).ok();
@@ -459,10 +509,20 @@ pub fn upload_file(configuration: &configuration::Configuration, pet_id: i64, ad
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ApiResponse`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::ApiResponse`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<UploadFileError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`delete_order`]
@@ -110,10 +110,20 @@ pub fn get_inventory(configuration: &configuration::Configuration, ) -> Result<s
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetInventoryError> = serde_json::from_str(&content).ok();
@@ -137,10 +147,20 @@ pub fn get_order_by_id(configuration: &configuration::Configuration, order_id: i
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Order`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Order`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetOrderByIdError> = serde_json::from_str(&content).ok();
@@ -165,10 +185,20 @@ pub fn place_order(configuration: &configuration::Configuration, order: models::
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Order`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Order`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<PlaceOrderError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`tests_file_response_get`]
@@ -66,10 +66,20 @@ pub fn tests_type_testing_get(configuration: &configuration::Configuration, ) ->
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::TypeTesting`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::TypeTesting`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<TestsTypeTestingGetError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`test_nullable_required_param`]

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`add_pet`]
@@ -102,10 +102,20 @@ pub fn add_pet(configuration: &configuration::Configuration, foo_pet: models::Fo
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooPet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooPet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<AddPetError> = serde_json::from_str(&content).ok();
@@ -176,10 +186,20 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::FooPet&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::FooPet&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<FindPetsByStatusError> = serde_json::from_str(&content).ok();
@@ -210,10 +230,20 @@ pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::FooPet&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::FooPet&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<FindPetsByTagsError> = serde_json::from_str(&content).ok();
@@ -245,10 +275,20 @@ pub fn get_pet_by_id(configuration: &configuration::Configuration, pet_id: i64) 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooPet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooPet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetPetByIdError> = serde_json::from_str(&content).ok();
@@ -276,10 +316,20 @@ pub fn update_pet(configuration: &configuration::Configuration, foo_pet: models:
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooPet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooPet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<UpdatePetError> = serde_json::from_str(&content).ok();
@@ -355,10 +405,20 @@ pub fn upload_file(configuration: &configuration::Configuration, pet_id: i64, ad
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooApiResponse`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooApiResponse`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<UploadFileError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`delete_order`]
@@ -97,10 +97,20 @@ pub fn get_inventory(configuration: &configuration::Configuration, ) -> Result<s
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetInventoryError> = serde_json::from_str(&content).ok();
@@ -124,10 +134,20 @@ pub fn get_order_by_id(configuration: &configuration::Configuration, order_id: i
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooOrder`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooOrder`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetOrderByIdError> = serde_json::from_str(&content).ok();
@@ -152,10 +172,20 @@ pub fn place_order(configuration: &configuration::Configuration, foo_order: mode
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooOrder`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooOrder`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<PlaceOrderError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`tests_file_response_get`]
@@ -66,10 +66,20 @@ pub fn tests_type_testing_get(configuration: &configuration::Configuration, ) ->
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooTypeTesting`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooTypeTesting`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<TestsTypeTestingGetError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/user_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`create_user`]
@@ -238,10 +238,20 @@ pub fn get_user_by_name(configuration: &configuration::Configuration, username: 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::FooUser`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::FooUser`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetUserByNameError> = serde_json::from_str(&content).ok();
@@ -268,10 +278,20 @@ pub fn login_user(configuration: &configuration::Configuration, username: &str, 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Ok(content),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `String`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<LoginUserError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore/docs/UserApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore/docs/UserApi.md
@@ -191,7 +191,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/xml, application/json
+- **Accept**: application/xml, application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/fake_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`test_nullable_required_param`]

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/mod.rs
@@ -103,7 +103,7 @@ impl From<&str> for ContentType {
     fn from(content_type: &str) -> Self {
         if content_type.starts_with("application") && content_type.contains("json") {
             return Self::Json;
-        } else if content_type == "text/plain" {
+        } else if content_type.starts_with("text/plain") {
             return Self::Text;
         } else {
             return Self::Unsupported(content_type.to_string());

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/mod.rs
@@ -92,6 +92,7 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
 
 /// Internal use only
 /// A content type supported by this client.
+#[allow(dead_code)]
 enum ContentType {
     Json,
     Text,

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/mod.rs
@@ -90,6 +90,26 @@ pub fn parse_deep_object(prefix: &str, value: &serde_json::Value) -> Vec<(String
     unimplemented!("Only objects are supported with style=deepObject")
 }
 
+/// Internal use only
+/// A content type supported by this client.
+enum ContentType {
+    Json,
+    Text,
+    Unsupported(String)
+}
+
+impl From<&str> for ContentType {
+    fn from(content_type: &str) -> Self {
+        if content_type.starts_with("application") && content_type.contains("json") {
+            return Self::Json;
+        } else if content_type == "text/plain" {
+            return Self::Text;
+        } else {
+            return Self::Unsupported(content_type.to_string());
+        }
+    }
+}
+
 pub mod fake_api;
 pub mod pet_api;
 pub mod store_api;

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`add_pet`]
@@ -102,10 +102,20 @@ pub fn add_pet(configuration: &configuration::Configuration, pet: models::Pet) -
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<AddPetError> = serde_json::from_str(&content).ok();
@@ -176,10 +186,20 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<FindPetsByStatusError> = serde_json::from_str(&content).ok();
@@ -210,10 +230,20 @@ pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `Vec&lt;models::Pet&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<FindPetsByTagsError> = serde_json::from_str(&content).ok();
@@ -245,10 +275,20 @@ pub fn get_pet_by_id(configuration: &configuration::Configuration, pet_id: i64) 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetPetByIdError> = serde_json::from_str(&content).ok();
@@ -276,10 +316,20 @@ pub fn update_pet(configuration: &configuration::Configuration, pet: models::Pet
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Pet`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Pet`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<UpdatePetError> = serde_json::from_str(&content).ok();
@@ -355,10 +405,20 @@ pub fn upload_file(configuration: &configuration::Configuration, pet_id: i64, ad
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::ApiResponse`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::ApiResponse`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<UploadFileError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/store_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`delete_order`]
@@ -97,10 +97,20 @@ pub fn get_inventory(configuration: &configuration::Configuration, ) -> Result<s
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `std::collections::HashMap&lt;String, i32&gt;`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetInventoryError> = serde_json::from_str(&content).ok();
@@ -124,10 +134,20 @@ pub fn get_order_by_id(configuration: &configuration::Configuration, order_id: i
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Order`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Order`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetOrderByIdError> = serde_json::from_str(&content).ok();
@@ -152,10 +172,20 @@ pub fn place_order(configuration: &configuration::Configuration, order: models::
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::Order`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::Order`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<PlaceOrderError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/testing_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`tests_file_response_get`]
@@ -66,10 +66,20 @@ pub fn tests_type_testing_get(configuration: &configuration::Configuration, ) ->
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::TypeTesting`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::TypeTesting`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<TestsTypeTestingGetError> = serde_json::from_str(&content).ok();

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/user_api.rs
@@ -10,9 +10,9 @@
 
 
 use reqwest;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
-use super::{Error, configuration};
+use super::{Error, configuration, ContentType};
 
 
 /// struct for typed errors of method [`create_user`]
@@ -238,10 +238,20 @@ pub fn get_user_by_name(configuration: &configuration::Configuration, username: 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `models::User`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `models::User`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<GetUserByNameError> = serde_json::from_str(&content).ok();
@@ -268,10 +278,20 @@ pub fn login_user(configuration: &configuration::Configuration, username: &str, 
     let resp = configuration.client.execute(req)?;
 
     let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
 
     if !status.is_client_error() && !status.is_server_error() {
         let content = resp.text()?;
-        serde_json::from_str(&content).map_err(Error::from)
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Ok(content),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `String`")))),
+        }
     } else {
         let content = resp.text()?;
         let entity: Option<LoginUserError> = serde_json::from_str(&content).ok();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I am continuing my quest to improve the Rust Reqwest based clients. :)

This PR adds better content type header handling to the reqwest & reqwest-trait clients.
Specifically it adds support for `text/plain` when the return type is `String`. (and better error messages when the return type is not a string, instead of blindly trying and failing to JSON parse non-json responses)

This will fix #20617 , however it will not fix hyper clients and if `supportMultipleResponses` is `true` then this approach will also not work.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro