### PR TITLE
Add openapi-normalizer rule to set tags to vendor extension

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -573,6 +573,13 @@ Example:
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_TAGS_TO_OPERATIONID=true
 ```
 
+- `SET_TAGS_TO_VENDOR_EXTENSION`:  when set to a string value, tags will be set to the value of the provided vendor extension
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableSetTagsToVendorExtension_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_TAGS_TO_VENDOR_EXTENSION=x-tags
+```
+
 - `ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE`: when set to true, auto fix integer with maximum value 4294967295 (2^32-1) or long with 18446744073709551615 (2^64-1) by adding x-unsigned to the schema
 
 Example:

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -91,6 +91,10 @@ public class OpenAPINormalizer {
     final String SET_TAGS_TO_OPERATIONID = "SET_TAGS_TO_OPERATIONID";
     String setTagsToOperationId;
 
+    // when set to a string value, tags will be set to the value of the provided vendor extension
+    final String SET_TAGS_TO_VENDOR_EXTENSION = "SET_TAGS_TO_VENDOR_EXTENSION";
+    String setTagsToVendorExtension;
+
     // when set to true, tags in all operations will be set to operationId or "default" if operationId
     // is empty
     final String FIX_DUPLICATED_OPERATIONID = "FIX_DUPLICATED_OPERATIONID";
@@ -158,6 +162,7 @@ public class OpenAPINormalizer {
         ruleNames.add(KEEP_ONLY_FIRST_TAG_IN_OPERATION);
         ruleNames.add(SET_TAGS_FOR_ALL_OPERATIONS);
         ruleNames.add(SET_TAGS_TO_OPERATIONID);
+        ruleNames.add(SET_TAGS_TO_VENDOR_EXTENSION);
         ruleNames.add(FIX_DUPLICATED_OPERATIONID);
         ruleNames.add(ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE);
         ruleNames.add(REFACTOR_ALLOF_WITH_PROPERTIES_ONLY);
@@ -222,6 +227,11 @@ public class OpenAPINormalizer {
         setTagsForAllOperations = inputRules.get(SET_TAGS_FOR_ALL_OPERATIONS);
         if (setTagsForAllOperations != null) {
             rules.put(SET_TAGS_FOR_ALL_OPERATIONS, true);
+        }
+
+        setTagsToVendorExtension = inputRules.get(SET_TAGS_TO_VENDOR_EXTENSION);
+        if (setTagsToVendorExtension != null) {
+            rules.put(SET_TAGS_TO_VENDOR_EXTENSION, true);
         }
 
         if (inputRules.get(FILTER) != null) {
@@ -374,6 +384,8 @@ public class OpenAPINormalizer {
         processSetTagsForAllOperations(operation);
 
         processSetTagsToOperationId(operation);
+
+        processSetTagsToVendorExtension(operation);
 
         processFixDuplicatedOperationId(operation);
     }
@@ -885,8 +897,7 @@ public class OpenAPINormalizer {
     }
 
     /**
-     * Keep only first tag in the operation if the operation has more than
-     * one tag.
+     * Remove/hide the x-internal in operations and model.
      *
      * @param operation Operation
      */
@@ -952,6 +963,34 @@ public class OpenAPINormalizer {
             operation.addTagsItem(operation.getOperationId());
         } else { // default to "default" if operationId is empty
             operation.addTagsItem("default");
+        }
+    }
+
+    /**
+     * Set the tag name to the value of the provided vendor extension
+     *
+     * @param operation Operation
+     */
+    private void processSetTagsToVendorExtension(Operation operation) {
+        if (StringUtils.isEmpty(setTagsToVendorExtension)) {
+            return;
+        }
+
+        if (operation.getExtensions() == null) {
+            return;
+        }
+
+        if (operation.getExtensions().containsKey(setTagsToVendorExtension)) {
+            operation.setTags(null);
+            Object argObj = operation.getExtensions().get(setTagsToVendorExtension);
+            if (argObj instanceof List) {
+                List<String> tags = (List<String>) argObj;
+                for (String tag : tags) {
+                    operation.addTagsItem(tag);
+                }
+            } else {
+                operation.addTagsItem(String.valueOf(argObj));
+            }
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -295,6 +295,21 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
+    public void testOpenAPINormalizerSetTagsToVendorExtension() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/enableSetTagsToVendorExtension_test.yaml");
+
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().size(), 2);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getExtensions().size(), 1);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SET_TAGS_TO_VENDOR_EXTENSION", "x-tags");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().size(), 1);
+    }
+
+    @Test
     public void testAddUnsignedToIntegerWithInvalidMaxValue() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml");
 

--- a/modules/openapi-generator/src/test/resources/3_0/enableSetTagsToVendorExtension_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enableSetTagsToVendorExtension_test.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /person/display/{personId}:
+    get:
+      x-tags:
+        - display
+      tags:
+        - person
+        - basic
+      parameters:
+        - name: personId
+          in: path
+          required: true
+          description: The id of the person to retrieve
+          schema:
+            type: string
+      operationId: list
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+components:
+  schemas:
+    Person:
+      description: person
+      type: object
+      properties:
+        $_type:
+          type: string
+        lastName:
+          type: string
+        firstName:
+          type: string


### PR DESCRIPTION
- Add openapi-normalizer rule to set tags to vendor extension
- add tests
- to close https://github.com/OpenAPITools/openapi-generator/issues/20709

e.g.

`java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/enableSetTagsToVendorExtension_test.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_TAGS_TO_VENDOR_EXTENSION=x-tags`
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
