### PR TITLE
[java][spring] Add option `optionalAcceptNullable` to accept null values

### DIFF
--- a/bin/configs/spring-cloud-3-with-optional.yaml
+++ b/bin/configs/spring-cloud-3-with-optional.yaml
@@ -1,6 +1,6 @@
 generatorName: spring
 library: spring-cloud
-outputDir: /tmp/samples/openapi3/client/petstore/spring-cloud-3-with-optional
+outputDir: samples/openapi3/client/petstore/spring-cloud-3-with-optional
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:

--- a/bin/configs/spring-cloud-3-with-optional.yaml
+++ b/bin/configs/spring-cloud-3-with-optional.yaml
@@ -1,6 +1,6 @@
 generatorName: spring
 library: spring-cloud
-outputDir: samples/openapi3/client/petstore/spring-cloud-3-with-optional
+outputDir: /tmp/samples/openapi3/client/petstore/spring-cloud-3-with-optional
 inputSpec: modules/openapi-generator/src/test/resources/3_0/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/JavaSpring
 additionalProperties:
@@ -12,3 +12,4 @@ additionalProperties:
   useSwaggerUI: "false"
   hideGenerationTimestamp: "true"
   documentationProvider: none
+  #optionalAcceptNullable: "false" # default to true

--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -73,6 +73,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |licenseUrl|The URL of the license| |http://unlicense.org|
 |modelPackage|package for generated models| |org.openapitools.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library. Not supported by `microprofile` library.| |true|
+|optionalAcceptNullable|Use `ofNullable` instead of just `of` to accept null values when using Optional.| |true|
 |parentArtifactId|parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |parentGroupId|parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |parentVersion|parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -66,6 +66,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |licenseUrl|The URL of the license| |http://unlicense.org|
 |modelPackage|package for generated models| |org.openapitools.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library. Not supported by `microprofile` library.| |true|
+|optionalAcceptNullable|Use `ofNullable` instead of just `of` to accept null values when using Optional.| |true|
 |parentArtifactId|parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |parentGroupId|parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |parentVersion|parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -114,6 +114,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String USE_REQUEST_MAPPING_ON_CONTROLLER = "useRequestMappingOnController";
     public static final String USE_REQUEST_MAPPING_ON_INTERFACE = "useRequestMappingOnInterface";
     public static final String USE_SEALED = "useSealed";
+    public static final String OPTIONAL_ACCEPT_NULLABLE = "optionalAcceptNullable";
 
     @Getter public enum RequestMappingMode {
         api_interface("Generate the @RequestMapping annotation on the generated Api Interface."),
@@ -167,6 +168,8 @@ public class SpringCodegen extends AbstractJavaCodegen
     protected boolean generatedConstructorWithRequiredArgs = true;
     @Getter @Setter
     protected RequestMappingMode requestMappingMode = RequestMappingMode.controller;
+    @Getter @Setter
+    protected boolean optionalAcceptNullable = true;
 
     public SpringCodegen() {
         super();
@@ -271,6 +274,9 @@ public class SpringCodegen extends AbstractJavaCodegen
             "Whether to generate constructors with required args for models",
             generatedConstructorWithRequiredArgs));
         cliOptions.add(new CliOption(RESOURCE_FOLDER, RESOURCE_FOLDER_DESC).defaultValue(this.getResourceFolder()));
+        cliOptions.add(CliOption.newBoolean(OPTIONAL_ACCEPT_NULLABLE,
+                "Use `ofNullable` instead of just `of` to accept null values when using Optional.",
+                optionalAcceptNullable));
 
         supportedLibraries.put(SPRING_BOOT, "Spring-boot Server application.");
         supportedLibraries.put(SPRING_CLOUD_LIBRARY,
@@ -434,6 +440,8 @@ public class SpringCodegen extends AbstractJavaCodegen
 
         convertPropertyToBooleanAndWriteBack(UNHANDLED_EXCEPTION_HANDLING, this::setUnhandledException);
         convertPropertyToBooleanAndWriteBack(USE_RESPONSE_ENTITY, this::setUseResponseEntity);
+        convertPropertyToBooleanAndWriteBack(OPTIONAL_ACCEPT_NULLABLE, this::setOptionalAcceptNullable);
+
         additionalProperties.put("springHttpStatus", new SpringHttpStatusLambda());
 
         convertPropertyToBooleanAndWriteBack(USE_ENUM_CASE_INSENSITIVE, this::setUseEnumCaseInsensitive);

--- a/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/pojo.mustache
@@ -156,7 +156,7 @@ public {{>sealed}}class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}
   {{! begin feature: fluent setter methods }}
   public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
     {{#openApiNullable}}
-    this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.ofNullable({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
+    this.{{name}} = {{#isNullable}}JsonNullable.of({{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}Optional.of{{#optionalAcceptNullable}}Nullable{{/optionalAcceptNullable}}({{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}}{{name}}{{#isNullable}}){{/isNullable}}{{#useOptional}}{{^required}}{{^isNullable}}{{^isContainer}}){{/isContainer}}{{/isNullable}}{{/required}}{{/useOptional}};
     {{/openApiNullable}}
     {{^openApiNullable}}
     this.{{name}} = {{name}};

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5325,24 +5325,45 @@ public class SpringCodegenTest {
                 );
     }
 
+    @Test
     public void shouldNotAcceptNullValues() throws IOException {
         SpringCodegen codegen = new SpringCodegen();
         codegen.setLibrary(SPRING_BOOT);
         codegen.setUseSpringBoot3(true);
         codegen.setUseOptional(true);
-        codegen.setOptionalAcceptNullable(true);
+        codegen.setOptionalAcceptNullable(false);
 
         Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/petstore.yaml");
         var file = files.get("Category.java");
 
         JavaFileAssert.assertThat(file)
                 .fileContains(
-                        "this.id = Optional.of(id);"
+                        "this.name = Optional.of(name);"
                 );
         JavaFileAssert.assertThat(file)
                 .fileDoesNotContain(
                         "this.name = Optional.ofNullable(name);"
                 );
+    }
 
+    @Test
+    public void shouldAcceptNullValues() throws IOException {
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setLibrary(SPRING_BOOT);
+        codegen.setUseSpringBoot3(true);
+        codegen.setUseOptional(true);
+        //codegen.setOptionalAcceptNullable(true); // default to true
+
+        Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/petstore.yaml");
+        var file = files.get("Category.java");
+
+        JavaFileAssert.assertThat(file)
+                .fileContains(
+                        "this.name = Optional.ofNullable(name);"
+                );
+        JavaFileAssert.assertThat(file)
+                .fileDoesNotContain(
+                        "this.name = Optional.of(name);"
+                );
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5324,4 +5324,25 @@ public class SpringCodegenTest {
                                 " @Nullable List<String> nullableContainer)"
                 );
     }
+
+    public void shouldNotAcceptNullValues() throws IOException {
+        SpringCodegen codegen = new SpringCodegen();
+        codegen.setLibrary(SPRING_BOOT);
+        codegen.setUseSpringBoot3(true);
+        codegen.setUseOptional(true);
+        codegen.setOptionalAcceptNullable(true);
+
+        Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/petstore.yaml");
+        var file = files.get("Category.java");
+
+        JavaFileAssert.assertThat(file)
+                .fileContains(
+                        "this.id = Optional.of(id);"
+                );
+        JavaFileAssert.assertThat(file)
+                .fileDoesNotContain(
+                        "this.name = Optional.ofNullable(name);"
+                );
+
+    }
 }


### PR DESCRIPTION
a follow-up PR to #20406 

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
