### PR TITLE
[erlang] erlang-server generator fixes

### DIFF
--- a/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/api.mustache
@@ -179,7 +179,7 @@ populate_request_params(_, [], Req, _, Model) ->
 populate_request_params(OperationID, [ReqParamName | T], Req0, ValidatorState, Model0) ->
     case populate_request_param(OperationID, ReqParamName, Req0, ValidatorState) of
         {ok, V, Req} ->
-            Model = maps:put(ReqParamName, V, Model0),
+            Model = Model0#{ReqParamName => V},
             populate_request_params(OperationID, T, Req, ValidatorState, Model);
         Error ->
             Error

--- a/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/handler.mustache
@@ -36,7 +36,7 @@ Exposes the following operation IDs:
         {operation_id :: operation_id(),
          accept_callback :: {{packageName}}_logic_handler:accept_callback(),
          provide_callback :: {{packageName}}_logic_handler:provide_callback(),
-         api_key_handler :: {{packageName}}_logic_handler:api_key_callback(),
+         api_key_callback :: {{packageName}}_logic_handler:api_key_callback(),
          context = #{} :: {{packageName}}_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -52,7 +52,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->
@@ -69,8 +69,8 @@ init(Req, {Operations, Module}) ->
 {{#authMethods.size}}
 is_authorized(Req0,
               #state{operation_id = '{{operationIdOriginal}}' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case {{packageName}}_auth:authorize_api_key(Handler, OperationID, {{#isApiKey.isKeyInQuery}}qs_val, {{/isApiKey.isKeyInQuery}}{{^isApiKey.isKeyInQuery}}header, {{/isApiKey.isKeyInQuery}}{{#isApiKey}}"{{keyParamName}}", {{/isApiKey}}{{^isApiKey}}"authorization", {{/isApiKey}}Req0) of
+                     api_key_callback = Handler} = State) ->
+    case {{packageName}}_auth:authorize_api_key(Handler, OperationID, {{#isApiKey.isKeyInQuery}}qs_val, {{/isApiKey.isKeyInQuery}}{{^isApiKey.isKeyInQuery}}header, {{/isApiKey.isKeyInQuery}}{{#isApiKey}}"{{keyParamName}}", {{/isApiKey}}{{^isApiKey}}<<"authorization">>, {{/isApiKey}}Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->

--- a/modules/openapi-generator/src/main/resources/erlang-server/server.mustache
+++ b/modules/openapi-generator/src/main/resources/erlang-server/server.mustache
@@ -33,12 +33,12 @@ get_cowboy_config(LogicHandler, ExtraOpts) ->
     maps:fold(fun get_cowboy_config/3, DefaultOpts, ExtraOpts).
 
 get_cowboy_config(env, #{dispatch := _Dispatch} = Env, AccIn) ->
-    maps:put(env, Env, AccIn);
+    AccIn#{env => Env};
 get_cowboy_config(env, NewEnv, #{env := OldEnv} = AccIn) ->
     Env = maps:merge(OldEnv, NewEnv),
-    maps:put(env, Env, AccIn);
+    AccIn#{env => Env};
 get_cowboy_config(Key, Value, AccIn) ->
-    maps:put(Key, Value, AccIn).
+    AccIn#{Key => Value}.
 
 get_default_dispatch(LogicHandler) ->
     Paths = {{packageName}}_router:get_paths(LogicHandler),

--- a/samples/server/echo_api/erlang-server/src/openapi_api.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_api.erl
@@ -686,7 +686,7 @@ populate_request_params(_, [], Req, _, Model) ->
 populate_request_params(OperationID, [ReqParamName | T], Req0, ValidatorState, Model0) ->
     case populate_request_param(OperationID, ReqParamName, Req0, ValidatorState) of
         {ok, V, Req} ->
-            Model = maps:put(ReqParamName, V, Model0),
+            Model = Model0#{ReqParamName => V},
             populate_request_params(OperationID, T, Req, ValidatorState, Model);
         Error ->
             Error

--- a/samples/server/echo_api/erlang-server/src/openapi_auth_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_auth_handler.erl
@@ -41,7 +41,7 @@ To test HTTP bearer authentication
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -57,7 +57,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->
@@ -73,8 +73,8 @@ allowed_methods(Req, State) ->
     {true | {false, iodata()}, cowboy_req:req(), state()}.
 is_authorized(Req0,
               #state{operation_id = 'test/auth/http/basic' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -82,8 +82,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'test/auth/http/bearer' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->

--- a/samples/server/echo_api/erlang-server/src/openapi_body_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_body_handler.erl
@@ -81,7 +81,7 @@ Test empty json (request body)
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -97,7 +97,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->

--- a/samples/server/echo_api/erlang-server/src/openapi_form_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_form_handler.erl
@@ -46,7 +46,7 @@ Test form parameter(s) for oneOf schema
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -62,7 +62,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->

--- a/samples/server/echo_api/erlang-server/src/openapi_header_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_header_handler.erl
@@ -36,7 +36,7 @@ Test header parameter(s)
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -52,7 +52,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->

--- a/samples/server/echo_api/erlang-server/src/openapi_path_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_path_handler.erl
@@ -36,7 +36,7 @@ Test path parameter(s)
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -52,7 +52,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->

--- a/samples/server/echo_api/erlang-server/src/openapi_query_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_query_handler.erl
@@ -81,7 +81,7 @@ Test query parameter(s)
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -97,7 +97,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->

--- a/samples/server/echo_api/erlang-server/src/openapi_server.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_server.erl
@@ -31,12 +31,12 @@ get_cowboy_config(LogicHandler, ExtraOpts) ->
     maps:fold(fun get_cowboy_config/3, DefaultOpts, ExtraOpts).
 
 get_cowboy_config(env, #{dispatch := _Dispatch} = Env, AccIn) ->
-    maps:put(env, Env, AccIn);
+    AccIn#{env => Env};
 get_cowboy_config(env, NewEnv, #{env := OldEnv} = AccIn) ->
     Env = maps:merge(OldEnv, NewEnv),
-    maps:put(env, Env, AccIn);
+    AccIn#{env => Env};
 get_cowboy_config(Key, Value, AccIn) ->
-    maps:put(Key, Value, AccIn).
+    AccIn#{Key => Value}.
 
 get_default_dispatch(LogicHandler) ->
     Paths = openapi_router:get_paths(LogicHandler),

--- a/samples/server/petstore/erlang-server/src/openapi_api.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_api.erl
@@ -525,7 +525,7 @@ populate_request_params(_, [], Req, _, Model) ->
 populate_request_params(OperationID, [ReqParamName | T], Req0, ValidatorState, Model0) ->
     case populate_request_param(OperationID, ReqParamName, Req0, ValidatorState) of
         {ok, V, Req} ->
-            Model = maps:put(ReqParamName, V, Model0),
+            Model = Model0#{ReqParamName => V},
             populate_request_params(OperationID, T, Req, ValidatorState, Model);
         Error ->
             Error

--- a/samples/server/petstore/erlang-server/src/openapi_pet_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_pet_handler.erl
@@ -71,7 +71,7 @@ uploads an image.
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -87,7 +87,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->
@@ -115,8 +115,8 @@ allowed_methods(Req, State) ->
     {true | {false, iodata()}, cowboy_req:req(), state()}.
 is_authorized(Req0,
               #state{operation_id = 'addPet' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -124,8 +124,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'deletePet' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -133,8 +133,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'findPetsByStatus' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -142,8 +142,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'findPetsByTags' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -151,8 +151,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'getPetById' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -160,8 +160,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'updatePet' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -169,8 +169,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'updatePetWithForm' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -178,8 +178,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'uploadFile' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->

--- a/samples/server/petstore/erlang-server/src/openapi_server.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_server.erl
@@ -31,12 +31,12 @@ get_cowboy_config(LogicHandler, ExtraOpts) ->
     maps:fold(fun get_cowboy_config/3, DefaultOpts, ExtraOpts).
 
 get_cowboy_config(env, #{dispatch := _Dispatch} = Env, AccIn) ->
-    maps:put(env, Env, AccIn);
+    AccIn#{env => Env};
 get_cowboy_config(env, NewEnv, #{env := OldEnv} = AccIn) ->
     Env = maps:merge(OldEnv, NewEnv),
-    maps:put(env, Env, AccIn);
+    AccIn#{env => Env};
 get_cowboy_config(Key, Value, AccIn) ->
-    maps:put(Key, Value, AccIn).
+    AccIn#{Key => Value}.
 
 get_default_dispatch(LogicHandler) ->
     Paths = openapi_router:get_paths(LogicHandler),

--- a/samples/server/petstore/erlang-server/src/openapi_store_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_store_handler.erl
@@ -51,7 +51,7 @@ Place an order for a pet.
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -67,7 +67,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->
@@ -87,8 +87,8 @@ allowed_methods(Req, State) ->
     {true | {false, iodata()}, cowboy_req:req(), state()}.
 is_authorized(Req0,
               #state{operation_id = 'getInventory' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->

--- a/samples/server/petstore/erlang-server/src/openapi_user_handler.erl
+++ b/samples/server/petstore/erlang-server/src/openapi_user_handler.erl
@@ -71,7 +71,7 @@ This can only be done by the logged in user.
         {operation_id :: operation_id(),
          accept_callback :: openapi_logic_handler:accept_callback(),
          provide_callback :: openapi_logic_handler:provide_callback(),
-         api_key_handler :: openapi_logic_handler:api_key_callback(),
+         api_key_callback :: openapi_logic_handler:api_key_callback(),
          context = #{} :: openapi_logic_handler:context()}).
 
 -type state() :: #state{}.
@@ -87,7 +87,7 @@ init(Req, {Operations, Module}) ->
     State = #state{operation_id = OperationID,
                    accept_callback = fun Module:accept_callback/4,
                    provide_callback = fun Module:provide_callback/4,
-                   api_key_handler = fun Module:authorize_api_key/2},
+                   api_key_callback = fun Module:api_key_callback/2},
     {cowboy_rest, Req, State}.
 
 -spec allowed_methods(cowboy_req:req(), state()) ->
@@ -115,8 +115,8 @@ allowed_methods(Req, State) ->
     {true | {false, iodata()}, cowboy_req:req(), state()}.
 is_authorized(Req0,
               #state{operation_id = 'createUser' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -124,8 +124,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'createUsersWithArrayInput' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -133,8 +133,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'createUsersWithListInput' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -142,8 +142,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'deleteUser' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -151,8 +151,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'logoutUser' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->
@@ -160,8 +160,8 @@ is_authorized(Req0,
     end;
 is_authorized(Req0,
               #state{operation_id = 'updateUser' = OperationID,
-                     api_key_handler = Handler} = State) ->
-    case openapi_auth:authorize_api_key(Handler, OperationID, header, "authorization", Req0) of
+                     api_key_callback = Handler} = State) ->
+    case openapi_auth:authorize_api_key(Handler, OperationID, header, <<"authorization">>, Req0) of
         {true, Context, Req} ->
             {true, Req, State#state{context = Context}};
         {false, AuthHeader, Req} ->


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Current erlang-server generates code with errors which will always crash on key authorisation.  This PR fix them and also has minor performance improvements for map updates.

@tsloughter

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
