### PR TITLE
fix(typescript-fetch): set prototype to fix instanceof not working

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -250,6 +250,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -257,6 +258,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -264,6 +266,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/validation-attributes/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -261,6 +261,7 @@ export class ResponseError extends Error {
     override name: "ResponseError" = "ResponseError";
     constructor(public response: Response, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, ResponseError.prototype);
     }
 }
 
@@ -268,6 +269,7 @@ export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
     constructor(public cause: Error, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, FetchError.prototype);
     }
 }
 
@@ -275,6 +277,7 @@ export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
     constructor(public field: string, msg?: string) {
         super(msg);
+        Object.setPrototypeOf(this, RequiredError.prototype);
     }
 }
 


### PR DESCRIPTION
Solves this issue: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work

```ts
try {
    // API call
} catch (error: unknown) {
    if (error instanceof FetchError) { // Currently this will never be true
        console.log(error.message);
    }
}
```

@TiFu  @taxpon @sebastianhaas  @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
