### PR TITLE
fix(openapi-generator): fixes GlobalSettings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
@@ -38,12 +38,13 @@ public class GlobalSettings {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GlobalSettings.class);
 
-    private static ThreadLocal<Properties> properties = new InheritableThreadLocal<Properties>() {
+    private static ThreadLocal<Properties> properties = new InheritableThreadLocal<>() {
         @Override
         protected Properties initialValue() {
             // avoid using System.getProperties().clone() which is broken in Gradle - see https://github.com/gradle/gradle/issues/17344
             Properties copy = new Properties();
-            copy.putAll(System.getProperties());
+            System.getProperties()
+                .forEach((k,v) -> copy.put(String.valueOf(k), String.valueOf(v)));
             return copy;
         }
     };
@@ -69,8 +70,10 @@ public class GlobalSettings {
     }
 
     public static void log() {
-        StringWriter stringWriter = new StringWriter();
-        properties.get().list(new PrintWriter(stringWriter));
-        LOGGER.debug("GlobalSettings: {}", stringWriter);
+        if(LOGGER.isDebugEnabled()) {
+            StringWriter stringWriter = new StringWriter();
+            properties.get().list(new PrintWriter(stringWriter));
+            LOGGER.debug("GlobalSettings: {}", stringWriter);
+        }
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/GlobalSettingsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/GlobalSettingsTest.java
@@ -1,8 +1,11 @@
 package org.openapitools.codegen.config;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import java.util.Properties;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -16,6 +19,7 @@ public class GlobalSettingsTest {
 
   @BeforeClass
   public void setUp() {
+    ((Logger) LoggerFactory.getLogger(GlobalSettings.class)).setLevel(Level.DEBUG);
     Properties props = new Properties(2);
     props.put("test1", OBJECT);
     props.put(OBJECT, "test2");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/GlobalSettingsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/GlobalSettingsTest.java
@@ -1,0 +1,32 @@
+package org.openapitools.codegen.config;
+
+import java.util.Properties;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test class for {@link GlobalSettings}
+ * @author Edoardo Patti
+ */
+public class GlobalSettingsTest {
+
+  private static final Object OBJECT = new Object();
+
+  @BeforeClass
+  public void setUp() {
+    Properties props = new Properties(2);
+    props.put("test1", OBJECT);
+    props.put(OBJECT, "test2");
+    System.getProperties().putAll(props);
+  }
+
+  @Test
+  public void testNonStringSystemProperties() {
+    assertThat(GlobalSettings.getProperty(OBJECT.toString())).isNotNull();
+    assertThat(GlobalSettings.getProperty("test1")).isNotNull();
+    assertThatNoException().isThrownBy(GlobalSettings::log);
+  }
+
+}


### PR DESCRIPTION
This pull request aims to fix an issue I've noticed when adding a non-string value or key as a system property.
The issue surfaces during the invocation of [CodeMojo#execute](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java#L962).
In such cases, [GlobalSettings#log](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java#L71) throws a `ClassCastException` as expected/partially documented  [here](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/Properties.java#L1240).

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
