### PR TITLE
[Python] Fix mustache tag syntax in github worklow

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
+++ b/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
@@ -29,4 +29,4 @@ jobs:
           pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest --cov={{packageName}}
+          pytest --cov=<%packageName%>

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/.github/workflows/python.yml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/.github/workflows/python.yml
@@ -28,4 +28,4 @@ jobs:
           pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest --cov={{packageName}}
+          pytest --cov=openapi_client

--- a/samples/client/echo_api/python/.github/workflows/python.yml
+++ b/samples/client/echo_api/python/.github/workflows/python.yml
@@ -28,4 +28,4 @@ jobs:
           pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest --cov={{packageName}}
+          pytest --cov=openapi_client

--- a/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
@@ -28,4 +28,4 @@ jobs:
           pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest --cov={{packageName}}
+          pytest --cov=petstore_api

--- a/samples/openapi3/client/petstore/python/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python/.github/workflows/python.yml
@@ -28,4 +28,4 @@ jobs:
           pip install -r test-requirements.txt
       - name: Test with pytest
         run: |
-          pytest --cov={{packageName}}
+          pytest --cov=petstore_api


### PR DESCRIPTION
This fixes the github workflow file template for the Python client.
In order to use the `{{ }}` Github syntax more easily the mustache markers are changed to `<% %>` at the beginning of the file, so we have to use those instead.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)
