### PR TITLE
[Rust] Fix enum variant name generation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -615,8 +615,9 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
                     for (CodegenProperty model : csOneOf) {
                         // Generate a valid name for the enum variant.
                         // Mainly needed for primitive types.
-                        String[] modelParts = model.dataType.replace("<", "Of").replace(">", "").split("::");
-                        model.datatypeWithEnum = camelize(modelParts[modelParts.length - 1]);
+
+                        model.datatypeWithEnum = camelize(model.dataType.replaceAll("(?:\\w+::)+(\\w+)", "$1")
+                                .replace("<", "Of").replace(">", ""));
 
                         // Primitive type is not properly set, this overrides it to guarantee adequate model generation.
                         if (!model.getDataType().matches(String.format(Locale.ROOT, ".*::%s", model.getDatatypeWithEnum()))) {

--- a/modules/openapi-generator/src/test/resources/3_0/rust-axum/rust-axum-oneof.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-axum/rust-axum-oneof.yaml
@@ -30,6 +30,7 @@ components:
         - "$ref": "#/components/schemas/Hello"
         - "$ref": "#/components/schemas/Greeting"
         - "$ref": "#/components/schemas/Goodbye"
+        - "$ref": "#/components/schemas/SomethingCompletelyDifferent"
       title: Message
     Hello:
       type: object
@@ -84,3 +85,9 @@ components:
       required:
         - op
         - d
+    SomethingCompletelyDifferent:
+      oneOf:
+      - items:
+          type: object
+        type: array
+      - type: object

--- a/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/models.rs
+++ b/samples/server/petstore/rust-axum/output/rust-axum-oneof/src/models.rs
@@ -932,6 +932,7 @@ pub enum Message {
     Hello(Box<models::Hello>),
     Greeting(Box<models::Greeting>),
     Goodbye(Box<models::Goodbye>),
+    SomethingCompletelyDifferent(Box<models::SomethingCompletelyDifferent>),
 }
 
 impl validator::Validate for Message {
@@ -940,6 +941,7 @@ impl validator::Validate for Message {
             Self::Hello(x) => x.validate(),
             Self::Greeting(x) => x.validate(),
             Self::Goodbye(x) => x.validate(),
+            Self::SomethingCompletelyDifferent(x) => x.validate(),
         }
     }
 }
@@ -953,6 +955,7 @@ impl serde::Serialize for Message {
             Self::Hello(x) => x.serialize(serializer),
             Self::Greeting(x) => x.serialize(serializer),
             Self::Goodbye(x) => x.serialize(serializer),
+            Self::SomethingCompletelyDifferent(x) => x.serialize(serializer),
         }
     }
 }
@@ -972,11 +975,55 @@ impl From<models::Goodbye> for Message {
         Self::Goodbye(Box::new(value))
     }
 }
+impl From<models::SomethingCompletelyDifferent> for Message {
+    fn from(value: models::SomethingCompletelyDifferent) -> Self {
+        Self::SomethingCompletelyDifferent(Box::new(value))
+    }
+}
 
 /// Converts Query Parameters representation (style=form, explode=false) to a Message value
 /// as specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde deserializer
 impl std::str::FromStr for Message {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(non_camel_case_types)]
+pub enum SomethingCompletelyDifferent {
+    VecOfObject(Box<Vec<crate::types::Object>>),
+    Object(Box<crate::types::Object>),
+}
+
+impl validator::Validate for SomethingCompletelyDifferent {
+    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+        match self {
+            Self::VecOfObject(_) => std::result::Result::Ok(()),
+            Self::Object(x) => x.validate(),
+        }
+    }
+}
+
+impl From<Vec<crate::types::Object>> for SomethingCompletelyDifferent {
+    fn from(value: Vec<crate::types::Object>) -> Self {
+        Self::VecOfObject(Box::new(value))
+    }
+}
+impl From<crate::types::Object> for SomethingCompletelyDifferent {
+    fn from(value: crate::types::Object) -> Self {
+        Self::Object(Box::new(value))
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a SomethingCompletelyDifferent value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for SomethingCompletelyDifferent {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {


### PR DESCRIPTION
Found out that `oneOf`'s enum variant names were not correctly generated and datatypes like `Vec<foo::bar::Baz>` would end up as `Baz` instead of `VecOfBaz` generating duplicates in cases like the test included.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
