### PR TITLE
[nim] Fix nim code generation in case of an endpoint for which schema defines both query parameters and multipart/form-data

### DIFF
--- a/modules/openapi-generator/src/main/resources/nim-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/nim-client/api.mustache
@@ -37,19 +37,19 @@ proc {{{operationId}}}*(httpClient: HttpClient{{#allParams}}, {{{paramName}}}: {
   httpClient.headers["Content-Type"] = "application/x-www-form-urlencoded"{{/isMultipart}}{{#isMultipart}}
   httpClient.headers["Content-Type"] = "multipart/form-data"{{/isMultipart}}{{/hasFormParams}}{{#hasHeaderParams}}{{#headerParams}}
   httpClient.headers["{{{baseName}}}"] = {{{paramName}}}{{#isArray}}.join(","){{/isArray}}{{/headerParams}}{{#description}} ## {{{.}}}{{/description}}{{/hasHeaderParams}}{{#hasQueryParams}}
-  let query_for_api_call = encodeQuery([{{#queryParams}}
+  let url_encoded_query_params = encodeQuery([{{#queryParams}}
     ("{{{baseName}}}", ${{{paramName}}}{{#isArray}}.join(","){{/isArray}}), # {{{description}}}{{/queryParams}}
   ]){{/hasQueryParams}}{{#hasFormParams}}{{^isMultipart}}
-  let query_for_api_call = encodeQuery([{{#formParams}}
+  let form_data = encodeQuery([{{#formParams}}
     ("{{{baseName}}}", ${{{paramName}}}{{#isArray}}.join(","){{/isArray}}), # {{{description}}}{{/formParams}}
   ]){{/isMultipart}}{{#isMultipart}}
-  let query_for_api_call = newMultipartData({
+  let multipart_data = newMultipartData({
 {{#formParams}}    "{{{baseName}}}": ${{{paramName}}}{{#isArray}}.join(","){{/isArray}}, # {{{description}}}
 {{/formParams}}
   }){{/isMultipart}}{{/hasFormParams}}{{#returnType}}
 
-  let response = httpClient.{{{httpMethod}}}(basepath & {{^pathParams}}"{{{path}}}"{{/pathParams}}{{#hasPathParams}}fmt"{{{path}}}"{{/hasPathParams}}{{#hasQueryParams}} & "?" & query_for_api_call{{/hasQueryParams}}{{#hasBodyParam}}{{#bodyParams}}, $(%{{{paramName}}}){{/bodyParams}}{{/hasBodyParam}}{{#hasFormParams}}, {{^isMultipart}}$query_for_api_call{{/isMultipart}}{{#isMultipart}}multipart=query_for_api_call{{/isMultipart}}{{/hasFormParams}})
+  let response = httpClient.{{{httpMethod}}}(basepath & {{^pathParams}}"{{{path}}}"{{/pathParams}}{{#hasPathParams}}fmt"{{{path}}}"{{/hasPathParams}}{{#hasQueryParams}} & "?" & url_encoded_query_params{{/hasQueryParams}}{{#hasBodyParam}}{{#bodyParams}}, $(%{{{paramName}}}){{/bodyParams}}{{/hasBodyParam}}{{#hasFormParams}}, {{^isMultipart}}$form_data{{/isMultipart}}{{#isMultipart}}multipart=multipart_data{{/isMultipart}}{{/hasFormParams}})
   constructResult[{{{returnType}}}](response){{/returnType}}{{^returnType}}
-  httpClient.{{{httpMethod}}}(basepath & {{^pathParams}}"{{{path}}}"{{/pathParams}}{{#hasPathParams}}fmt"{{{path}}}"{{/hasPathParams}}{{#hasQueryParams}} & "?" & query_for_api_call{{/hasQueryParams}}{{#hasBodyParam}}{{#bodyParams}}, $(%{{{paramName}}}){{/bodyParams}}{{/hasBodyParam}}{{#hasFormParams}}, {{^isMultipart}}$query_for_api_call{{/isMultipart}}{{#isMultipart}}multipart=query_for_api_call{{/isMultipart}}{{/hasFormParams}}){{/returnType}}
+  httpClient.{{{httpMethod}}}(basepath & {{^pathParams}}"{{{path}}}"{{/pathParams}}{{#hasPathParams}}fmt"{{{path}}}"{{/hasPathParams}}{{#hasQueryParams}} & "?" & url_encoded_query_params{{/hasQueryParams}}{{#hasBodyParam}}{{#bodyParams}}, $(%{{{paramName}}}){{/bodyParams}}{{/hasBodyParam}}{{#hasFormParams}}, {{^isMultipart}}$form_data{{/isMultipart}}{{#isMultipart}}multipart=multipart_data{{/isMultipart}}{{/hasFormParams}}){{/returnType}}
 
 {{/operation}}{{/operations}}

--- a/samples/client/petstore/nim/petstore/apis/api_pet.nim
+++ b/samples/client/petstore/nim/petstore/apis/api_pet.nim
@@ -55,21 +55,21 @@ proc deletePet*(httpClient: HttpClient, petId: int64, apiKey: string): Response 
 
 proc findPetsByStatus*(httpClient: HttpClient, status: seq[Status]): (Option[seq[Pet]], Response) =
   ## Finds Pets by status
-  let query_for_api_call = encodeQuery([
+  let url_encoded_query_params = encodeQuery([
     ("status", $status.join(",")), # Status values that need to be considered for filter
   ])
 
-  let response = httpClient.get(basepath & "/pet/findByStatus" & "?" & query_for_api_call)
+  let response = httpClient.get(basepath & "/pet/findByStatus" & "?" & url_encoded_query_params)
   constructResult[seq[Pet]](response)
 
 
 proc findPetsByTags*(httpClient: HttpClient, tags: seq[string]): (Option[seq[Pet]], Response) {.deprecated.} =
   ## Finds Pets by tags
-  let query_for_api_call = encodeQuery([
+  let url_encoded_query_params = encodeQuery([
     ("tags", $tags.join(",")), # Tags to filter by
   ])
 
-  let response = httpClient.get(basepath & "/pet/findByTags" & "?" & query_for_api_call)
+  let response = httpClient.get(basepath & "/pet/findByTags" & "?" & url_encoded_query_params)
   constructResult[seq[Pet]](response)
 
 
@@ -91,21 +91,21 @@ proc updatePet*(httpClient: HttpClient, pet: Pet): (Option[Pet], Response) =
 proc updatePetWithForm*(httpClient: HttpClient, petId: int64, name: string, status: string): Response =
   ## Updates a pet in the store with form data
   httpClient.headers["Content-Type"] = "application/x-www-form-urlencoded"
-  let query_for_api_call = encodeQuery([
+  let form_data = encodeQuery([
     ("name", $name), # Updated name of the pet
     ("status", $status), # Updated status of the pet
   ])
-  httpClient.post(basepath & fmt"/pet/{petId}", $query_for_api_call)
+  httpClient.post(basepath & fmt"/pet/{petId}", $form_data)
 
 
 proc uploadFile*(httpClient: HttpClient, petId: int64, additionalMetadata: string, file: string): (Option[ApiResponse], Response) =
   ## uploads an image
   httpClient.headers["Content-Type"] = "multipart/form-data"
-  let query_for_api_call = newMultipartData({
+  let multipart_data = newMultipartData({
     "additionalMetadata": $additionalMetadata, # Additional data to pass to server
     "file": $file, # file to upload
   })
 
-  let response = httpClient.post(basepath & fmt"/pet/{petId}/uploadImage", multipart=query_for_api_call)
+  let response = httpClient.post(basepath & fmt"/pet/{petId}/uploadImage", multipart=multipart_data)
   constructResult[ApiResponse](response)
 

--- a/samples/client/petstore/nim/petstore/apis/api_user.nim
+++ b/samples/client/petstore/nim/petstore/apis/api_user.nim
@@ -70,12 +70,12 @@ proc getUserByName*(httpClient: HttpClient, username: string): (Option[User], Re
 
 proc loginUser*(httpClient: HttpClient, username: string, password: string): (Option[string], Response) =
   ## Logs user into the system
-  let query_for_api_call = encodeQuery([
+  let url_encoded_query_params = encodeQuery([
     ("username", $username), # The user name for login
     ("password", $password), # The password for login in clear text
   ])
 
-  let response = httpClient.get(basepath & "/user/login" & "?" & query_for_api_call)
+  let response = httpClient.get(basepath & "/user/login" & "?" & url_encoded_query_params)
   constructResult[string](response)
 
 


### PR DESCRIPTION
Same parameter name declared multiple time in the same scope. => nim generated code does not compile.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
