### PR TITLE
[BUG] [ASCIIDOC] Asciidoc generator sets not defined example values as string value "null"

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AsciidocDocumentationCodegen.java
@@ -16,8 +16,10 @@
 
 package org.openapitools.codegen.languages;
 
+import io.swagger.v3.oas.models.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
+import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.*;
 
 import java.io.File;
@@ -324,6 +326,27 @@ public class AsciidocDocumentationCodegen extends DefaultCodegen implements Code
         } else {
             additionalProperties.put(flag, value);
         }
+    }
+
+    // override to avoid printing of string "null"
+    // when no example exists
+    @Override
+    public String toExampleValue(Schema schema) {
+        if (schema.getExample() != null) {
+            return schema.getExample().toString();
+        }
+        return null;
+    }
+
+    // Avoid additional escapes of \ -> \\, " -> \"
+    // in regular expressions that are
+    // introduced by the `escapeText` method.
+    // Note: We don't need this here since we want to print
+    // the plain regular expression
+    // Therefore, override  this method to skip `escapeText`.
+    @Override
+    public String toRegularExpression(String pattern) {
+        return addRegularExpressionDelimiter(pattern);
     }
 
     @Override


### PR DESCRIPTION
The Asciidoc generator writes for not defined example values of e.g. model attributes the string value "null" instead of leaving it empty. 

Furthermore, override the `toRegularExpression` method to avoid additional escapes of e.g. `\` ->` \\`, ` ` -> `\` in regular expressions by skipping calling the submethod `escapeText`.
Note: We don't need additonal escapes in regular expressions for the asciidoc generator since we want to print the plain regular expression as it is in a doc file.

This PR closes Issue https://github.com/OpenAPITools/openapi-generator/issues/17149.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@JkbLskw