### PR TITLE
Fix #20692 [typescript-angular] Support enumDescription / x-enum-descriptions

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
@@ -2,6 +2,11 @@
 export enum {{classname}} {
 {{#allowableValues}}
 {{#enumVars}}
+{{#enumDescription}}
+
+    /**
+     * {{.}}
+     */{{/enumDescription}}
     {{name}} = {{{value}}}{{^-last}},{{/-last}}
 {{/enumVars}}
 {{/allowableValues}}
@@ -13,6 +18,11 @@ export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last
 export const {{classname}} = {
 {{#allowableValues}}
 {{#enumVars}}
+{{#enumDescription}}
+
+    /**
+     * {{.}}
+     */{{/enumDescription}}
     {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
 {{/enumVars}}
 {{/allowableValues}}

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-angular/composed-schemas.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-angular/composed-schemas.yaml
@@ -34,6 +34,9 @@ components:
     DogBreed:
       type: string
       enum: [Dingo, Husky]
+      x-enum-descriptions:
+      - Canis lupus dingo
+      - Siberian Husky
 
     PetWithSimpleDiscriminator:
       type: object
@@ -104,6 +107,9 @@ components:
             inlineBreed:
               type: string
               enum: [ Dingo, Husky ]
+              x-enum-descriptions:
+              - Canis lupus dingo
+              - Siberian Husky
     CatComposed:
       allOf:
         - $ref: '#/components/schemas/PetWithoutDiscriminator'

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/model/dogBreed.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/model/dogBreed.ts
@@ -10,7 +10,15 @@
 
 
 export enum DogBreedModel {
+
+    /**
+     * Canis lupus dingo
+     */
     Dingo = 'Dingo',
+
+    /**
+     * Siberian Husky
+     */
     Husky = 'Husky'
 }
 

--- a/samples/client/others/typescript-angular/builds/composed-schemas/model/dogBreed.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/model/dogBreed.ts
@@ -10,7 +10,15 @@
 
 
 export enum DogBreedModel {
+
+    /**
+     * Canis lupus dingo
+     */
     Dingo = 'Dingo',
+
+    /**
+     * Siberian Husky
+     */
     Husky = 'Husky'
 }
 


### PR DESCRIPTION
Fixes #20692.

Adapted `typescript-angular/modelEnum.mustache` to respect `x-enum-descriptions` / `enumDescription`.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Mention technical committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
