### PR TITLE
[rust] Fixed nullable byte arrays

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -129,9 +129,9 @@ pub struct {{{classname}}} {
     /// {{{.}}}
     {{/description}}
     {{#isByteArray}}
-    {{#required}}#[serde_as(as = "serde_with::base64::Base64")]{{/required}}{{^required}}#[serde_as(as = "Option<serde_with::base64::Base64>")]{{/required}}
+    {{#required}}#[serde_as(as = "serde_with::base64::Base64")]{{/required}}{{^required}}#[serde_as(as = "{{#isNullable}}Option<{{/isNullable}}Option<serde_with::base64::Base64>{{#isNullable}}>{{/isNullable}}")]{{/required}}
     {{/isByteArray}}
-    #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default, with = "::serde_with::rust::double_option"{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
+    #[serde(rename = "{{{baseName}}}"{{^required}}{{#isNullable}}, default{{^isByteArray}}, with = "::serde_with::rust::double_option"{{/isByteArray}}{{/isNullable}}{{/required}}{{^required}}, skip_serializing_if = "Option::is_none"{{/required}}{{#required}}{{#isNullable}}, deserialize_with = "Option::deserialize"{{/isNullable}}{{/required}})]
     pub {{{name}}}: {{!
     ### Option Start
     }}{{#isNullable}}Option<{{/isNullable}}{{^required}}Option<{{/required}}{{!

--- a/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/petstore.yaml
@@ -915,6 +915,10 @@ components:
         bytes:
           type: string
           format: byte
+        nullableBytes: # Regression test for bug report in #20500
+          type: string
+          format: byte
+          nullable: true
         decimal:
           type: string
           format: number

--- a/samples/client/petstore/rust/hyper/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/hyper/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/hyper/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/hyper0x/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/hyper0x/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/hyper0x/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/hyper0x/petstore/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest-trait/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-async/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-async/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/FooTypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/docs/FooTypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/models/foo_type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/models/foo_type_testing.rs
@@ -34,6 +34,9 @@ pub struct FooTypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl FooTypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore/docs/TypeTesting.md
+++ b/samples/client/petstore/rust/reqwest/petstore/docs/TypeTesting.md
@@ -12,6 +12,7 @@ Name | Type | Description | Notes
 **boolean** | **bool** |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) |  | 
 **bytes** | **String** |  | 
+**nullable_bytes** | Option<**String**> |  | [optional]
 **decimal** | **String** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/type_testing.rs
@@ -34,6 +34,9 @@ pub struct TypeTesting {
     #[serde_as(as = "serde_with::base64::Base64")]
     #[serde(rename = "bytes")]
     pub bytes: Vec<u8>,
+    #[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
+    #[serde(rename = "nullableBytes", default, skip_serializing_if = "Option::is_none")]
+    pub nullable_bytes: Option<Option<Vec<u8>>>,
     #[serde(rename = "decimal")]
     pub decimal: String,
 }
@@ -50,6 +53,7 @@ impl TypeTesting {
             boolean,
             uuid,
             bytes,
+            nullable_bytes: None,
             decimal,
         }
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes one of the issues reported in #20500.

The issue is types with nullable string of bytes
```yaml
properties:
  myByteArray:
    type: string
    format: byte
    nullable: true
```
will generate invalid code
```rs
struct Foo {
    #[serde_as(as = "Option<serde_with::base64::Base64>")]
    #[serde(rename = "myByteArray", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
    pub my_byte_array: Option<Option<Vec<u8>>>,
}
```
this does not compile due to `serde_as` not being compatible with `serde_with`.

```
error: Cannot combine `serde_as` with serde's `with`, `deserialize_with`, or `serialize_with`.
  --> src/models/credentials.rs:22:5
   |
22 |     #[serde_as(as = "Option<serde_with::base64::Base64>")]
   |     
```

This PR removes the `with` and adds 2 Options if the type is a nullable byte array

```rs
#[serde_as(as = "Option<Option<serde_with::base64::Base64>>")]
#[serde(rename = "myByteArray", default, skip_serializing_if = "Option::is_none")]
pub my_byte_array: Option<Option<Vec<u8>>>,
```



<details><summary>PR checklist</summary>

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

</details> 



cc: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

