### PR TITLE
[rust] Fixed allOf with only one model

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7196,7 +7196,7 @@ public class DefaultCodegen implements CodegenConfig {
         Schema original = null;
         // check if it's allOf (only 1 sub schema) with or without default/nullable/etc set in the top level
         if (ModelUtils.isAllOf(schema) && schema.getAllOf().size() == 1 &&
-                ModelUtils.getType(schema) == null) {
+                (ModelUtils.getType(schema) == null || "object".equals(ModelUtils.getType(schema)))) {
             if (schema.getAllOf().get(0) instanceof Schema) {
                 original = schema;
                 schema = (Schema) schema.getAllOf().get(0);
@@ -7849,7 +7849,7 @@ public class DefaultCodegen implements CodegenConfig {
         Schema original = null;
         // check if it's allOf (only 1 sub schema) with or without default/nullable/etc set in the top level
         if (ModelUtils.isAllOf(schema) && schema.getAllOf().size() == 1 &&
-                ModelUtils.getType(schema) == null) {
+                (ModelUtils.getType(schema) == null || "object".equals(ModelUtils.getType(schema)))) {
             if (schema.getAllOf().get(0) instanceof Schema) {
                 original = schema;
                 schema = (Schema) schema.getAllOf().get(0);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -3990,11 +3990,6 @@ public class DefaultCodegenTest {
         CodegenOperation co;
         CodegenParameter cp;
 
-        path = "/ComposedObject";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
-        cp = co.bodyParam;
-        assertTrue(cp.getIsMap());
-
         path = "/ComposedNumber";
         co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;

--- a/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
@@ -676,6 +676,26 @@ paths:
                     student: '#/components/schemas/Person'
                     teacher: '#/components/schemas/Person'
                     car: '#/components/schemas/Vehicle'
+  '/tests/allOfWithOneModel':
+    get:
+      tags:
+        - testing
+      summary: 'Test for allOf with a single option. (One of the issues in #20500)'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/Person'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: string
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'

--- a/samples/client/petstore/rust/hyper/petstore/README.md
+++ b/samples/client/petstore/rust/hyper/petstore/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **Get** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **Get** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **Post** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **Get** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **Get** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **Get** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **Get** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/hyper/petstore/docs/TestingApi.md
+++ b/samples/client/petstore/rust/hyper/petstore/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **Get** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **Get** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **Get** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **Get** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/hyper/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/apis/testing_api.rs
@@ -37,6 +37,7 @@ impl<C: Connect> TestingApiClient<C>
 }
 
 pub trait TestingApi: Send + Sync {
+    fn tests_all_of_with_one_model_get(&self, person: models::Person) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send>>;
     fn tests_discriminator_duplicate_enums_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TestsDiscriminatorDuplicateEnumsGet200Response, Error>> + Send>>;
     fn tests_file_response_get(&self, ) -> Pin<Box<dyn Future<Output = Result<std::path::PathBuf, Error>> + Send>>;
     fn tests_type_testing_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TypeTesting, Error>> + Send>>;
@@ -44,6 +45,15 @@ pub trait TestingApi: Send + Sync {
 
 impl<C: Connect>TestingApi for TestingApiClient<C>
     where C: Clone + std::marker::Send + Sync {
+    #[allow(unused_mut)]
+    fn tests_all_of_with_one_model_get(&self, person: models::Person) -> Pin<Box<dyn Future<Output = Result<String, Error>> + Send>> {
+        let mut req = __internal_request::Request::new(hyper::Method::GET, "/tests/allOfWithOneModel".to_string())
+        ;
+        req = req.with_body_param(person);
+
+        req.execute(self.configuration.borrow())
+    }
+
     #[allow(unused_mut)]
     fn tests_discriminator_duplicate_enums_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TestsDiscriminatorDuplicateEnumsGet200Response, Error>> + Send>> {
         let mut req = __internal_request::Request::new(hyper::Method::GET, "/tests/discriminatorDuplicateEnums".to_string())

--- a/samples/client/petstore/rust/hyper0x/petstore/README.md
+++ b/samples/client/petstore/rust/hyper0x/petstore/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/hyper0x/petstore/docs/TestingApi.md
+++ b/samples/client/petstore/rust/hyper0x/petstore/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/hyper0x/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/hyper0x/petstore/src/apis/testing_api.rs
@@ -36,6 +36,7 @@ impl<C: hyper::client::connect::Connect> TestingApiClient<C>
 }
 
 pub trait TestingApi {
+    fn tests_all_of_with_one_model_get(&self, person: models::Person) -> Pin<Box<dyn Future<Output = Result<String, Error>>>>;
     fn tests_discriminator_duplicate_enums_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TestsDiscriminatorDuplicateEnumsGet200Response, Error>>>>;
     fn tests_file_response_get(&self, ) -> Pin<Box<dyn Future<Output = Result<std::path::PathBuf, Error>>>>;
     fn tests_type_testing_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TypeTesting, Error>>>>;
@@ -43,6 +44,15 @@ pub trait TestingApi {
 
 impl<C: hyper::client::connect::Connect>TestingApi for TestingApiClient<C>
     where C: Clone + std::marker::Send + Sync {
+    #[allow(unused_mut)]
+    fn tests_all_of_with_one_model_get(&self, person: models::Person) -> Pin<Box<dyn Future<Output = Result<String, Error>>>> {
+        let mut req = __internal_request::Request::new(hyper::Method::GET, "/tests/allOfWithOneModel".to_string())
+        ;
+        req = req.with_body_param(person);
+
+        req.execute(self.configuration.borrow())
+    }
+
     #[allow(unused_mut)]
     fn tests_discriminator_duplicate_enums_get(&self, ) -> Pin<Box<dyn Future<Output = Result<models::TestsDiscriminatorDuplicateEnumsGet200Response, Error>>>> {
         let mut req = __internal_request::Request::new(hyper::Method::GET, "/tests/discriminatorDuplicateEnums".to_string())

--- a/samples/client/petstore/rust/reqwest-trait/petstore/README.md
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest-trait/petstore/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/testing_api.rs
@@ -14,6 +14,20 @@ use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
 
+/// struct for passing parameters to the method [`tests_all_of_with_one_model_get`]
+#[derive(Clone, Debug)]
+pub struct TestsAllOfWithOneModelGetParams {
+    pub person: models::Person
+}
+
+
+/// struct for typed successes of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetSuccess {
+    Status200(String),
+    UnknownValue(serde_json::Value),
+}
 
 /// struct for typed successes of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +53,13 @@ pub enum TestsTypeTestingGetSuccess {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetError {
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -60,6 +81,32 @@ pub enum TestsTypeTestingGetError {
     UnknownValue(serde_json::Value),
 }
 
+
+pub async fn tests_all_of_with_one_model_get(configuration: &configuration::Configuration, params: TestsAllOfWithOneModelGetParams) -> Result<ResponseContent<TestsAllOfWithOneModelGetSuccess>, Error<TestsAllOfWithOneModelGetError>> {
+
+    let uri_str = format!("{}/tests/allOfWithOneModel", configuration.base_path);
+    let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
+
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    req_builder = req_builder.json(&params.person);
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req).await?;
+
+    let status = resp.status();
+
+    if !status.is_client_error() && !status.is_server_error() {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetSuccess> = serde_json::from_str(&content).ok();
+        Ok(ResponseContent { status, content, entity })
+    } else {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetError> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
 
 pub async fn tests_discriminator_duplicate_enums_get(configuration: &configuration::Configuration) -> Result<ResponseContent<TestsDiscriminatorDuplicateEnumsGetSuccess>, Error<TestsDiscriminatorDuplicateEnumsGetError>> {
 

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/testing_api.rs
@@ -14,6 +14,20 @@ use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
 
+/// struct for passing parameters to the method [`tests_all_of_with_one_model_get`]
+#[derive(Clone, Debug)]
+pub struct TestsAllOfWithOneModelGetParams {
+    pub person: models::Person
+}
+
+
+/// struct for typed successes of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetSuccess {
+    Status200(String),
+    UnknownValue(serde_json::Value),
+}
 
 /// struct for typed successes of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +53,13 @@ pub enum TestsTypeTestingGetSuccess {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetError {
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -60,6 +81,32 @@ pub enum TestsTypeTestingGetError {
     UnknownValue(serde_json::Value),
 }
 
+
+pub async fn tests_all_of_with_one_model_get(configuration: &configuration::Configuration, params: TestsAllOfWithOneModelGetParams) -> Result<ResponseContent<TestsAllOfWithOneModelGetSuccess>, Error<TestsAllOfWithOneModelGetError>> {
+
+    let uri_str = format!("{}/tests/allOfWithOneModel", configuration.base_path);
+    let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
+
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    req_builder = req_builder.json(&params.person);
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req).await?;
+
+    let status = resp.status();
+
+    if !status.is_client_error() && !status.is_server_error() {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetSuccess> = serde_json::from_str(&content).ok();
+        Ok(ResponseContent { status, content, entity })
+    } else {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetError> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
 
 pub async fn tests_discriminator_duplicate_enums_get(configuration: &configuration::Configuration) -> Result<ResponseContent<TestsDiscriminatorDuplicateEnumsGetSuccess>, Error<TestsDiscriminatorDuplicateEnumsGetError>> {
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore-async/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/testing_api.rs
@@ -14,6 +14,20 @@ use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
 
+/// struct for passing parameters to the method [`tests_all_of_with_one_model_get`]
+#[derive(Clone, Debug)]
+pub struct TestsAllOfWithOneModelGetParams {
+    pub person: models::Person
+}
+
+
+/// struct for typed successes of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetSuccess {
+    Status200(String),
+    UnknownValue(serde_json::Value),
+}
 
 /// struct for typed successes of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +53,13 @@ pub enum TestsTypeTestingGetSuccess {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetError {
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -60,6 +81,32 @@ pub enum TestsTypeTestingGetError {
     UnknownValue(serde_json::Value),
 }
 
+
+pub async fn tests_all_of_with_one_model_get(configuration: &configuration::Configuration, params: TestsAllOfWithOneModelGetParams) -> Result<ResponseContent<TestsAllOfWithOneModelGetSuccess>, Error<TestsAllOfWithOneModelGetError>> {
+
+    let uri_str = format!("{}/tests/allOfWithOneModel", configuration.base_path);
+    let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
+
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    req_builder = req_builder.json(&params.person);
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req).await?;
+
+    let status = resp.status();
+
+    if !status.is_client_error() && !status.is_server_error() {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetSuccess> = serde_json::from_str(&content).ok();
+        Ok(ResponseContent { status, content, entity })
+    } else {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetError> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
 
 pub async fn tests_discriminator_duplicate_enums_get(configuration: &configuration::Configuration) -> Result<ResponseContent<TestsDiscriminatorDuplicateEnumsGetSuccess>, Error<TestsDiscriminatorDuplicateEnumsGetError>> {
 

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/testing_api.rs
@@ -14,6 +14,20 @@ use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
 
+/// struct for passing parameters to the method [`tests_all_of_with_one_model_get`]
+#[derive(Clone, Debug)]
+pub struct TestsAllOfWithOneModelGetParams {
+    pub person: models::Person
+}
+
+
+/// struct for typed successes of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetSuccess {
+    Status200(String),
+    UnknownValue(serde_json::Value),
+}
 
 /// struct for typed successes of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +53,13 @@ pub enum TestsTypeTestingGetSuccess {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetError {
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -60,6 +81,32 @@ pub enum TestsTypeTestingGetError {
     UnknownValue(serde_json::Value),
 }
 
+
+pub async fn tests_all_of_with_one_model_get(configuration: &configuration::Configuration, params: TestsAllOfWithOneModelGetParams) -> Result<ResponseContent<TestsAllOfWithOneModelGetSuccess>, Error<TestsAllOfWithOneModelGetError>> {
+
+    let uri_str = format!("{}/tests/allOfWithOneModel", configuration.base_path);
+    let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
+
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    req_builder = req_builder.json(&params.person);
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req).await?;
+
+    let status = resp.status();
+
+    if !status.is_client_error() && !status.is_server_error() {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetSuccess> = serde_json::from_str(&content).ok();
+        Ok(ResponseContent { status, content, entity })
+    } else {
+        let content = resp.text().await?;
+        let entity: Option<TestsAllOfWithOneModelGetError> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
 
 pub async fn tests_discriminator_duplicate_enums_get(configuration: &configuration::Configuration) -> Result<ResponseContent<TestsDiscriminatorDuplicateEnumsGetSuccess>, Error<TestsDiscriminatorDuplicateEnumsGetError>> {
 

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/testing_api.rs
@@ -15,6 +15,13 @@ use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
 
 
+/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetError {
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -36,6 +43,43 @@ pub enum TestsTypeTestingGetError {
     UnknownValue(serde_json::Value),
 }
 
+
+pub fn tests_all_of_with_one_model_get(configuration: &configuration::Configuration, person: models::Person) -> Result<String, Error<TestsAllOfWithOneModelGetError>> {
+    // add a prefix to parameters to efficiently prevent name collisions
+    let p_person = person;
+
+    let uri_str = format!("{}/tests/allOfWithOneModel", configuration.base_path);
+    let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
+
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    req_builder = req_builder.json(&p_person);
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req)?;
+
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
+
+    if !status.is_client_error() && !status.is_server_error() {
+        let content = resp.text()?;
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `String`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `String`")))),
+        }
+    } else {
+        let content = resp.text()?;
+        let entity: Option<TestsAllOfWithOneModelGetError> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
 
 pub fn tests_discriminator_duplicate_enums_get(configuration: &configuration::Configuration, ) -> Result<models::TestsDiscriminatorDuplicateEnumsGet200Response, Error<TestsDiscriminatorDuplicateEnumsGetError>> {
 

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(foo_person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**foo_person** | [**FooPerson**](FooPerson.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore/README.md
+++ b/samples/client/petstore/rust/reqwest/petstore/README.md
@@ -39,6 +39,7 @@ Class | Method | HTTP request | Description
 *StoreApi* | [**get_inventory**](docs/StoreApi.md#get_inventory) | **GET** /store/inventory | Returns pet inventories by status
 *StoreApi* | [**get_order_by_id**](docs/StoreApi.md#get_order_by_id) | **GET** /store/order/{orderId} | Find purchase order by ID
 *StoreApi* | [**place_order**](docs/StoreApi.md#place_order) | **POST** /store/order | Place an order for a pet
+*TestingApi* | [**tests_all_of_with_one_model_get**](docs/TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 *TestingApi* | [**tests_discriminator_duplicate_enums_get**](docs/TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 *TestingApi* | [**tests_file_response_get**](docs/TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 *TestingApi* | [**tests_type_testing_get**](docs/TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema

--- a/samples/client/petstore/rust/reqwest/petstore/docs/TestingApi.md
+++ b/samples/client/petstore/rust/reqwest/petstore/docs/TestingApi.md
@@ -4,10 +4,39 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**tests_all_of_with_one_model_get**](TestingApi.md#tests_all_of_with_one_model_get) | **GET** /tests/allOfWithOneModel | Test for allOf with a single option. (One of the issues in #20500)
 [**tests_discriminator_duplicate_enums_get**](TestingApi.md#tests_discriminator_duplicate_enums_get) | **GET** /tests/discriminatorDuplicateEnums | Test for duplicate enums when using discriminator. (One of the issues in #20500)
 [**tests_file_response_get**](TestingApi.md#tests_file_response_get) | **GET** /tests/fileResponse | Returns an image file
 [**tests_type_testing_get**](TestingApi.md#tests_type_testing_get) | **GET** /tests/typeTesting | Route to test the TypeTesting schema
 
+
+
+## tests_all_of_with_one_model_get
+
+> String tests_all_of_with_one_model_get(person)
+Test for allOf with a single option. (One of the issues in #20500)
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**person** | [**Person**](Person.md) |  | [required] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 
 ## tests_discriminator_duplicate_enums_get

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/testing_api.rs
@@ -15,6 +15,13 @@ use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
 
 
+/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TestsAllOfWithOneModelGetError {
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`tests_discriminator_duplicate_enums_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -36,6 +43,43 @@ pub enum TestsTypeTestingGetError {
     UnknownValue(serde_json::Value),
 }
 
+
+pub fn tests_all_of_with_one_model_get(configuration: &configuration::Configuration, person: models::Person) -> Result<String, Error<TestsAllOfWithOneModelGetError>> {
+    // add a prefix to parameters to efficiently prevent name collisions
+    let p_person = person;
+
+    let uri_str = format!("{}/tests/allOfWithOneModel", configuration.base_path);
+    let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
+
+    if let Some(ref user_agent) = configuration.user_agent {
+        req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
+    }
+    req_builder = req_builder.json(&p_person);
+
+    let req = req_builder.build()?;
+    let resp = configuration.client.execute(req)?;
+
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream");
+    let content_type = super::ContentType::from(content_type);
+
+    if !status.is_client_error() && !status.is_server_error() {
+        let content = resp.text()?;
+        match content_type {
+            ContentType::Json => serde_json::from_str(&content).map_err(Error::from),
+            ContentType::Text => return Err(Error::from(serde_json::Error::custom("Received `text/plain` content type response that cannot be converted to `String`"))),
+            ContentType::Unsupported(unknown_type) => return Err(Error::from(serde_json::Error::custom(format!("Received `{unknown_type}` content type response that cannot be converted to `String`")))),
+        }
+    } else {
+        let content = resp.text()?;
+        let entity: Option<TestsAllOfWithOneModelGetError> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent { status, content, entity }))
+    }
+}
 
 pub fn tests_discriminator_duplicate_enums_get(configuration: &configuration::Configuration, ) -> Result<models::TestsDiscriminatorDuplicateEnumsGet200Response, Error<TestsDiscriminatorDuplicateEnumsGetError>> {
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes an issue reported in #20500.

`unknown_base_type: models::UNKNOWN_BASE_TYPE`  in `api.rs`

See [this](https://github.com/OpenAPITools/openapi-generator/issues/20500#issuecomment-2676969870) comment for more details.


<details><summary>PR checklist</summary>

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

</details> 

cc: @wing328 since there are changes to `DefaultCodegen.java`



