### PR TITLE
Added support for Cookie parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -72,7 +72,7 @@ public interface {{classname}}  {
     @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} })
 {{/hasProduces}}
 {{^singleRequestParameter}}
-    {{^vendorExtensions.x-java-is-response-void}}{{#microprofileServer}}{{> server_operation}}{{/microprofileServer}}{{^microprofileServer}}{{> client_operation}}{{/microprofileServer}}{{/vendorExtensions.x-java-is-response-void}}{{#vendorExtensions.x-java-is-response-void}}{{#microprofileMutiny}}Uni<Void>{{/microprofileMutiny}}{{^microprofileMutiny}}void{{/microprofileMutiny}}{{/vendorExtensions.x-java-is-response-void}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException, ProcessingException;
+    {{^vendorExtensions.x-java-is-response-void}}{{#microprofileServer}}{{> server_operation}}{{/microprofileServer}}{{^microprofileServer}}{{> client_operation}}{{/microprofileServer}}{{/vendorExtensions.x-java-is-response-void}}{{#vendorExtensions.x-java-is-response-void}}{{#microprofileMutiny}}Uni<Void>{{/microprofileMutiny}}{{^microprofileMutiny}}void{{/microprofileMutiny}}{{/vendorExtensions.x-java-is-response-void}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{>cookieParams}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException, ProcessingException;
 {{/singleRequestParameter}}
 {{#singleRequestParameter}}
     {{^vendorExtensions.x-java-is-response-void}}{{#microprofileMutiny}}Uni<{{{returnType}}}>{{/microprofileMutiny}}{{^microprofileMutiny}}{{{returnType}}}{{/microprofileMutiny}}{{/vendorExtensions.x-java-is-response-void}}{{#vendorExtensions.x-java-is-response-void}}{{#microprofileMutiny}}Uni<Void>{{/microprofileMutiny}}{{^microprofileMutiny}}void{{/microprofileMutiny}}{{/vendorExtensions.x-java-is-response-void}} {{nickname}}({{#hasNonBodyParams}}@BeanParam {{operationIdCamelCase}}Request request{{/hasNonBodyParams}}{{#bodyParams}}{{#hasNonBodyParams}}, {{/hasNonBodyParams}}{{>bodyParams}}{{/bodyParams}}) throws ApiException, ProcessingException;
@@ -91,6 +91,9 @@ public interface {{classname}}  {
         {{#formParams}}
         private {{>formParams}};
         {{/formParams}}
+        {{#cookieParams}}
+        private {{>cookieParams}};
+        {{/cookieParams}}
 
         private {{operationIdCamelCase}}Request() {
         }
@@ -106,7 +109,7 @@ public interface {{classname}}  {
          * @param {{paramName}}{{>formParamsNameSuffix}} {{description}} ({{^required}}optional{{^isContainer}}{{#defaultValue}}, default to {{.}}{{/defaultValue}}{{/isContainer}}{{/required}}{{#required}}required{{/required}})
          * @return {{operationIdCamelCase}}Request
          */
-        public {{operationIdCamelCase}}Request {{paramName}}{{>formParamsNameSuffix}}({{>queryParamsImpl}}{{>pathParamsImpl}}{{>headerParamsImpl}}{{>formParamsImpl}}) {
+        public {{operationIdCamelCase}}Request {{paramName}}{{>formParamsNameSuffix}}({{>queryParamsImpl}}{{>pathParamsImpl}}{{>headerParamsImpl}}{{>formParamsImpl}}{{>cookieParamsImpl}}) {
             this.{{paramName}}{{>formParamsNameSuffix}} = {{paramName}}{{>formParamsNameSuffix}};
             return this;
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/beanValidationCookieParams.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/beanValidationCookieParams.mustache
@@ -1,0 +1,1 @@
+{{#required}} @NotNull{{/required}}{{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/cookieParams.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/cookieParams.mustache
@@ -1,0 +1,1 @@
+{{#isCookieParam}}@CookieParam("{{baseName}}") {{#useBeanValidation}}{{>beanValidationCookieParams}}{{/useBeanValidation}} {{{dataType}}} {{paramName}}{{/isCookieParam}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/cookieParamsImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/cookieParamsImpl.mustache
@@ -1,0 +1,1 @@
+{{#isCookieParam}}{{{dataType}}} {{paramName}}{{/isCookieParam}}

--- a/modules/openapi-generator/src/test/resources/bugs/microprofile_cookie.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/microprofile_cookie.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+info:
+  version: 2.0.0
+  title: test
+paths:
+  /pets:
+    get:
+      summary: bla
+      operationId: getCustomer
+      parameters:
+        - name: first
+          in: header
+          schema:
+            type: string
+        - name: cookieParameter
+          in: cookie
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
The Java MicroProfile generator was missing support for cookie parameters and would generate invalid code.

Example:
````yaml
openapi: "3.0.0"
info:
  version: 2.0.0
  title: test
paths:
  /pets:
    get:
      summary: bla
      operationId: getCustomer
      parameters:
        - name: first
          in: header
          schema:
            type: string
        - name: cookieParameter
          in: cookie
          schema:
            type: string
      responses:
        '200':
          description: OK
````            
would generate 
````java
@RegisterRestClient()
@RegisterProvider(ApiExceptionMapper.class)
@Path("/pets")
public interface CustomerApiApi  {

    /**
     * get information of the current customer
     *
     */
    @GET

    @Produces({ "application/vnd.advisory-v1+json", "application/problem+json" })
    GetCustomer200Response getPets(@HeaderParam("x-refnr")  String xRefnr, ) throws ApiException, ProcessingException;
}
````
Note the trailing slash.  

The issue recides in an `allParams` loop that was missing output for cookie.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


Fixes #20727

Technical mention

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)