### PR TITLE
fix(typescript-nestjs): handle query params serialization properly

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -137,7 +137,7 @@ export class {{classname}} {
             })
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}
-            queryParameters['{{baseName}}'] = {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']);
+            queryParameters.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']));
         {{/isCollectionFormatMulti}}
         }
         {{/isArray}}

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -176,7 +176,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (status) {
-            queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('status', status.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = {...this.defaultHeaders};
@@ -236,7 +236,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (tags) {
-            queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = {...this.defaultHeaders};

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -177,7 +177,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (status) {
-            queryParameters['status'] = status.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('status', status.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = {...this.defaultHeaders};
@@ -237,7 +237,7 @@ export class PetService {
 
         let queryParameters = new URLSearchParams();
         if (tags) {
-            queryParameters['tags'] = tags.join(COLLECTION_FORMATS['csv']);
+            queryParameters.append('tags', tags.join(COLLECTION_FORMATS['csv']));
         }
 
         let headers = {...this.defaultHeaders};


### PR DESCRIPTION
### **Fix: Properly Serialize Query Parameters in OpenAPI Generator for TypeScript NestJS**  

#### **Issue**  
The current template assigns query parameters using:  
```mustache
queryParameters['{{baseName}}'] = {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']);
```
However, this does not work with `URLSearchParams`, as it does not allow direct property assignment. Instead, it requires `.set()` or `.append()` to properly modify query parameters.

#### **Fix**  
Replace the assignment with:  
```mustache
queryParameters.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']));
```
This ensures that query parameters are correctly added and serialized in the request URL.