### PR TITLE
Fix #20649 Handling of x-implements for enumeration in java and spring generators

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -1078,7 +1078,7 @@ public class JavaClientCodegen extends AbstractJavaCodegen
                     cm.anyOf.remove("ModelNull");
                 }
             }
-            if (this.parcelableModel) {
+            if (this.parcelableModel && !cm.isEnum) {
                 ((ArrayList<String>) cm.getVendorExtensions().get("x-implements")).add("Parcelable");
             }
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumClass.mustache
@@ -8,7 +8,7 @@
   @JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
   {{/jsonb}}
 {{/withXml}}
-  {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
+  {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
 
     {{#allowableValues}}
     {{#withXml}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/enumOuterClass.mustache
@@ -13,7 +13,7 @@ import java.net.URI;
 @JsonbTypeSerializer({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Serializer.class)
 @JsonbTypeDeserializer({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Deserializer.class)
 {{/jsonb}}
-{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#gson}}
   {{#allowableValues}}{{#enumVars}}
   @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/modelEnum.mustache
@@ -23,7 +23,7 @@ import java.net.URI;
 @JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
 @JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
 {{/jsonb}}
-{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#allowableValues}}{{#enumVars}}
     {{#enumDescription}}
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelEnum.mustache
@@ -12,7 +12,7 @@ import com.google.gson.stream.JsonWriter;
  * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
  */
 @JsonAdapter({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
-{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#allowableValues}}{{#enumVars}}
     {{#enumDescription}}
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/modelInnerEnum.mustache
@@ -6,7 +6,7 @@
   @XmlType(name="{{datatypeWithEnum}}")
   @XmlEnum({{dataType}}.class)
 {{/withXml}}
-  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
     {{#allowableValues}}
       {{#enumVars}}
     {{#enumDescription}}

--- a/modules/openapi-generator/src/main/resources/Java/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/modelEnum.mustache
@@ -23,7 +23,7 @@ import java.net.URI;
 @JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
 @JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
 {{/jsonb}}
-{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#allowableValues}}{{#enumVars}}
     {{#enumDescription}}
   /**

--- a/modules/openapi-generator/src/main/resources/Java/modelInnerEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/modelInnerEnum.mustache
@@ -12,7 +12,7 @@
   @XmlType(name="{{datatypeWithEnum}}")
   @XmlEnum({{dataType}}.class)
 {{/withXml}}
-  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
     {{#allowableValues}}
       {{#enumVars}}
     {{#enumDescription}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
@@ -1,7 +1,7 @@
   /**
    * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}
    */
-  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}} {
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
     {{#gson}}
         {{#allowableValues}}
             {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
@@ -1,7 +1,7 @@
   /**
    * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}
    */
-  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}}{
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}} {
     {{#gson}}
         {{#allowableValues}}
             {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumClass.mustache
@@ -1,7 +1,7 @@
   /**
    * {{^description}}Gets or Sets {{{name}}}{{/description}}{{{description}}}
    */
-  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+  {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}}{
     {{#gson}}
         {{#allowableValues}}
             {{#enumVars}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 {{>additionalEnumTypeAnnotations}}
 {{>generatedAnnotation}}
-public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}}{
+public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}} {
   {{#gson}}
   {{#allowableValues}}{{#enumVars}}
   {{#enumDescription}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 {{>additionalEnumTypeAnnotations}}
 {{>generatedAnnotation}}
-public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}} {
+public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
   {{#gson}}
   {{#allowableValues}}{{#enumVars}}
   {{#enumDescription}}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/enumOuterClass.mustache
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  */
 {{>additionalEnumTypeAnnotations}}
 {{>generatedAnnotation}}
-public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}{{#vendorExtensions.x-implements}}{{#-first}} implements {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}} {{/vendorExtensions.x-implements}}{
   {{#gson}}
   {{#allowableValues}}{{#enumVars}}
   {{#enumDescription}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3365,4 +3365,17 @@ public class JavaClientCodegenTest {
                 "responseBody.isBlank()? null: memberVarObjectMapper.readValue(responseBody, new TypeReference<LocationData>() {})"
         );
     }
+
+    @Test
+    public void testEnumWithImplements() {
+        final Path output = newTempFolder();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/enum-implements.yaml");
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOutputDir(output.toString());
+
+        Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
+                .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("Type.java")).fileContains("Type implements org.openapitools.java.EnumInterface {");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5257,7 +5257,7 @@ public class SpringCodegenTest {
     public void testEnumWithImplements() {
         final Path output = newTempFolder();
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/enum-implements.yaml");
-        JavaClientCodegen codegen = new JavaClientCodegen();
+        SpringCodegen codegen = new SpringCodegen();
         codegen.setOutputDir(output.toString());
 
         Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5252,4 +5252,17 @@ public class SpringCodegenTest {
                                 " @Nullable List<String> nullableContainer)"
                 );
     }
+
+    @Test
+    public void testEnumWithImplements() {
+        final Path output = newTempFolder();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/enum-implements.yaml");
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOutputDir(output.toString());
+
+        Map<String, File> files = new DefaultGenerator().opts(new ClientOptInput().openAPI(openAPI).config(codegen))
+                .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("Type.java")).fileContains("Type implements org.openapitools.java.EnumInterface {");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/enum-implements.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum-implements.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+paths:
+  /ponies:
+    get:
+      summary: Returns all animals.
+      description: Optional extended description in Markdown.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pony'
+components:
+  schemas:
+    Pony:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/Type'
+    Type:
+      type: string
+      x-implements: org.openapitools.java.EnumInterface
+      enum:
+        - Earth
+        - Pegasi
+        - Unicorn

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumClass.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/EnumClass.java
@@ -29,7 +29,7 @@ import com.google.gson.stream.JsonWriter;
  * Gets or Sets EnumClass
  */
 @JsonAdapter(EnumClass.Adapter.class)
-public enum EnumClass {
+public enum EnumClass implements Parcelable {
   
   _ABC("_abc"),
   

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterEnum.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/model/OuterEnum.java
@@ -29,7 +29,7 @@ import com.google.gson.stream.JsonWriter;
  * Gets or Sets OuterEnum
  */
 @JsonAdapter(OuterEnum.Adapter.class)
-public enum OuterEnum {
+public enum OuterEnum implements Parcelable {
   
   PLACED("placed"),
   


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->

#20649

 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

Spring:
@cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)