### PR TITLE
[csharp][httpclient] do not use deprecated HttpRequestMessage.Properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-functions/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-functions/libraries/httpclient/ApiClient.mustache
@@ -167,6 +167,9 @@ namespace {{packageName}}.Client
     /// </remarks>
     {{>visibility}} partial class ApiClient : IDisposable, ISynchronousClient{{#supportsAsync}}, IAsynchronousClient{{/supportsAsync}}
     {
+    {{#net60OrLater}}
+        private static readonly HttpRequestOptionsKey<List<Cookie>> _httpOptionsCookieContainerKey = new("CookieContainer");
+    {{/net60OrLater}}
         private readonly string _baseUrl;
 
         private readonly HttpClientHandler _httpClientHandler;
@@ -382,12 +385,15 @@ namespace {{packageName}}.Client
                 }
             }
 
-
-
             // TODO provide an alternative that allows cookies per request instead of per API client
             if (options.Cookies != null && options.Cookies.Count > 0)
             {
+            {{#net60OrLater}}
+                request.Options.Set(_httpOptionsCookieContainerKey, options.Cookies);
+            {{/net60OrLater}}
+            {{^net60OrLater}}
                 request.Properties["CookieContainer"] = options.Cookies;
+            {{/net60OrLater}}
             }
 
             return request;
@@ -474,9 +480,16 @@ namespace {{packageName}}.Client
                     _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
                 }
 
+            {{^net60OrLater}}
                 var cookieContainer = req.Properties.ContainsKey("CookieContainer") ? req.Properties["CookieContainer"] as List<Cookie> : null;
+            {{/net60OrLater}}
 
+            {{#net60OrLater}}
+                if (req.Options.TryGetValue(_httpOptionsCookieContainerKey, out var cookieContainer))
+            {{/net60OrLater}}
+            {{^net60OrLater}}
                 if (cookieContainer != null)
+            {{/net60OrLater}}
                 {
                     if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     foreach (var cookie in cookieContainer)

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache
@@ -79,7 +79,7 @@ namespace {{packageName}}.Client
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response)
         {
-            var result = (T) await Deserialize(response, typeof(T)).ConfigureAwait(false);
+            var result = (T)await Deserialize(response, typeof(T)).ConfigureAwait(false);
             return result;
         }
 
@@ -95,13 +95,13 @@ namespace {{packageName}}.Client
             // process response headers, e.g. Access-Control-Allow-Methods
             foreach (var responseHeader in response.Headers)
             {
-                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+                headers.Add(responseHeader.Key + "=" + ClientUtils.ParameterToString(responseHeader.Value));
             }
 
             // process response content headers, e.g. Content-Type
             foreach (var responseHeader in response.Content.Headers)
             {
-                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+                headers.Add(responseHeader.Key + "=" + ClientUtils.ParameterToString(responseHeader.Value));
             }
 
             // RFC 2183 & RFC 2616
@@ -112,7 +112,8 @@ namespace {{packageName}}.Client
             }
             else if (type == typeof(FileParameter))
             {
-                if (headers != null) {
+                if (headers != null)
+                {
                     foreach (var header in headers)
                     {
                         var match = fileNameRegex.Match(header.ToString());
@@ -191,6 +192,9 @@ namespace {{packageName}}.Client
     /// </remarks>
     {{>visibility}} partial class ApiClient : IDisposable, ISynchronousClient{{#supportsAsync}}, IAsynchronousClient{{/supportsAsync}}
     {
+    {{#net60OrLater}}
+        private static readonly HttpRequestOptionsKey<List<Cookie>> _httpOptionsCookieContainerKey = new("CookieContainer");
+    {{/net60OrLater}}
         private readonly string _baseUrl;
 
         private readonly HttpClientHandler _httpClientHandler;
@@ -283,7 +287,8 @@ namespace {{packageName}}.Client
         /// </summary>
         public void Dispose()
         {
-            if(_disposeClient) {
+            if(_disposeClient)
+            {
                 _httpClient.Dispose();
             }
         }
@@ -413,7 +418,12 @@ namespace {{packageName}}.Client
             // TODO provide an alternative that allows cookies per request instead of per API client
             if (options.Cookies != null && options.Cookies.Count > 0)
             {
+            {{#net60OrLater}}
+                request.Options.Set(_httpOptionsCookieContainerKey, options.Cookies);
+            {{/net60OrLater}}
+            {{^net60OrLater}}
                 request.Properties["CookieContainer"] = options.Cookies;
+            {{/net60OrLater}}
             }
 
             return request;
@@ -424,7 +434,7 @@ namespace {{packageName}}.Client
 
         private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
         {
-            T result = (T) responseData;
+            T result = (T)responseData;
             string rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>({{#caseInsensitiveResponseHeaders}}StringComparer.OrdinalIgnoreCase{{/caseInsensitiveResponseHeaders}}), result, rawContent)
@@ -459,7 +469,7 @@ namespace {{packageName}}.Client
                         transformed.Cookies.Add(cookie);
                     }
                 }
-                catch (PlatformNotSupportedException) {}
+                catch (PlatformNotSupportedException) { }
             }
 
             return transformed;
@@ -496,15 +506,22 @@ namespace {{packageName}}.Client
 
                 if (configuration.ClientCertificates != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
                 }
 
+            {{^net60OrLater}}
                 var cookieContainer = req.Properties.ContainsKey("CookieContainer") ? req.Properties["CookieContainer"] as List<Cookie> : null;
+            {{/net60OrLater}}
 
+            {{#net60OrLater}}
+                if (req.Options.TryGetValue(_httpOptionsCookieContainerKey, out var cookieContainer))
+            {{/net60OrLater}}
+            {{^net60OrLater}}
                 if (cookieContainer != null)
+            {{/net60OrLater}}
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     foreach (var cookie in cookieContainer)
                     {
                         _httpClientHandler.CookieContainer.Add(cookie);
@@ -546,11 +563,11 @@ namespace {{packageName}}.Client
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof({{{packageName}}}.{{modelPackage}}.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
                 {
-                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                    responseData = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    responseData = (T)(object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 }
 
                 InterceptResponse(req, response);

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Client
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response)
         {
-            var result = (T) await Deserialize(response, typeof(T)).ConfigureAwait(false);
+            var result = (T)await Deserialize(response, typeof(T)).ConfigureAwait(false);
             return result;
         }
 
@@ -99,13 +99,13 @@ namespace Org.OpenAPITools.Client
             // process response headers, e.g. Access-Control-Allow-Methods
             foreach (var responseHeader in response.Headers)
             {
-                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+                headers.Add(responseHeader.Key + "=" + ClientUtils.ParameterToString(responseHeader.Value));
             }
 
             // process response content headers, e.g. Content-Type
             foreach (var responseHeader in response.Content.Headers)
             {
-                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+                headers.Add(responseHeader.Key + "=" + ClientUtils.ParameterToString(responseHeader.Value));
             }
 
             // RFC 2183 & RFC 2616
@@ -116,7 +116,8 @@ namespace Org.OpenAPITools.Client
             }
             else if (type == typeof(FileParameter))
             {
-                if (headers != null) {
+                if (headers != null)
+                {
                     foreach (var header in headers)
                     {
                         var match = fileNameRegex.Match(header.ToString());
@@ -195,6 +196,7 @@ namespace Org.OpenAPITools.Client
     /// </remarks>
     public partial class ApiClient : IDisposable, ISynchronousClient, IAsynchronousClient
     {
+        private static readonly HttpRequestOptionsKey<List<Cookie>> _httpOptionsCookieContainerKey = new("CookieContainer");
         private readonly string _baseUrl;
 
         private readonly HttpClientHandler _httpClientHandler;
@@ -287,7 +289,8 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public void Dispose()
         {
-            if(_disposeClient) {
+            if(_disposeClient)
+            {
                 _httpClient.Dispose();
             }
         }
@@ -415,7 +418,7 @@ namespace Org.OpenAPITools.Client
             // TODO provide an alternative that allows cookies per request instead of per API client
             if (options.Cookies != null && options.Cookies.Count > 0)
             {
-                request.Properties["CookieContainer"] = options.Cookies;
+                request.Options.Set(_httpOptionsCookieContainerKey, options.Cookies);
             }
 
             return request;
@@ -426,7 +429,7 @@ namespace Org.OpenAPITools.Client
 
         private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
         {
-            T result = (T) responseData;
+            T result = (T)responseData;
             string rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
@@ -461,7 +464,7 @@ namespace Org.OpenAPITools.Client
                         transformed.Cookies.Add(cookie);
                     }
                 }
-                catch (PlatformNotSupportedException) {}
+                catch (PlatformNotSupportedException) { }
             }
 
             return transformed;
@@ -498,15 +501,14 @@ namespace Org.OpenAPITools.Client
 
                 if (configuration.ClientCertificates != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
                 }
 
-                var cookieContainer = req.Properties.ContainsKey("CookieContainer") ? req.Properties["CookieContainer"] as List<Cookie> : null;
 
-                if (cookieContainer != null)
+                if (req.Options.TryGetValue(_httpOptionsCookieContainerKey, out var cookieContainer))
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     foreach (var cookie in cookieContainer)
                     {
                         _httpClientHandler.CookieContainer.Add(cookie);
@@ -544,11 +546,11 @@ namespace Org.OpenAPITools.Client
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
                 {
-                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                    responseData = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    responseData = (T)(object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 }
 
                 InterceptResponse(req, response);

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Client
 
         public async Task<T> Deserialize<T>(HttpResponseMessage response)
         {
-            var result = (T) await Deserialize(response, typeof(T)).ConfigureAwait(false);
+            var result = (T)await Deserialize(response, typeof(T)).ConfigureAwait(false);
             return result;
         }
 
@@ -98,13 +98,13 @@ namespace Org.OpenAPITools.Client
             // process response headers, e.g. Access-Control-Allow-Methods
             foreach (var responseHeader in response.Headers)
             {
-                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+                headers.Add(responseHeader.Key + "=" + ClientUtils.ParameterToString(responseHeader.Value));
             }
 
             // process response content headers, e.g. Content-Type
             foreach (var responseHeader in response.Content.Headers)
             {
-                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+                headers.Add(responseHeader.Key + "=" + ClientUtils.ParameterToString(responseHeader.Value));
             }
 
             // RFC 2183 & RFC 2616
@@ -115,7 +115,8 @@ namespace Org.OpenAPITools.Client
             }
             else if (type == typeof(FileParameter))
             {
-                if (headers != null) {
+                if (headers != null)
+                {
                     foreach (var header in headers)
                     {
                         var match = fileNameRegex.Match(header.ToString());
@@ -286,7 +287,8 @@ namespace Org.OpenAPITools.Client
         /// </summary>
         public void Dispose()
         {
-            if(_disposeClient) {
+            if(_disposeClient)
+            {
                 _httpClient.Dispose();
             }
         }
@@ -425,7 +427,7 @@ namespace Org.OpenAPITools.Client
 
         private async Task<ApiResponse<T>> ToApiResponse<T>(HttpResponseMessage response, object responseData, Uri uri)
         {
-            T result = (T) responseData;
+            T result = (T)responseData;
             string rawContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             var transformed = new ApiResponse<T>(response.StatusCode, new Multimap<string, string>(), result, rawContent)
@@ -460,7 +462,7 @@ namespace Org.OpenAPITools.Client
                         transformed.Cookies.Add(cookie);
                     }
                 }
-                catch (PlatformNotSupportedException) {}
+                catch (PlatformNotSupportedException) { }
             }
 
             return transformed;
@@ -497,7 +499,7 @@ namespace Org.OpenAPITools.Client
 
                 if (configuration.ClientCertificates != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Configuration `ClientCertificates` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     _httpClientHandler.ClientCertificates.AddRange(configuration.ClientCertificates);
                 }
 
@@ -505,7 +507,7 @@ namespace Org.OpenAPITools.Client
 
                 if (cookieContainer != null)
                 {
-                    if(_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
+                    if (_httpClientHandler == null) throw new InvalidOperationException("Request property `CookieContainer` not supported when the client is explicitly created without an HttpClientHandler, use the proper constructor.");
                     foreach (var cookie in cookieContainer)
                     {
                         _httpClientHandler.CookieContainer.Add(cookie);
@@ -543,11 +545,11 @@ namespace Org.OpenAPITools.Client
                 // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
                 if (typeof(Org.OpenAPITools.Model.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
                 {
-                    responseData = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                    responseData = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
                 }
                 else if (typeof(T).Name == "Stream") // for binary response
                 {
-                    responseData = (T) (object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    responseData = (T)(object) await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 }
 
                 InterceptResponse(req, response);


### PR DESCRIPTION
Currently generated code (for recent .Net versions) has warnings because the Api uses `HttpRequestMessage.Properties` which is deprecated. This PR replaces its usages with `HttpRequestMessage.Options`. 
Additionally some formatting has been changed.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)
