### PR TITLE
[Go]Add Value suffix to Golang types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -750,6 +750,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         content = content.trim().replace("[", "map_of_");
         content = content.trim().replace("]", "");
         content = content.trim().replace("interface{}", "Any");
+        content += "_value";
         return camelize(content);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -134,11 +134,11 @@ public class GoClientCodegenTest {
         files.forEach(File::deleteOnExit);
 
         Path modelFile = Paths.get(output + "/model_example.go");
-        TestUtils.assertFileContains(modelFile, "Child *Child");
-        TestUtils.assertFileContains(modelFile, "Int32 *int32");
-        TestUtils.assertFileContains(modelFile, "dst.Int32");
-        TestUtils.assertFileNotContains(modelFile, "int32 *int32");
-        TestUtils.assertFileNotContains(modelFile, "dst.int32");
+        TestUtils.assertFileContains(modelFile, "ChildValue *Child");
+        TestUtils.assertFileContains(modelFile, "Int32Value *int32");
+        TestUtils.assertFileContains(modelFile, "dst.Int32Value");
+        TestUtils.assertFileNotContains(modelFile, "int32value *int32");
+        TestUtils.assertFileNotContains(modelFile, "dst.int32value");
     }
 
     @Test
@@ -174,7 +174,7 @@ public class GoClientCodegenTest {
         files.forEach(File::deleteOnExit);
 
         Path docFile = Paths.get(output + "/docs/PetAPI.md");
-        TestUtils.assertFileContains(docFile, "openapiclient.pet{Cat: openapiclient.NewCat(\"Attr_example\")}, openapiclient.pet{Cat: openapiclient.NewCat(\"Attr_example\")}, openapiclient.pet{Cat: openapiclient.NewCat(\"Attr_example\")}");
+        TestUtils.assertFileContains(docFile, "openapiclient.pet{CatValue: openapiclient.NewCat(\"Attr_example\")}, openapiclient.pet{CatValue: openapiclient.NewCat(\"Attr_example\")}, openapiclient.pet{CatValue: openapiclient.NewCat(\"Attr_example\")}");
     }
 
     @Test

--- a/samples/client/others/go/oneof-anyof-required/model_object.go
+++ b/samples/client/others/go/oneof-anyof-required/model_object.go
@@ -18,21 +18,21 @@ import (
 
 // Object - struct for Object
 type Object struct {
-	NestedObject1 *NestedObject1
-	NestedObject2 *NestedObject2
+	NestedObject1Value *NestedObject1
+	NestedObject2Value *NestedObject2
 }
 
 // NestedObject1AsObject is a convenience function that returns NestedObject1 wrapped in Object
-func NestedObject1AsObject(v *NestedObject1) Object {
+func NestedObject1ValueAsObject(v *NestedObject1) Object {
 	return Object{
-		NestedObject1: v,
+		NestedObject1Value: v,
 	}
 }
 
 // NestedObject2AsObject is a convenience function that returns NestedObject2 wrapped in Object
-func NestedObject2AsObject(v *NestedObject2) Object {
+func NestedObject2ValueAsObject(v *NestedObject2) Object {
 	return Object{
-		NestedObject2: v,
+		NestedObject2Value: v,
 	}
 }
 
@@ -41,44 +41,44 @@ func NestedObject2AsObject(v *NestedObject2) Object {
 func (dst *Object) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into NestedObject1
-	err = newStrictDecoder(data).Decode(&dst.NestedObject1)
+	// try to unmarshal data into NestedObject1Value
+	err = newStrictDecoder(data).Decode(&dst.NestedObject1Value)
 	if err == nil {
-		jsonNestedObject1, _ := json.Marshal(dst.NestedObject1)
-		if string(jsonNestedObject1) == "{}" { // empty struct
-			dst.NestedObject1 = nil
+		jsonNestedObject1Value, _ := json.Marshal(dst.NestedObject1Value)
+		if string(jsonNestedObject1Value) == "{}" { // empty struct
+			dst.NestedObject1Value = nil
 		} else {
-			if err = validator.Validate(dst.NestedObject1); err != nil {
-				dst.NestedObject1 = nil
+			if err = validator.Validate(dst.NestedObject1Value); err != nil {
+				dst.NestedObject1Value = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.NestedObject1 = nil
+		dst.NestedObject1Value = nil
 	}
 
-	// try to unmarshal data into NestedObject2
-	err = newStrictDecoder(data).Decode(&dst.NestedObject2)
+	// try to unmarshal data into NestedObject2Value
+	err = newStrictDecoder(data).Decode(&dst.NestedObject2Value)
 	if err == nil {
-		jsonNestedObject2, _ := json.Marshal(dst.NestedObject2)
-		if string(jsonNestedObject2) == "{}" { // empty struct
-			dst.NestedObject2 = nil
+		jsonNestedObject2Value, _ := json.Marshal(dst.NestedObject2Value)
+		if string(jsonNestedObject2Value) == "{}" { // empty struct
+			dst.NestedObject2Value = nil
 		} else {
-			if err = validator.Validate(dst.NestedObject2); err != nil {
-				dst.NestedObject2 = nil
+			if err = validator.Validate(dst.NestedObject2Value); err != nil {
+				dst.NestedObject2Value = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.NestedObject2 = nil
+		dst.NestedObject2Value = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.NestedObject1 = nil
-		dst.NestedObject2 = nil
+		dst.NestedObject1Value = nil
+		dst.NestedObject2Value = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(Object)")
 	} else if match == 1 {
@@ -90,12 +90,12 @@ func (dst *Object) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src Object) MarshalJSON() ([]byte, error) {
-	if src.NestedObject1 != nil {
-		return json.Marshal(&src.NestedObject1)
+	if src.NestedObject1Value != nil {
+		return json.Marshal(&src.NestedObject1Value)
 	}
 
-	if src.NestedObject2 != nil {
-		return json.Marshal(&src.NestedObject2)
+	if src.NestedObject2Value != nil {
+		return json.Marshal(&src.NestedObject2Value)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -106,12 +106,12 @@ func (obj *Object) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.NestedObject1 != nil {
-		return obj.NestedObject1
+	if obj.NestedObject1Value != nil {
+		return obj.NestedObject1Value
 	}
 
-	if obj.NestedObject2 != nil {
-		return obj.NestedObject2
+	if obj.NestedObject2Value != nil {
+		return obj.NestedObject2Value
 	}
 
 	// all schemas are nil

--- a/samples/client/others/go/oneof-anyof-required/model_object2.go
+++ b/samples/client/others/go/oneof-anyof-required/model_object2.go
@@ -18,37 +18,37 @@ import (
 
 // Object2 struct for Object2
 type Object2 struct {
-	NestedObject1 *NestedObject1
-	NestedObject2 *NestedObject2
+	NestedObject1Value *NestedObject1
+	NestedObject2Value *NestedObject2
 }
 
 // Unmarshal JSON data into any of the pointers in the struct
 func (dst *Object2) UnmarshalJSON(data []byte) error {
 	var err error
-	// try to unmarshal JSON data into NestedObject1
-	err = json.Unmarshal(data, &dst.NestedObject1);
+	// try to unmarshal JSON data into NestedObject1Value
+	err = json.Unmarshal(data, &dst.NestedObject1Value);
 	if err == nil {
-		jsonNestedObject1, _ := json.Marshal(dst.NestedObject1)
-		if string(jsonNestedObject1) == "{}" { // empty struct
-			dst.NestedObject1 = nil
+		jsonNestedObject1Value, _ := json.Marshal(dst.NestedObject1Value)
+		if string(jsonNestedObject1Value) == "{}" { // empty struct
+			dst.NestedObject1Value = nil
 		} else {
-			return nil // data stored in dst.NestedObject1, return on the first match
+			return nil // data stored in dst.NestedObject1Value, return on the first match
 		}
 	} else {
-		dst.NestedObject1 = nil
+		dst.NestedObject1Value = nil
 	}
 
-	// try to unmarshal JSON data into NestedObject2
-	err = json.Unmarshal(data, &dst.NestedObject2);
+	// try to unmarshal JSON data into NestedObject2Value
+	err = json.Unmarshal(data, &dst.NestedObject2Value);
 	if err == nil {
-		jsonNestedObject2, _ := json.Marshal(dst.NestedObject2)
-		if string(jsonNestedObject2) == "{}" { // empty struct
-			dst.NestedObject2 = nil
+		jsonNestedObject2Value, _ := json.Marshal(dst.NestedObject2Value)
+		if string(jsonNestedObject2Value) == "{}" { // empty struct
+			dst.NestedObject2Value = nil
 		} else {
-			return nil // data stored in dst.NestedObject2, return on the first match
+			return nil // data stored in dst.NestedObject2Value, return on the first match
 		}
 	} else {
-		dst.NestedObject2 = nil
+		dst.NestedObject2Value = nil
 	}
 
 	return fmt.Errorf("data failed to match schemas in anyOf(Object2)")
@@ -56,12 +56,12 @@ func (dst *Object2) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src Object2) MarshalJSON() ([]byte, error) {
-	if src.NestedObject1 != nil {
-		return json.Marshal(&src.NestedObject1)
+	if src.NestedObject1Value != nil {
+		return json.Marshal(&src.NestedObject1Value)
 	}
 
-	if src.NestedObject2 != nil {
-		return json.Marshal(&src.NestedObject2)
+	if src.NestedObject2Value != nil {
+		return json.Marshal(&src.NestedObject2Value)
 	}
 
 	return nil, nil // no data in anyOf schemas

--- a/samples/client/others/go/oneof-discriminator-lookup/model_object.go
+++ b/samples/client/others/go/oneof-discriminator-lookup/model_object.go
@@ -17,21 +17,21 @@ import (
 
 // Object - struct for Object
 type Object struct {
-	NestedObject1 *NestedObject1
-	NestedObject2 *NestedObject2
+	NestedObject1Value *NestedObject1
+	NestedObject2Value *NestedObject2
 }
 
 // NestedObject1AsObject is a convenience function that returns NestedObject1 wrapped in Object
-func NestedObject1AsObject(v *NestedObject1) Object {
+func NestedObject1ValueAsObject(v *NestedObject1) Object {
 	return Object{
-		NestedObject1: v,
+		NestedObject1Value: v,
 	}
 }
 
 // NestedObject2AsObject is a convenience function that returns NestedObject2 wrapped in Object
-func NestedObject2AsObject(v *NestedObject2) Object {
+func NestedObject2ValueAsObject(v *NestedObject2) Object {
 	return Object{
-		NestedObject2: v,
+		NestedObject2Value: v,
 	}
 }
 
@@ -99,12 +99,12 @@ func (dst *Object) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src Object) MarshalJSON() ([]byte, error) {
-	if src.NestedObject1 != nil {
-		return json.Marshal(&src.NestedObject1)
+	if src.NestedObject1Value != nil {
+		return json.Marshal(&src.NestedObject1Value)
 	}
 
-	if src.NestedObject2 != nil {
-		return json.Marshal(&src.NestedObject2)
+	if src.NestedObject2Value != nil {
+		return json.Marshal(&src.NestedObject2Value)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -115,12 +115,12 @@ func (obj *Object) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.NestedObject1 != nil {
-		return obj.NestedObject1
+	if obj.NestedObject1Value != nil {
+		return obj.NestedObject1Value
 	}
 
-	if obj.NestedObject2 != nil {
-		return obj.NestedObject2
+	if obj.NestedObject2Value != nil {
+		return obj.NestedObject2Value
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_any_of_primitive_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_any_of_primitive_type.go
@@ -18,51 +18,51 @@ import (
 
 // AnyOfPrimitiveType struct for AnyOfPrimitiveType
 type AnyOfPrimitiveType struct {
-	OneOfPrimitiveTypeChild *OneOfPrimitiveTypeChild
-	ArrayOfString *[]string
-	Int32 *int32
+	OneOfPrimitiveTypeChildValue *OneOfPrimitiveTypeChild
+	ArrayOfStringValue *[]string
+	Int32Value *int32
 }
 
 // Unmarshal JSON data into any of the pointers in the struct
 func (dst *AnyOfPrimitiveType) UnmarshalJSON(data []byte) error {
 	var err error
-	// try to unmarshal JSON data into OneOfPrimitiveTypeChild
-	err = json.Unmarshal(data, &dst.OneOfPrimitiveTypeChild);
+	// try to unmarshal JSON data into OneOfPrimitiveTypeChildValue
+	err = json.Unmarshal(data, &dst.OneOfPrimitiveTypeChildValue);
 	if err == nil {
-		jsonOneOfPrimitiveTypeChild, _ := json.Marshal(dst.OneOfPrimitiveTypeChild)
-		if string(jsonOneOfPrimitiveTypeChild) == "{}" { // empty struct
-			dst.OneOfPrimitiveTypeChild = nil
+		jsonOneOfPrimitiveTypeChildValue, _ := json.Marshal(dst.OneOfPrimitiveTypeChildValue)
+		if string(jsonOneOfPrimitiveTypeChildValue) == "{}" { // empty struct
+			dst.OneOfPrimitiveTypeChildValue = nil
 		} else {
-			return nil // data stored in dst.OneOfPrimitiveTypeChild, return on the first match
+			return nil // data stored in dst.OneOfPrimitiveTypeChildValue, return on the first match
 		}
 	} else {
-		dst.OneOfPrimitiveTypeChild = nil
+		dst.OneOfPrimitiveTypeChildValue = nil
 	}
 
-	// try to unmarshal JSON data into ArrayOfString
-	err = json.Unmarshal(data, &dst.ArrayOfString);
+	// try to unmarshal JSON data into ArrayOfStringValue
+	err = json.Unmarshal(data, &dst.ArrayOfStringValue);
 	if err == nil {
-		jsonArrayOfString, _ := json.Marshal(dst.ArrayOfString)
-		if string(jsonArrayOfString) == "{}" { // empty struct
-			dst.ArrayOfString = nil
+		jsonArrayOfStringValue, _ := json.Marshal(dst.ArrayOfStringValue)
+		if string(jsonArrayOfStringValue) == "{}" { // empty struct
+			dst.ArrayOfStringValue = nil
 		} else {
-			return nil // data stored in dst.ArrayOfString, return on the first match
+			return nil // data stored in dst.ArrayOfStringValue, return on the first match
 		}
 	} else {
-		dst.ArrayOfString = nil
+		dst.ArrayOfStringValue = nil
 	}
 
-	// try to unmarshal JSON data into Int32
-	err = json.Unmarshal(data, &dst.Int32);
+	// try to unmarshal JSON data into Int32Value
+	err = json.Unmarshal(data, &dst.Int32Value);
 	if err == nil {
-		jsonInt32, _ := json.Marshal(dst.Int32)
-		if string(jsonInt32) == "{}" { // empty struct
-			dst.Int32 = nil
+		jsonInt32Value, _ := json.Marshal(dst.Int32Value)
+		if string(jsonInt32Value) == "{}" { // empty struct
+			dst.Int32Value = nil
 		} else {
-			return nil // data stored in dst.Int32, return on the first match
+			return nil // data stored in dst.Int32Value, return on the first match
 		}
 	} else {
-		dst.Int32 = nil
+		dst.Int32Value = nil
 	}
 
 	return fmt.Errorf("data failed to match schemas in anyOf(AnyOfPrimitiveType)")
@@ -70,16 +70,16 @@ func (dst *AnyOfPrimitiveType) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src AnyOfPrimitiveType) MarshalJSON() ([]byte, error) {
-	if src.OneOfPrimitiveTypeChild != nil {
-		return json.Marshal(&src.OneOfPrimitiveTypeChild)
+	if src.OneOfPrimitiveTypeChildValue != nil {
+		return json.Marshal(&src.OneOfPrimitiveTypeChildValue)
 	}
 
-	if src.ArrayOfString != nil {
-		return json.Marshal(&src.ArrayOfString)
+	if src.ArrayOfStringValue != nil {
+		return json.Marshal(&src.ArrayOfStringValue)
 	}
 
-	if src.Int32 != nil {
-		return json.Marshal(&src.Int32)
+	if src.Int32Value != nil {
+		return json.Marshal(&src.Int32Value)
 	}
 
 	return nil, nil // no data in anyOf schemas

--- a/samples/openapi3/client/petstore/go/go-petstore/model_filter_any.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_filter_any.go
@@ -20,8 +20,8 @@ var _ MappedNullable = &FilterAny{}
 
 // FilterAny struct for FilterAny
 type FilterAny struct {
-	FilterTypeRange *FilterTypeRange
-	FilterTypeRegex *FilterTypeRegex
+	FilterTypeRangeValue *FilterTypeRange
+	FilterTypeRegexValue *FilterTypeRegex
 }
 
 // Unmarshal JSON data into any of the pointers in the struct
@@ -98,30 +98,30 @@ func (dst *FilterAny) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	// try to unmarshal JSON data into FilterTypeRange
-	err = json.Unmarshal(data, &dst.FilterTypeRange);
+	// try to unmarshal JSON data into FilterTypeRangeValue
+	err = json.Unmarshal(data, &dst.FilterTypeRangeValue);
 	if err == nil {
-		jsonFilterTypeRange, _ := json.Marshal(dst.FilterTypeRange)
-		if string(jsonFilterTypeRange) == "{}" { // empty struct
-			dst.FilterTypeRange = nil
+		jsonFilterTypeRangeValue, _ := json.Marshal(dst.FilterTypeRangeValue)
+		if string(jsonFilterTypeRangeValue) == "{}" { // empty struct
+			dst.FilterTypeRangeValue = nil
 		} else {
-			return nil // data stored in dst.FilterTypeRange, return on the first match
+			return nil // data stored in dst.FilterTypeRangeValue, return on the first match
 		}
 	} else {
-		dst.FilterTypeRange = nil
+		dst.FilterTypeRangeValue = nil
 	}
 
-	// try to unmarshal JSON data into FilterTypeRegex
-	err = json.Unmarshal(data, &dst.FilterTypeRegex);
+	// try to unmarshal JSON data into FilterTypeRegexValue
+	err = json.Unmarshal(data, &dst.FilterTypeRegexValue);
 	if err == nil {
-		jsonFilterTypeRegex, _ := json.Marshal(dst.FilterTypeRegex)
-		if string(jsonFilterTypeRegex) == "{}" { // empty struct
-			dst.FilterTypeRegex = nil
+		jsonFilterTypeRegexValue, _ := json.Marshal(dst.FilterTypeRegexValue)
+		if string(jsonFilterTypeRegexValue) == "{}" { // empty struct
+			dst.FilterTypeRegexValue = nil
 		} else {
-			return nil // data stored in dst.FilterTypeRegex, return on the first match
+			return nil // data stored in dst.FilterTypeRegexValue, return on the first match
 		}
 	} else {
-		dst.FilterTypeRegex = nil
+		dst.FilterTypeRegexValue = nil
 	}
 
 	return fmt.Errorf("data failed to match schemas in anyOf(FilterAny)")
@@ -129,24 +129,24 @@ func (dst *FilterAny) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src FilterAny) MarshalJSON() ([]byte, error) {
-	if src.FilterTypeRange != nil {
-		return json.Marshal(&src.FilterTypeRange)
+	if src.FilterTypeRangeValue != nil {
+		return json.Marshal(&src.FilterTypeRangeValue)
 	}
 
-	if src.FilterTypeRegex != nil {
-		return json.Marshal(&src.FilterTypeRegex)
+	if src.FilterTypeRegexValue != nil {
+		return json.Marshal(&src.FilterTypeRegexValue)
 	}
 
 	return nil, nil // no data in anyOf schemas
 }
 
 func (src FilterAny) ToMap() (map[string]interface{}, error) {
-	if src.FilterTypeRange != nil {
-		return src.FilterTypeRange.ToMap()
+	if src.FilterTypeRangeValue != nil {
+		return src.FilterTypeRangeValue.ToMap()
 	}
 
-	if src.FilterTypeRegex != nil {
-		return src.FilterTypeRegex.ToMap()
+	if src.FilterTypeRegexValue != nil {
+		return src.FilterTypeRegexValue.ToMap()
 	}
 
     return nil, nil // no data in anyOf schemas

--- a/samples/openapi3/client/petstore/go/go-petstore/model_fruit.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_fruit.go
@@ -18,21 +18,21 @@ import (
 
 // Fruit - struct for Fruit
 type Fruit struct {
-	Apple *Apple
-	Banana *Banana
+	AppleValue *Apple
+	BananaValue *Banana
 }
 
 // AppleAsFruit is a convenience function that returns Apple wrapped in Fruit
-func AppleAsFruit(v *Apple) Fruit {
+func AppleValueAsFruit(v *Apple) Fruit {
 	return Fruit{
-		Apple: v,
+		AppleValue: v,
 	}
 }
 
 // BananaAsFruit is a convenience function that returns Banana wrapped in Fruit
-func BananaAsFruit(v *Banana) Fruit {
+func BananaValueAsFruit(v *Banana) Fruit {
 	return Fruit{
-		Banana: v,
+		BananaValue: v,
 	}
 }
 
@@ -41,44 +41,44 @@ func BananaAsFruit(v *Banana) Fruit {
 func (dst *Fruit) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into Apple
-	err = newStrictDecoder(data).Decode(&dst.Apple)
+	// try to unmarshal data into AppleValue
+	err = newStrictDecoder(data).Decode(&dst.AppleValue)
 	if err == nil {
-		jsonApple, _ := json.Marshal(dst.Apple)
-		if string(jsonApple) == "{}" { // empty struct
-			dst.Apple = nil
+		jsonAppleValue, _ := json.Marshal(dst.AppleValue)
+		if string(jsonAppleValue) == "{}" { // empty struct
+			dst.AppleValue = nil
 		} else {
-			if err = validator.Validate(dst.Apple); err != nil {
-				dst.Apple = nil
+			if err = validator.Validate(dst.AppleValue); err != nil {
+				dst.AppleValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.Apple = nil
+		dst.AppleValue = nil
 	}
 
-	// try to unmarshal data into Banana
-	err = newStrictDecoder(data).Decode(&dst.Banana)
+	// try to unmarshal data into BananaValue
+	err = newStrictDecoder(data).Decode(&dst.BananaValue)
 	if err == nil {
-		jsonBanana, _ := json.Marshal(dst.Banana)
-		if string(jsonBanana) == "{}" { // empty struct
-			dst.Banana = nil
+		jsonBananaValue, _ := json.Marshal(dst.BananaValue)
+		if string(jsonBananaValue) == "{}" { // empty struct
+			dst.BananaValue = nil
 		} else {
-			if err = validator.Validate(dst.Banana); err != nil {
-				dst.Banana = nil
+			if err = validator.Validate(dst.BananaValue); err != nil {
+				dst.BananaValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.Banana = nil
+		dst.BananaValue = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.Apple = nil
-		dst.Banana = nil
+		dst.AppleValue = nil
+		dst.BananaValue = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(Fruit)")
 	} else if match == 1 {
@@ -90,12 +90,12 @@ func (dst *Fruit) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src Fruit) MarshalJSON() ([]byte, error) {
-	if src.Apple != nil {
-		return json.Marshal(&src.Apple)
+	if src.AppleValue != nil {
+		return json.Marshal(&src.AppleValue)
 	}
 
-	if src.Banana != nil {
-		return json.Marshal(&src.Banana)
+	if src.BananaValue != nil {
+		return json.Marshal(&src.BananaValue)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -106,12 +106,12 @@ func (obj *Fruit) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.Apple != nil {
-		return obj.Apple
+	if obj.AppleValue != nil {
+		return obj.AppleValue
 	}
 
-	if obj.Banana != nil {
-		return obj.Banana
+	if obj.BananaValue != nil {
+		return obj.BananaValue
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_fruit_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_fruit_req.go
@@ -18,21 +18,21 @@ import (
 
 // FruitReq - struct for FruitReq
 type FruitReq struct {
-	AppleReq *AppleReq
-	BananaReq *BananaReq
+	AppleReqValue *AppleReq
+	BananaReqValue *BananaReq
 }
 
 // AppleReqAsFruitReq is a convenience function that returns AppleReq wrapped in FruitReq
-func AppleReqAsFruitReq(v *AppleReq) FruitReq {
+func AppleReqValueAsFruitReq(v *AppleReq) FruitReq {
 	return FruitReq{
-		AppleReq: v,
+		AppleReqValue: v,
 	}
 }
 
 // BananaReqAsFruitReq is a convenience function that returns BananaReq wrapped in FruitReq
-func BananaReqAsFruitReq(v *BananaReq) FruitReq {
+func BananaReqValueAsFruitReq(v *BananaReq) FruitReq {
 	return FruitReq{
-		BananaReq: v,
+		BananaReqValue: v,
 	}
 }
 
@@ -41,44 +41,44 @@ func BananaReqAsFruitReq(v *BananaReq) FruitReq {
 func (dst *FruitReq) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into AppleReq
-	err = newStrictDecoder(data).Decode(&dst.AppleReq)
+	// try to unmarshal data into AppleReqValue
+	err = newStrictDecoder(data).Decode(&dst.AppleReqValue)
 	if err == nil {
-		jsonAppleReq, _ := json.Marshal(dst.AppleReq)
-		if string(jsonAppleReq) == "{}" { // empty struct
-			dst.AppleReq = nil
+		jsonAppleReqValue, _ := json.Marshal(dst.AppleReqValue)
+		if string(jsonAppleReqValue) == "{}" { // empty struct
+			dst.AppleReqValue = nil
 		} else {
-			if err = validator.Validate(dst.AppleReq); err != nil {
-				dst.AppleReq = nil
+			if err = validator.Validate(dst.AppleReqValue); err != nil {
+				dst.AppleReqValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.AppleReq = nil
+		dst.AppleReqValue = nil
 	}
 
-	// try to unmarshal data into BananaReq
-	err = newStrictDecoder(data).Decode(&dst.BananaReq)
+	// try to unmarshal data into BananaReqValue
+	err = newStrictDecoder(data).Decode(&dst.BananaReqValue)
 	if err == nil {
-		jsonBananaReq, _ := json.Marshal(dst.BananaReq)
-		if string(jsonBananaReq) == "{}" { // empty struct
-			dst.BananaReq = nil
+		jsonBananaReqValue, _ := json.Marshal(dst.BananaReqValue)
+		if string(jsonBananaReqValue) == "{}" { // empty struct
+			dst.BananaReqValue = nil
 		} else {
-			if err = validator.Validate(dst.BananaReq); err != nil {
-				dst.BananaReq = nil
+			if err = validator.Validate(dst.BananaReqValue); err != nil {
+				dst.BananaReqValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.BananaReq = nil
+		dst.BananaReqValue = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.AppleReq = nil
-		dst.BananaReq = nil
+		dst.AppleReqValue = nil
+		dst.BananaReqValue = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(FruitReq)")
 	} else if match == 1 {
@@ -90,12 +90,12 @@ func (dst *FruitReq) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src FruitReq) MarshalJSON() ([]byte, error) {
-	if src.AppleReq != nil {
-		return json.Marshal(&src.AppleReq)
+	if src.AppleReqValue != nil {
+		return json.Marshal(&src.AppleReqValue)
 	}
 
-	if src.BananaReq != nil {
-		return json.Marshal(&src.BananaReq)
+	if src.BananaReqValue != nil {
+		return json.Marshal(&src.BananaReqValue)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -106,12 +106,12 @@ func (obj *FruitReq) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.AppleReq != nil {
-		return obj.AppleReq
+	if obj.AppleReqValue != nil {
+		return obj.AppleReqValue
 	}
 
-	if obj.BananaReq != nil {
-		return obj.BananaReq
+	if obj.BananaReqValue != nil {
+		return obj.BananaReqValue
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_gm_fruit.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_gm_fruit.go
@@ -18,37 +18,37 @@ import (
 
 // GmFruit struct for GmFruit
 type GmFruit struct {
-	Apple *Apple
-	Banana *Banana
+	AppleValue *Apple
+	BananaValue *Banana
 }
 
 // Unmarshal JSON data into any of the pointers in the struct
 func (dst *GmFruit) UnmarshalJSON(data []byte) error {
 	var err error
-	// try to unmarshal JSON data into Apple
-	err = json.Unmarshal(data, &dst.Apple);
+	// try to unmarshal JSON data into AppleValue
+	err = json.Unmarshal(data, &dst.AppleValue);
 	if err == nil {
-		jsonApple, _ := json.Marshal(dst.Apple)
-		if string(jsonApple) == "{}" { // empty struct
-			dst.Apple = nil
+		jsonAppleValue, _ := json.Marshal(dst.AppleValue)
+		if string(jsonAppleValue) == "{}" { // empty struct
+			dst.AppleValue = nil
 		} else {
-			return nil // data stored in dst.Apple, return on the first match
+			return nil // data stored in dst.AppleValue, return on the first match
 		}
 	} else {
-		dst.Apple = nil
+		dst.AppleValue = nil
 	}
 
-	// try to unmarshal JSON data into Banana
-	err = json.Unmarshal(data, &dst.Banana);
+	// try to unmarshal JSON data into BananaValue
+	err = json.Unmarshal(data, &dst.BananaValue);
 	if err == nil {
-		jsonBanana, _ := json.Marshal(dst.Banana)
-		if string(jsonBanana) == "{}" { // empty struct
-			dst.Banana = nil
+		jsonBananaValue, _ := json.Marshal(dst.BananaValue)
+		if string(jsonBananaValue) == "{}" { // empty struct
+			dst.BananaValue = nil
 		} else {
-			return nil // data stored in dst.Banana, return on the first match
+			return nil // data stored in dst.BananaValue, return on the first match
 		}
 	} else {
-		dst.Banana = nil
+		dst.BananaValue = nil
 	}
 
 	return fmt.Errorf("data failed to match schemas in anyOf(GmFruit)")
@@ -56,12 +56,12 @@ func (dst *GmFruit) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src GmFruit) MarshalJSON() ([]byte, error) {
-	if src.Apple != nil {
-		return json.Marshal(&src.Apple)
+	if src.AppleValue != nil {
+		return json.Marshal(&src.AppleValue)
 	}
 
-	if src.Banana != nil {
-		return json.Marshal(&src.Banana)
+	if src.BananaValue != nil {
+		return json.Marshal(&src.BananaValue)
 	}
 
 	return nil, nil // no data in anyOf schemas

--- a/samples/openapi3/client/petstore/go/go-petstore/model_incident_data.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_incident_data.go
@@ -18,21 +18,21 @@ import (
 
 // IncidentData - struct for IncidentData
 type IncidentData struct {
-	ArrayOfMapmapOfStringAny *[]map[string]interface{}
-	MapmapOfStringAny *map[string]interface{}
+	ArrayOfMapmapOfStringAnyValue *[]map[string]interface{}
+	MapmapOfStringAnyValue *map[string]interface{}
 }
 
 // []map[string]interface{}AsIncidentData is a convenience function that returns []map[string]interface{} wrapped in IncidentData
-func ArrayOfMapmapOfStringAnyAsIncidentData(v *[]map[string]interface{}) IncidentData {
+func ArrayOfMapmapOfStringAnyValueAsIncidentData(v *[]map[string]interface{}) IncidentData {
 	return IncidentData{
-		ArrayOfMapmapOfStringAny: v,
+		ArrayOfMapmapOfStringAnyValue: v,
 	}
 }
 
 // map[string]interface{}AsIncidentData is a convenience function that returns map[string]interface{} wrapped in IncidentData
-func MapmapOfStringAnyAsIncidentData(v *map[string]interface{}) IncidentData {
+func MapmapOfStringAnyValueAsIncidentData(v *map[string]interface{}) IncidentData {
 	return IncidentData{
-		MapmapOfStringAny: v,
+		MapmapOfStringAnyValue: v,
 	}
 }
 
@@ -46,44 +46,44 @@ func (dst *IncidentData) UnmarshalJSON(data []byte) error {
 	}
 
 	match := 0
-	// try to unmarshal data into ArrayOfMapmapOfStringAny
-	err = newStrictDecoder(data).Decode(&dst.ArrayOfMapmapOfStringAny)
+	// try to unmarshal data into ArrayOfMapmapOfStringAnyValue
+	err = newStrictDecoder(data).Decode(&dst.ArrayOfMapmapOfStringAnyValue)
 	if err == nil {
-		jsonArrayOfMapmapOfStringAny, _ := json.Marshal(dst.ArrayOfMapmapOfStringAny)
-		if string(jsonArrayOfMapmapOfStringAny) == "{}" { // empty struct
-			dst.ArrayOfMapmapOfStringAny = nil
+		jsonArrayOfMapmapOfStringAnyValue, _ := json.Marshal(dst.ArrayOfMapmapOfStringAnyValue)
+		if string(jsonArrayOfMapmapOfStringAnyValue) == "{}" { // empty struct
+			dst.ArrayOfMapmapOfStringAnyValue = nil
 		} else {
-			if err = validator.Validate(dst.ArrayOfMapmapOfStringAny); err != nil {
-				dst.ArrayOfMapmapOfStringAny = nil
+			if err = validator.Validate(dst.ArrayOfMapmapOfStringAnyValue); err != nil {
+				dst.ArrayOfMapmapOfStringAnyValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.ArrayOfMapmapOfStringAny = nil
+		dst.ArrayOfMapmapOfStringAnyValue = nil
 	}
 
-	// try to unmarshal data into MapmapOfStringAny
-	err = newStrictDecoder(data).Decode(&dst.MapmapOfStringAny)
+	// try to unmarshal data into MapmapOfStringAnyValue
+	err = newStrictDecoder(data).Decode(&dst.MapmapOfStringAnyValue)
 	if err == nil {
-		jsonMapmapOfStringAny, _ := json.Marshal(dst.MapmapOfStringAny)
-		if string(jsonMapmapOfStringAny) == "{}" { // empty struct
-			dst.MapmapOfStringAny = nil
+		jsonMapmapOfStringAnyValue, _ := json.Marshal(dst.MapmapOfStringAnyValue)
+		if string(jsonMapmapOfStringAnyValue) == "{}" { // empty struct
+			dst.MapmapOfStringAnyValue = nil
 		} else {
-			if err = validator.Validate(dst.MapmapOfStringAny); err != nil {
-				dst.MapmapOfStringAny = nil
+			if err = validator.Validate(dst.MapmapOfStringAnyValue); err != nil {
+				dst.MapmapOfStringAnyValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.MapmapOfStringAny = nil
+		dst.MapmapOfStringAnyValue = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.ArrayOfMapmapOfStringAny = nil
-		dst.MapmapOfStringAny = nil
+		dst.ArrayOfMapmapOfStringAnyValue = nil
+		dst.MapmapOfStringAnyValue = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(IncidentData)")
 	} else if match == 1 {
@@ -95,12 +95,12 @@ func (dst *IncidentData) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src IncidentData) MarshalJSON() ([]byte, error) {
-	if src.ArrayOfMapmapOfStringAny != nil {
-		return json.Marshal(&src.ArrayOfMapmapOfStringAny)
+	if src.ArrayOfMapmapOfStringAnyValue != nil {
+		return json.Marshal(&src.ArrayOfMapmapOfStringAnyValue)
 	}
 
-	if src.MapmapOfStringAny != nil {
-		return json.Marshal(&src.MapmapOfStringAny)
+	if src.MapmapOfStringAnyValue != nil {
+		return json.Marshal(&src.MapmapOfStringAnyValue)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -111,12 +111,12 @@ func (obj *IncidentData) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.ArrayOfMapmapOfStringAny != nil {
-		return obj.ArrayOfMapmapOfStringAny
+	if obj.ArrayOfMapmapOfStringAnyValue != nil {
+		return obj.ArrayOfMapmapOfStringAnyValue
 	}
 
-	if obj.MapmapOfStringAny != nil {
-		return obj.MapmapOfStringAny
+	if obj.MapmapOfStringAnyValue != nil {
+		return obj.MapmapOfStringAnyValue
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mammal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mammal.go
@@ -18,21 +18,21 @@ import (
 
 // Mammal - struct for Mammal
 type Mammal struct {
-	Whale *Whale
-	Zebra *Zebra
+	WhaleValue *Whale
+	ZebraValue *Zebra
 }
 
 // WhaleAsMammal is a convenience function that returns Whale wrapped in Mammal
-func WhaleAsMammal(v *Whale) Mammal {
+func WhaleValueAsMammal(v *Whale) Mammal {
 	return Mammal{
-		Whale: v,
+		WhaleValue: v,
 	}
 }
 
 // ZebraAsMammal is a convenience function that returns Zebra wrapped in Mammal
-func ZebraAsMammal(v *Zebra) Mammal {
+func ZebraValueAsMammal(v *Zebra) Mammal {
 	return Mammal{
-		Zebra: v,
+		ZebraValue: v,
 	}
 }
 
@@ -41,44 +41,44 @@ func ZebraAsMammal(v *Zebra) Mammal {
 func (dst *Mammal) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into Whale
-	err = newStrictDecoder(data).Decode(&dst.Whale)
+	// try to unmarshal data into WhaleValue
+	err = newStrictDecoder(data).Decode(&dst.WhaleValue)
 	if err == nil {
-		jsonWhale, _ := json.Marshal(dst.Whale)
-		if string(jsonWhale) == "{}" { // empty struct
-			dst.Whale = nil
+		jsonWhaleValue, _ := json.Marshal(dst.WhaleValue)
+		if string(jsonWhaleValue) == "{}" { // empty struct
+			dst.WhaleValue = nil
 		} else {
-			if err = validator.Validate(dst.Whale); err != nil {
-				dst.Whale = nil
+			if err = validator.Validate(dst.WhaleValue); err != nil {
+				dst.WhaleValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.Whale = nil
+		dst.WhaleValue = nil
 	}
 
-	// try to unmarshal data into Zebra
-	err = newStrictDecoder(data).Decode(&dst.Zebra)
+	// try to unmarshal data into ZebraValue
+	err = newStrictDecoder(data).Decode(&dst.ZebraValue)
 	if err == nil {
-		jsonZebra, _ := json.Marshal(dst.Zebra)
-		if string(jsonZebra) == "{}" { // empty struct
-			dst.Zebra = nil
+		jsonZebraValue, _ := json.Marshal(dst.ZebraValue)
+		if string(jsonZebraValue) == "{}" { // empty struct
+			dst.ZebraValue = nil
 		} else {
-			if err = validator.Validate(dst.Zebra); err != nil {
-				dst.Zebra = nil
+			if err = validator.Validate(dst.ZebraValue); err != nil {
+				dst.ZebraValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.Zebra = nil
+		dst.ZebraValue = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.Whale = nil
-		dst.Zebra = nil
+		dst.WhaleValue = nil
+		dst.ZebraValue = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(Mammal)")
 	} else if match == 1 {
@@ -90,12 +90,12 @@ func (dst *Mammal) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src Mammal) MarshalJSON() ([]byte, error) {
-	if src.Whale != nil {
-		return json.Marshal(&src.Whale)
+	if src.WhaleValue != nil {
+		return json.Marshal(&src.WhaleValue)
 	}
 
-	if src.Zebra != nil {
-		return json.Marshal(&src.Zebra)
+	if src.ZebraValue != nil {
+		return json.Marshal(&src.ZebraValue)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -106,12 +106,12 @@ func (obj *Mammal) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.Whale != nil {
-		return obj.Whale
+	if obj.WhaleValue != nil {
+		return obj.WhaleValue
 	}
 
-	if obj.Zebra != nil {
-		return obj.Zebra
+	if obj.ZebraValue != nil {
+		return obj.ZebraValue
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type.go
@@ -18,29 +18,29 @@ import (
 
 // OneOfPrimitiveType - struct for OneOfPrimitiveType
 type OneOfPrimitiveType struct {
-	OneOfPrimitiveTypeChild *OneOfPrimitiveTypeChild
-	ArrayOfString *[]string
-	Int32 *int32
+	OneOfPrimitiveTypeChildValue *OneOfPrimitiveTypeChild
+	ArrayOfStringValue *[]string
+	Int32Value *int32
 }
 
 // OneOfPrimitiveTypeChildAsOneOfPrimitiveType is a convenience function that returns OneOfPrimitiveTypeChild wrapped in OneOfPrimitiveType
-func OneOfPrimitiveTypeChildAsOneOfPrimitiveType(v *OneOfPrimitiveTypeChild) OneOfPrimitiveType {
+func OneOfPrimitiveTypeChildValueAsOneOfPrimitiveType(v *OneOfPrimitiveTypeChild) OneOfPrimitiveType {
 	return OneOfPrimitiveType{
-		OneOfPrimitiveTypeChild: v,
+		OneOfPrimitiveTypeChildValue: v,
 	}
 }
 
 // []stringAsOneOfPrimitiveType is a convenience function that returns []string wrapped in OneOfPrimitiveType
-func ArrayOfStringAsOneOfPrimitiveType(v *[]string) OneOfPrimitiveType {
+func ArrayOfStringValueAsOneOfPrimitiveType(v *[]string) OneOfPrimitiveType {
 	return OneOfPrimitiveType{
-		ArrayOfString: v,
+		ArrayOfStringValue: v,
 	}
 }
 
 // int32AsOneOfPrimitiveType is a convenience function that returns int32 wrapped in OneOfPrimitiveType
-func Int32AsOneOfPrimitiveType(v *int32) OneOfPrimitiveType {
+func Int32ValueAsOneOfPrimitiveType(v *int32) OneOfPrimitiveType {
 	return OneOfPrimitiveType{
-		Int32: v,
+		Int32Value: v,
 	}
 }
 
@@ -49,62 +49,62 @@ func Int32AsOneOfPrimitiveType(v *int32) OneOfPrimitiveType {
 func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into OneOfPrimitiveTypeChild
-	err = newStrictDecoder(data).Decode(&dst.OneOfPrimitiveTypeChild)
+	// try to unmarshal data into OneOfPrimitiveTypeChildValue
+	err = newStrictDecoder(data).Decode(&dst.OneOfPrimitiveTypeChildValue)
 	if err == nil {
-		jsonOneOfPrimitiveTypeChild, _ := json.Marshal(dst.OneOfPrimitiveTypeChild)
-		if string(jsonOneOfPrimitiveTypeChild) == "{}" { // empty struct
-			dst.OneOfPrimitiveTypeChild = nil
+		jsonOneOfPrimitiveTypeChildValue, _ := json.Marshal(dst.OneOfPrimitiveTypeChildValue)
+		if string(jsonOneOfPrimitiveTypeChildValue) == "{}" { // empty struct
+			dst.OneOfPrimitiveTypeChildValue = nil
 		} else {
-			if err = validator.Validate(dst.OneOfPrimitiveTypeChild); err != nil {
-				dst.OneOfPrimitiveTypeChild = nil
+			if err = validator.Validate(dst.OneOfPrimitiveTypeChildValue); err != nil {
+				dst.OneOfPrimitiveTypeChildValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.OneOfPrimitiveTypeChild = nil
+		dst.OneOfPrimitiveTypeChildValue = nil
 	}
 
-	// try to unmarshal data into ArrayOfString
-	err = newStrictDecoder(data).Decode(&dst.ArrayOfString)
+	// try to unmarshal data into ArrayOfStringValue
+	err = newStrictDecoder(data).Decode(&dst.ArrayOfStringValue)
 	if err == nil {
-		jsonArrayOfString, _ := json.Marshal(dst.ArrayOfString)
-		if string(jsonArrayOfString) == "{}" { // empty struct
-			dst.ArrayOfString = nil
+		jsonArrayOfStringValue, _ := json.Marshal(dst.ArrayOfStringValue)
+		if string(jsonArrayOfStringValue) == "{}" { // empty struct
+			dst.ArrayOfStringValue = nil
 		} else {
-			if err = validator.Validate(dst.ArrayOfString); err != nil {
-				dst.ArrayOfString = nil
+			if err = validator.Validate(dst.ArrayOfStringValue); err != nil {
+				dst.ArrayOfStringValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.ArrayOfString = nil
+		dst.ArrayOfStringValue = nil
 	}
 
-	// try to unmarshal data into Int32
-	err = newStrictDecoder(data).Decode(&dst.Int32)
+	// try to unmarshal data into Int32Value
+	err = newStrictDecoder(data).Decode(&dst.Int32Value)
 	if err == nil {
-		jsonInt32, _ := json.Marshal(dst.Int32)
-		if string(jsonInt32) == "{}" { // empty struct
-			dst.Int32 = nil
+		jsonInt32Value, _ := json.Marshal(dst.Int32Value)
+		if string(jsonInt32Value) == "{}" { // empty struct
+			dst.Int32Value = nil
 		} else {
-			if err = validator.Validate(dst.Int32); err != nil {
-				dst.Int32 = nil
+			if err = validator.Validate(dst.Int32Value); err != nil {
+				dst.Int32Value = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.Int32 = nil
+		dst.Int32Value = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.OneOfPrimitiveTypeChild = nil
-		dst.ArrayOfString = nil
-		dst.Int32 = nil
+		dst.OneOfPrimitiveTypeChildValue = nil
+		dst.ArrayOfStringValue = nil
+		dst.Int32Value = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(OneOfPrimitiveType)")
 	} else if match == 1 {
@@ -116,16 +116,16 @@ func (dst *OneOfPrimitiveType) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src OneOfPrimitiveType) MarshalJSON() ([]byte, error) {
-	if src.OneOfPrimitiveTypeChild != nil {
-		return json.Marshal(&src.OneOfPrimitiveTypeChild)
+	if src.OneOfPrimitiveTypeChildValue != nil {
+		return json.Marshal(&src.OneOfPrimitiveTypeChildValue)
 	}
 
-	if src.ArrayOfString != nil {
-		return json.Marshal(&src.ArrayOfString)
+	if src.ArrayOfStringValue != nil {
+		return json.Marshal(&src.ArrayOfStringValue)
 	}
 
-	if src.Int32 != nil {
-		return json.Marshal(&src.Int32)
+	if src.Int32Value != nil {
+		return json.Marshal(&src.Int32Value)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -136,16 +136,16 @@ func (obj *OneOfPrimitiveType) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.OneOfPrimitiveTypeChild != nil {
-		return obj.OneOfPrimitiveTypeChild
+	if obj.OneOfPrimitiveTypeChildValue != nil {
+		return obj.OneOfPrimitiveTypeChildValue
 	}
 
-	if obj.ArrayOfString != nil {
-		return obj.ArrayOfString
+	if obj.ArrayOfStringValue != nil {
+		return obj.ArrayOfStringValue
 	}
 
-	if obj.Int32 != nil {
-		return obj.Int32
+	if obj.Int32Value != nil {
+		return obj.Int32Value
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_types.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_types.go
@@ -19,21 +19,21 @@ import (
 
 // OneOfPrimitiveTypes - struct for OneOfPrimitiveTypes
 type OneOfPrimitiveTypes struct {
-	String *string
-	TimeTime *time.Time
+	StringValue *string
+	TimeTimeValue *time.Time
 }
 
 // stringAsOneOfPrimitiveTypes is a convenience function that returns string wrapped in OneOfPrimitiveTypes
-func StringAsOneOfPrimitiveTypes(v *string) OneOfPrimitiveTypes {
+func StringValueAsOneOfPrimitiveTypes(v *string) OneOfPrimitiveTypes {
 	return OneOfPrimitiveTypes{
-		String: v,
+		StringValue: v,
 	}
 }
 
 // time.TimeAsOneOfPrimitiveTypes is a convenience function that returns time.Time wrapped in OneOfPrimitiveTypes
-func TimeTimeAsOneOfPrimitiveTypes(v *time.Time) OneOfPrimitiveTypes {
+func TimeTimeValueAsOneOfPrimitiveTypes(v *time.Time) OneOfPrimitiveTypes {
 	return OneOfPrimitiveTypes{
-		TimeTime: v,
+		TimeTimeValue: v,
 	}
 }
 
@@ -42,44 +42,44 @@ func TimeTimeAsOneOfPrimitiveTypes(v *time.Time) OneOfPrimitiveTypes {
 func (dst *OneOfPrimitiveTypes) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into String
-	err = newStrictDecoder(data).Decode(&dst.String)
+	// try to unmarshal data into StringValue
+	err = newStrictDecoder(data).Decode(&dst.StringValue)
 	if err == nil {
-		jsonString, _ := json.Marshal(dst.String)
-		if string(jsonString) == "{}" { // empty struct
-			dst.String = nil
+		jsonStringValue, _ := json.Marshal(dst.StringValue)
+		if string(jsonStringValue) == "{}" { // empty struct
+			dst.StringValue = nil
 		} else {
-			if err = validator.Validate(dst.String); err != nil {
-				dst.String = nil
+			if err = validator.Validate(dst.StringValue); err != nil {
+				dst.StringValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.String = nil
+		dst.StringValue = nil
 	}
 
-	// try to unmarshal data into TimeTime
-	err = newStrictDecoder(data).Decode(&dst.TimeTime)
+	// try to unmarshal data into TimeTimeValue
+	err = newStrictDecoder(data).Decode(&dst.TimeTimeValue)
 	if err == nil {
-		jsonTimeTime, _ := json.Marshal(dst.TimeTime)
-		if string(jsonTimeTime) == "{}" { // empty struct
-			dst.TimeTime = nil
+		jsonTimeTimeValue, _ := json.Marshal(dst.TimeTimeValue)
+		if string(jsonTimeTimeValue) == "{}" { // empty struct
+			dst.TimeTimeValue = nil
 		} else {
-			if err = validator.Validate(dst.TimeTime); err != nil {
-				dst.TimeTime = nil
+			if err = validator.Validate(dst.TimeTimeValue); err != nil {
+				dst.TimeTimeValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.TimeTime = nil
+		dst.TimeTimeValue = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.String = nil
-		dst.TimeTime = nil
+		dst.StringValue = nil
+		dst.TimeTimeValue = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(OneOfPrimitiveTypes)")
 	} else if match == 1 {
@@ -91,12 +91,12 @@ func (dst *OneOfPrimitiveTypes) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src OneOfPrimitiveTypes) MarshalJSON() ([]byte, error) {
-	if src.String != nil {
-		return json.Marshal(&src.String)
+	if src.StringValue != nil {
+		return json.Marshal(&src.StringValue)
 	}
 
-	if src.TimeTime != nil {
-		return json.Marshal(&src.TimeTime)
+	if src.TimeTimeValue != nil {
+		return json.Marshal(&src.TimeTimeValue)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -107,12 +107,12 @@ func (obj *OneOfPrimitiveTypes) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.String != nil {
-		return obj.String
+	if obj.StringValue != nil {
+		return obj.StringValue
 	}
 
-	if obj.TimeTime != nil {
-		return obj.TimeTime
+	if obj.TimeTimeValue != nil {
+		return obj.TimeTimeValue
 	}
 
 	// all schemas are nil

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_with_complex_type.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_with_complex_type.go
@@ -18,21 +18,21 @@ import (
 
 // OneOfWithComplexType - struct for OneOfWithComplexType
 type OneOfWithComplexType struct {
-	ArrayOfString *[]string
-	String *string
+	ArrayOfStringValue *[]string
+	StringValue *string
 }
 
 // []stringAsOneOfWithComplexType is a convenience function that returns []string wrapped in OneOfWithComplexType
-func ArrayOfStringAsOneOfWithComplexType(v *[]string) OneOfWithComplexType {
+func ArrayOfStringValueAsOneOfWithComplexType(v *[]string) OneOfWithComplexType {
 	return OneOfWithComplexType{
-		ArrayOfString: v,
+		ArrayOfStringValue: v,
 	}
 }
 
 // stringAsOneOfWithComplexType is a convenience function that returns string wrapped in OneOfWithComplexType
-func StringAsOneOfWithComplexType(v *string) OneOfWithComplexType {
+func StringValueAsOneOfWithComplexType(v *string) OneOfWithComplexType {
 	return OneOfWithComplexType{
-		String: v,
+		StringValue: v,
 	}
 }
 
@@ -41,44 +41,44 @@ func StringAsOneOfWithComplexType(v *string) OneOfWithComplexType {
 func (dst *OneOfWithComplexType) UnmarshalJSON(data []byte) error {
 	var err error
 	match := 0
-	// try to unmarshal data into ArrayOfString
-	err = newStrictDecoder(data).Decode(&dst.ArrayOfString)
+	// try to unmarshal data into ArrayOfStringValue
+	err = newStrictDecoder(data).Decode(&dst.ArrayOfStringValue)
 	if err == nil {
-		jsonArrayOfString, _ := json.Marshal(dst.ArrayOfString)
-		if string(jsonArrayOfString) == "{}" { // empty struct
-			dst.ArrayOfString = nil
+		jsonArrayOfStringValue, _ := json.Marshal(dst.ArrayOfStringValue)
+		if string(jsonArrayOfStringValue) == "{}" { // empty struct
+			dst.ArrayOfStringValue = nil
 		} else {
-			if err = validator.Validate(dst.ArrayOfString); err != nil {
-				dst.ArrayOfString = nil
+			if err = validator.Validate(dst.ArrayOfStringValue); err != nil {
+				dst.ArrayOfStringValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.ArrayOfString = nil
+		dst.ArrayOfStringValue = nil
 	}
 
-	// try to unmarshal data into String
-	err = newStrictDecoder(data).Decode(&dst.String)
+	// try to unmarshal data into StringValue
+	err = newStrictDecoder(data).Decode(&dst.StringValue)
 	if err == nil {
-		jsonString, _ := json.Marshal(dst.String)
-		if string(jsonString) == "{}" { // empty struct
-			dst.String = nil
+		jsonStringValue, _ := json.Marshal(dst.StringValue)
+		if string(jsonStringValue) == "{}" { // empty struct
+			dst.StringValue = nil
 		} else {
-			if err = validator.Validate(dst.String); err != nil {
-				dst.String = nil
+			if err = validator.Validate(dst.StringValue); err != nil {
+				dst.StringValue = nil
 			} else {
 				match++
 			}
 		}
 	} else {
-		dst.String = nil
+		dst.StringValue = nil
 	}
 
 	if match > 1 { // more than 1 match
 		// reset to nil
-		dst.ArrayOfString = nil
-		dst.String = nil
+		dst.ArrayOfStringValue = nil
+		dst.StringValue = nil
 
 		return fmt.Errorf("data matches more than one schema in oneOf(OneOfWithComplexType)")
 	} else if match == 1 {
@@ -90,12 +90,12 @@ func (dst *OneOfWithComplexType) UnmarshalJSON(data []byte) error {
 
 // Marshal data from the first non-nil pointers in the struct to JSON
 func (src OneOfWithComplexType) MarshalJSON() ([]byte, error) {
-	if src.ArrayOfString != nil {
-		return json.Marshal(&src.ArrayOfString)
+	if src.ArrayOfStringValue != nil {
+		return json.Marshal(&src.ArrayOfStringValue)
 	}
 
-	if src.String != nil {
-		return json.Marshal(&src.String)
+	if src.StringValue != nil {
+		return json.Marshal(&src.StringValue)
 	}
 
 	return nil, nil // no data in oneOf schemas
@@ -106,12 +106,12 @@ func (obj *OneOfWithComplexType) GetActualInstance() (interface{}) {
 	if obj == nil {
 		return nil
 	}
-	if obj.ArrayOfString != nil {
-		return obj.ArrayOfString
+	if obj.ArrayOfStringValue != nil {
+		return obj.ArrayOfStringValue
 	}
 
-	if obj.String != nil {
-		return obj.String
+	if obj.StringValue != nil {
+		return obj.StringValue
 	}
 
 	// all schemas are nil


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The Go client library generates Parameter structs for OneOf and AnyOf types. When one of the types is a string, then the property name will be `String`. This prevents us from creating a `String()` method which can be used with the `fmt` package.

By adding a Value suffix to the property names, we don't change any logic while allowing for more flexibility with the generated client.

This however requires existing clients to update calls to the implementations they made.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)
