### PR TITLE
[kotlin][client] Explode query param properly

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-okhttp/api.mustache
@@ -208,17 +208,44 @@ import {{packageName}}.infrastructure.toMultiValue
                 {{#queryParams}}
                 {{^required}}
                 if ({{{paramName}}} != null) {
+                    {{#isModel}}
+                    {{#vars}}
+                    if ({{{paramName}}}.{{name}} != null) {
+                        put("{{#isDeepObject}}{{{paramName}}}[{{/isDeepObject}}{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}{{#isDeepObject}}]{{/isDeepObject}}", {{#isContainer}}toMultiValue({{{paramName}}}.{{name}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}.{{name}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}.{{name}}){{/isDate}}{{#isEnum}}{{#isString}}{{{paramName}}}.{{name}}.value{{/isString}}{{^isString}}{{{paramName}}}.{{name}}.toString(){{/isString}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.{{name}}.toString(){{/isDate}}{{/isDateTime}}{{/isEnum}}){{/isContainer}})
+                    }
+                    {{/vars}}
+                    {{/isModel}}
+                    {{^isModel}}
                     put("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}){{/isDate}}{{#isEnum}}{{#isString}}{{{paramName}}}.value{{/isString}}{{^isString}}{{{paramName}}}.toString(){{/isString}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}{{/isEnum}}){{/isContainer}})
+                    {{/isModel}}
                 }
                 {{/required}}
                 {{#required}}
                 {{#isNullable}}
                 if ({{{paramName}}} != null) {
+                    {{#isModel}}
+                    {{#vars}}
+                    if ({{{paramName}}}.{{name}} != null) {
+                        put("{{#isDeepObject}}{{{paramName}}}[{{/isDeepObject}}{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}{{#isDeepObject}}]{{/isDeepObject}}", {{#isContainer}}toMultiValue({{{paramName}}}.{{name}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}.{{name}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}.{{name}}){{/isDate}}{{#isEnum}}{{#isString}}{{{paramName}}}.{{name}}.value{{/isString}}{{^isString}}{{{paramName}}}.{{name}}.toString(){{/isString}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.{{name}}.toString(){{/isDate}}{{/isDateTime}}{{/isEnum}}){{/isContainer}})
+                    }
+                    {{/vars}}
+                    {{/isModel}}
+                    {{^isModel}}
                     put("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}){{/isDate}}{{#isEnum}}{{#isString}}{{{paramName}}}.value{{/isString}}{{^isString}}{{{paramName}}}.toString(){{/isString}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}{{/isEnum}}){{/isContainer}})
+                    {{/isModel}}
                 }
                 {{/isNullable}}
                 {{^isNullable}}
+                {{#isModel}}
+                {{#vars}}
+                if ({{{paramName}}}.{{name}} != null) {
+                    put("{{#isDeepObject}}{{{paramName}}}[{{/isDeepObject}}{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}{{#isDeepObject}}]{{/isDeepObject}}", {{#isContainer}}toMultiValue({{{paramName}}}.{{name}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}.{{name}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}.{{name}}){{/isDate}}{{#isEnum}}{{#isString}}{{{paramName}}}.{{name}}.value{{/isString}}{{^isString}}{{{paramName}}}.{{name}}.toString(){{/isString}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.{{name}}.toString(){{/isDate}}{{/isDateTime}}{{/isEnum}}){{/isContainer}})
+                }
+                {{/vars}}
+                {{/isModel}}
+                {{^isModel}}
                 put("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}", {{#isContainer}}toMultiValue({{{paramName}}}.toList(), "{{collectionFormat}}"){{/isContainer}}{{^isContainer}}listOf({{#isDateTime}}parseDateToQueryString({{{paramName}}}){{/isDateTime}}{{#isDate}}parseDateToQueryString({{{paramName}}}){{/isDate}}{{#isEnum}}{{#isString}}{{{paramName}}}.value{{/isString}}{{^isString}}{{{paramName}}}.toString(){{/isString}}{{/isEnum}}{{^isEnum}}{{^isDateTime}}{{^isDate}}{{{paramName}}}.toString(){{/isDate}}{{/isDateTime}}{{/isEnum}}){{/isContainer}})
+                {{/isModel}}
                 {{/isNullable}}
                 {{/required}}
                 {{/queryParams}}

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
@@ -391,7 +391,24 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
             .apply {
                 if (queryObject != null) {
-                    put("query_object", listOf(queryObject.toString()))
+                    if (queryObject.id != null) {
+                        put("queryObject[id]", listOf(queryObject.id.toString()))
+                    }
+                    if (queryObject.name != null) {
+                        put("queryObject[name]", listOf(queryObject.name.toString()))
+                    }
+                    if (queryObject.category != null) {
+                        put("queryObject[category]", listOf(queryObject.category.toString()))
+                    }
+                    if (queryObject.photoUrls != null) {
+                        put("queryObject[photoUrls]", toMultiValue(queryObject.photoUrls.toList(), ""))
+                    }
+                    if (queryObject.tags != null) {
+                        put("queryObject[tags]", toMultiValue(queryObject.tags.toList(), ""))
+                    }
+                    if (queryObject.status != null) {
+                        put("queryObject[status]", listOf(queryObject.status.value))
+                    }
                 }
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
@@ -469,7 +486,9 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
             .apply {
                 if (queryObject != null) {
-                    put("query_object", listOf(queryObject.toString()))
+                    if (queryObject.propertyValues != null) {
+                        put("values", toMultiValue(queryObject.propertyValues.toList(), ""))
+                    }
                 }
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
@@ -547,7 +566,24 @@ class QueryApi(basePath: kotlin.String = defaultBasePath, client: Call.Factory =
         val localVariableQuery: MultiValueMap = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
             .apply {
                 if (queryObject != null) {
-                    put("query_object", listOf(queryObject.toString()))
+                    if (queryObject.id != null) {
+                        put("id", listOf(queryObject.id.toString()))
+                    }
+                    if (queryObject.name != null) {
+                        put("name", listOf(queryObject.name.toString()))
+                    }
+                    if (queryObject.category != null) {
+                        put("category", listOf(queryObject.category.toString()))
+                    }
+                    if (queryObject.photoUrls != null) {
+                        put("photoUrls", toMultiValue(queryObject.photoUrls.toList(), ""))
+                    }
+                    if (queryObject.tags != null) {
+                        put("tags", toMultiValue(queryObject.tags.toList(), ""))
+                    }
+                    if (queryObject.status != null) {
+                        put("status", listOf(queryObject.status.value))
+                    }
                 }
             }
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()


### PR DESCRIPTION
### Problem
It's not possible to use request objects in the API (e.g. `findItems(SearchRequest(name, status, fromDate, ...))`). One more example is a pagination parameter, something like `Page(size,offset)`. I'd like to use a model in the API but it's not possible at the moment.

Kotlin Client generator is not exploding a query object properly. It uses the object `toString()` method, so API request doesn't work. See [OpenAPI Parameter Serialization](https://swagger.io/docs/specification/v3_0/serialization/#query-parameters).

Used `isModel`, `isDeepObject`, `vars` template variables to fill `localVariableQuery` with the fields of the query object.

It should work fine for objects with primitive, enum, date props. The behavior for nested objects and arrays is undefined (And it is mentioned in [the doc](https://swagger.io/docs/specification/v3_0/serialization/#query-parameters))

The generated `QueryApi.kt` sample from the echo-api shows the expected query parameters.

To close https://github.com/OpenAPITools/openapi-generator/issues/20715

CC: @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l

<details>
<summary>PR checklist</summary>
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
</details>