### PR TITLE
[Python] Add `ca_cert_data` parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -47,7 +47,8 @@ class RESTClientObject:
         self.maxsize = configuration.connection_pool_maxsize
 
         self.ssl_context = ssl.create_default_context(
-            cafile=configuration.ssl_ca_cert
+            cafile=configuration.ssl_ca_cert,
+            cadata=configuration.ca_cert_data,
         )
         if configuration.cert_file:
             self.ssl_context.load_cert_chain(

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -183,6 +183,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
+    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
+      certificate data in PEM (str) or DER (bytes) format.
 
 {{#hasAuthMethods}}
     :Example:
@@ -289,6 +291,7 @@ conf = {{{packageName}}}.Configuration(
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
+        ca_cert_data: Optional[str | bytes] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:
@@ -372,6 +375,10 @@ conf = {{{packageName}}}.Configuration(
         """
         self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
+        """
+        self.ca_cert_data = ca_cert_data
+        """Set this to verify the peer using PEM (str) or DER (bytes)
+           certificate data.
         """
         self.cert_file = None
         """client certificate file

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -10,7 +10,7 @@ from logging import FileHandler
 import multiprocessing
 {{/asyncio}}
 import sys
-from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict
+from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired, Self
 
 import urllib3
@@ -183,8 +183,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
-    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
-      certificate data in PEM (str) or DER (bytes) format.
+    :param ca_cert_data: verify the peer using concatenated CA certificate data
+      in PEM (str) or DER (bytes) format.
 
 {{#hasAuthMethods}}
     :Example:
@@ -284,14 +284,14 @@ conf = {{{packageName}}}.Configuration(
 {{#hasHttpSignatureMethods}}
         signing_info: Optional[HttpSigningConfiguration]=None,
 {{/hasHttpSignatureMethods}}
-        server_index: Optional[int]=None, 
+        server_index: Optional[int]=None,
         server_variables: Optional[ServerVariablesT]=None,
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
-        ca_cert_data: Optional[str | bytes] = None,
+        ca_cert_data: Optional[Union[str, bytes]] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -66,6 +66,7 @@ class RESTClientObject:
             "ca_certs": configuration.ssl_ca_cert,
             "cert_file": configuration.cert_file,
             "key_file": configuration.key_file,
+            "ca_cert_data": configuration.ca_cert_data,
         }
         if configuration.assert_hostname is not None:
             pool_args['assert_hostname'] = (

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -19,7 +19,7 @@ import logging
 from logging import FileHandler
 import multiprocessing
 import sys
-from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict
+from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired, Self
 
 import urllib3
@@ -163,8 +163,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
-    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
-      certificate data in PEM (str) or DER (bytes) format.
+    :param ca_cert_data: verify the peer using concatenated CA certificate data
+      in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -195,14 +195,14 @@ conf = openapi_client.Configuration(
         username: Optional[str]=None,
         password: Optional[str]=None,
         access_token: Optional[str]=None,
-        server_index: Optional[int]=None, 
+        server_index: Optional[int]=None,
         server_variables: Optional[ServerVariablesT]=None,
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
-        ca_cert_data: Optional[str | bytes] = None,
+        ca_cert_data: Optional[Union[str, bytes]] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -163,6 +163,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
+    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
+      certificate data in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -200,6 +202,7 @@ conf = openapi_client.Configuration(
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
+        ca_cert_data: Optional[str | bytes] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:
@@ -276,6 +279,10 @@ conf = openapi_client.Configuration(
         """
         self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
+        """
+        self.ca_cert_data = ca_cert_data
+        """Set this to verify the peer using PEM (str) or DER (bytes)
+           certificate data.
         """
         self.cert_file = None
         """client certificate file

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
@@ -77,6 +77,7 @@ class RESTClientObject:
             "ca_certs": configuration.ssl_ca_cert,
             "cert_file": configuration.cert_file,
             "key_file": configuration.key_file,
+            "ca_cert_data": configuration.ca_cert_data,
         }
         if configuration.assert_hostname is not None:
             pool_args['assert_hostname'] = (

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -19,7 +19,7 @@ import logging
 from logging import FileHandler
 import multiprocessing
 import sys
-from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict
+from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired, Self
 
 import urllib3
@@ -163,8 +163,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
-    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
-      certificate data in PEM (str) or DER (bytes) format.
+    :param ca_cert_data: verify the peer using concatenated CA certificate data
+      in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -195,14 +195,14 @@ conf = openapi_client.Configuration(
         username: Optional[str]=None,
         password: Optional[str]=None,
         access_token: Optional[str]=None,
-        server_index: Optional[int]=None, 
+        server_index: Optional[int]=None,
         server_variables: Optional[ServerVariablesT]=None,
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
-        ca_cert_data: Optional[str | bytes] = None,
+        ca_cert_data: Optional[Union[str, bytes]] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -163,6 +163,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
+    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
+      certificate data in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -200,6 +202,7 @@ conf = openapi_client.Configuration(
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
+        ca_cert_data: Optional[str | bytes] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:
@@ -276,6 +279,10 @@ conf = openapi_client.Configuration(
         """
         self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
+        """
+        self.ca_cert_data = ca_cert_data
+        """Set this to verify the peer using PEM (str) or DER (bytes)
+           certificate data.
         """
         self.cert_file = None
         """client certificate file

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -77,6 +77,7 @@ class RESTClientObject:
             "ca_certs": configuration.ssl_ca_cert,
             "cert_file": configuration.cert_file,
             "key_file": configuration.key_file,
+            "ca_cert_data": configuration.ca_cert_data,
         }
         if configuration.assert_hostname is not None:
             pool_args['assert_hostname'] = (

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -17,7 +17,7 @@ import http.client as httplib
 import logging
 from logging import FileHandler
 import sys
-from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict
+from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired, Self
 
 import urllib3
@@ -168,8 +168,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
-    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
-      certificate data in PEM (str) or DER (bytes) format.
+    :param ca_cert_data: verify the peer using concatenated CA certificate data
+      in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -259,14 +259,14 @@ conf = petstore_api.Configuration(
         password: Optional[str]=None,
         access_token: Optional[str]=None,
         signing_info: Optional[HttpSigningConfiguration]=None,
-        server_index: Optional[int]=None, 
+        server_index: Optional[int]=None,
         server_variables: Optional[ServerVariablesT]=None,
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
-        ca_cert_data: Optional[str | bytes] = None,
+        ca_cert_data: Optional[Union[str, bytes]] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -168,6 +168,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
+    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
+      certificate data in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -264,6 +266,7 @@ conf = petstore_api.Configuration(
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
+        ca_cert_data: Optional[str | bytes] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:
@@ -345,6 +348,10 @@ conf = petstore_api.Configuration(
         """
         self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
+        """
+        self.ca_cert_data = ca_cert_data
+        """Set this to verify the peer using PEM (str) or DER (bytes)
+           certificate data.
         """
         self.cert_file = None
         """client certificate file

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -57,7 +57,8 @@ class RESTClientObject:
         self.maxsize = configuration.connection_pool_maxsize
 
         self.ssl_context = ssl.create_default_context(
-            cafile=configuration.ssl_ca_cert
+            cafile=configuration.ssl_ca_cert,
+            cadata=configuration.ca_cert_data,
         )
         if configuration.cert_file:
             self.ssl_context.load_cert_chain(

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -18,7 +18,7 @@ import logging
 from logging import FileHandler
 import multiprocessing
 import sys
-from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict
+from typing import Any, ClassVar, Dict, List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired, Self
 
 import urllib3
@@ -169,8 +169,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
-    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
-      certificate data in PEM (str) or DER (bytes) format.
+    :param ca_cert_data: verify the peer using concatenated CA certificate data
+      in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -260,14 +260,14 @@ conf = petstore_api.Configuration(
         password: Optional[str]=None,
         access_token: Optional[str]=None,
         signing_info: Optional[HttpSigningConfiguration]=None,
-        server_index: Optional[int]=None, 
+        server_index: Optional[int]=None,
         server_variables: Optional[ServerVariablesT]=None,
         server_operation_index: Optional[Dict[int, int]]=None,
         server_operation_variables: Optional[Dict[int, ServerVariablesT]]=None,
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
-        ca_cert_data: Optional[str | bytes] = None,
+        ca_cert_data: Optional[Union[str, bytes]] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -169,6 +169,8 @@ class Configuration:
     :param ssl_ca_cert: str - the path to a file of concatenated CA certificates
       in PEM format.
     :param retries: Number of retries for API requests.
+    :param ca_cert_data: str|bytes - verify the peer using concatenated CA
+      certificate data in PEM (str) or DER (bytes) format.
 
     :Example:
 
@@ -265,6 +267,7 @@ conf = petstore_api.Configuration(
         ignore_operation_servers: bool=False,
         ssl_ca_cert: Optional[str]=None,
         retries: Optional[int] = None,
+        ca_cert_data: Optional[str | bytes] = None,
         *,
         debug: Optional[bool] = None,
     ) -> None:
@@ -346,6 +349,10 @@ conf = petstore_api.Configuration(
         """
         self.ssl_ca_cert = ssl_ca_cert
         """Set this to customize the certificate file to verify the peer.
+        """
+        self.ca_cert_data = ca_cert_data
+        """Set this to verify the peer using PEM (str) or DER (bytes)
+           certificate data.
         """
         self.cert_file = None
         """client certificate file

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -76,6 +76,7 @@ class RESTClientObject:
             "ca_certs": configuration.ssl_ca_cert,
             "cert_file": configuration.cert_file,
             "key_file": configuration.key_file,
+            "ca_cert_data": configuration.ca_cert_data,
         }
         if configuration.assert_hostname is not None:
             pool_args['assert_hostname'] = (


### PR DESCRIPTION
The `ca_cert_data` parameter lets a client validate a server's CA certificate chain using a variable/constant containing PEM (`str`) or DER (`bytes`) data, rather than needing to reference a file on disk.

Naming is based on what `urllib3` calls this parameter.

I've applied a similar patch to some locally generated bindings for `asyncio` and `urllib3`, and it's working there.

@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


