### PR TITLE
[csharp] Handle query param encoding issues in .net9

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/HttpSigningConfiguration.mustache
@@ -133,16 +133,18 @@ namespace {{packageName}}.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/net9/EnumMappings/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Client/HttpSigningConfiguration.cs
@@ -141,16 +141,18 @@ namespace Org.OpenAPITools.Client
             foreach (var parameter in requestOptions.QueryParameters)
             {
 #if (NETCOREAPP)
+                string framework = RuntimeInformation.FrameworkDescription;
+                string key = framework.StartsWith(".NET 9")?parameter.Key:HttpUtility.UrlEncode(parameter.Key);
                 if (parameter.Value.Count > 1)
                 { // array
                     foreach (var value in parameter.Value)
                     {
-                        httpValues.Add(HttpUtility.UrlEncode(parameter.Key) + "[]", value);
+                        httpValues.Add(key + "[]", value);
                     }
                 }
                 else
                 {
-                    httpValues.Add(HttpUtility.UrlEncode(parameter.Key), parameter.Value[0]);
+                    httpValues.Add(key, parameter.Value[0]);
                 }
 #else
                 if (parameter.Value.Count > 1)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

In .net9 SDK URL Encoding is done as part of HttpUtility.ParseQueryString() method removing dependency on HttpUtility.UrlEncode() method.

Present implementation double encodes the URL for query parameters resulting in wrong URL's.

In order to avoid double encoding in  .net9 this PR blocks use of HttpUtility.UrlEncode() for .net9 SDK


