### PR TITLE
[rust] Fixed compiler errors for decimal types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -206,6 +206,8 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
         typeMapping.put("date", "string");
         typeMapping.put("DateTime", "String");
         typeMapping.put("password", "String");
+        typeMapping.put("decimal", "String");
+
         // TODO(bcourtine): review file mapping.
         // I tried to map as "std::io::File", but Reqwest multipart file requires a "AsRef<Path>" param.
         // Getting a file from a Path is simple, but the opposite is difficult. So I map as "std::path::Path".

--- a/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
@@ -871,6 +871,7 @@ components:
         - boolean
         - uuid
         - bytes
+        - decimal
       properties:
         int32:
           type: integer
@@ -894,6 +895,9 @@ components:
         bytes:
           type: string
           format: byte
+        decimal:
+          type: string
+          format: number
     Return:
       description: Test using keywords
       type: object

--- a/samples/client/petstore/rust/hyper/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/hyper/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/hyper/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/hyper0x/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/hyper0x/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/hyper0x/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/hyper0x/petstore/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest-trait/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-async/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/FooTypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/FooTypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/models/foo_type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/models/foo_type_testing.rs
@@ -34,11 +34,13 @@ pub struct FooTypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl FooTypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> FooTypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> FooTypeTesting {
         FooTypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl FooTypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/type_testing.rs
@@ -34,11 +34,13 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde(rename = "decimal")]
+    pub decimal: String,
 }
 
 impl TypeTesting {
     /// Test handling of different field data types
-    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>) -> TypeTesting {
+    pub fn new(int32: i32, int64: i64, float: f32, double: f64, string: String, boolean: bool, uuid: uuid::Uuid, bytes: Vec<u8>, decimal: String) -> TypeTesting {
         TypeTesting {
             int32,
             int64,
@@ -48,6 +50,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            decimal,
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore/tests/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/tests/type_testing.rs
@@ -13,7 +13,8 @@ fn test_types() {
         string: String::from("something"),
         boolean: true,
         uuid: Uuid::new_v4(),
-        bytes: vec![1,2,3,4]
+        bytes: vec![1, 2, 3, 4],
+        decimal: String::from("foo"),
     };
     assert_eq!(type_of(tt.int32), "i32");
     assert_eq!(type_of(tt.int64), "i64");
@@ -22,6 +23,7 @@ fn test_types() {
     assert_eq!(type_of(tt.string), "alloc::string::String");
     assert_eq!(type_of(tt.boolean), "bool");
     assert_eq!(type_of(tt.uuid), "uuid::Uuid");
+    assert_eq!(type_of(tt.decimal), "alloc::string::String");
 }
 
 fn type_of<T>(_: T) -> &'static str {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixed compiler errors for `type: string, format: number` (aka decimal) types.
See https://github.com/OpenAPITools/openapi-generator/issues/20626 for more details

In the issue I mentioned some potential libraries for to represent decimal types.
However after some thought, I think defaulting to `String` makes sense. 
The user can simply parse the string into their desired BigDecimal datatype and we can add a config flag for a specific library in the future if there is demand for it.

<details><summary>PR checklist</summary>
<!-- Please check the completed items below -->
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
</details> 

cc: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro
