### PR TITLE
[java][Microprofile] add config options to disable usage of ApiExceptionMapper

### DIFF
--- a/docs/generators/java-microprofile.md
+++ b/docs/generators/java-microprofile.md
@@ -66,7 +66,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |licenseName|The name of the license| |Unlicense|
 |licenseUrl|The URL of the license| |http://unlicense.org|
 |microprofileFramework|Framework for microprofile. Possible values &quot;kumuluzee&quot;| |null|
+|microprofileGlobalExceptionMapper|Should ApiExceptionMapper be annotated with @Provider making it a global exception mapper| |true|
 |microprofileMutiny|Whether to use async types for microprofile (currently only Smallrye Mutiny is supported).| |null|
+|microprofileRegisterExceptionMapper|Should generated API Clients be annotated with @RegisterProvider(ApiExceptionMapper.class).| |true|
 |microprofileRestClientVersion|Version of MicroProfile Rest Client API.| |null|
 |modelPackage|package for generated models| |org.openapitools.client.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library. Not supported by `microprofile` library.| |true|

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -66,7 +66,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |licenseName|The name of the license| |Unlicense|
 |licenseUrl|The URL of the license| |http://unlicense.org|
 |microprofileFramework|Framework for microprofile. Possible values &quot;kumuluzee&quot;| |null|
+|microprofileGlobalExceptionMapper|Should ApiExceptionMapper be annotated with @Provider making it a global exception mapper| |true|
 |microprofileMutiny|Whether to use async types for microprofile (currently only Smallrye Mutiny is supported).| |null|
+|microprofileRegisterExceptionMapper|Should generated API Clients be annotated with @RegisterProvider(ApiExceptionMapper.class).| |true|
 |microprofileRestClientVersion|Version of MicroProfile Rest Client API.| |null|
 |modelPackage|package for generated models| |org.openapitools.client.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library. Not supported by `microprofile` library.| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -70,6 +70,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     public static final String CASE_INSENSITIVE_RESPONSE_HEADERS = "caseInsensitiveResponseHeaders";
     public static final String MICROPROFILE_FRAMEWORK = "microprofileFramework";
     public static final String MICROPROFILE_MUTINY = "microprofileMutiny";
+    public static final String MICROPROFILE_GLOBAL_EXCEPTION_MAPPER = "microprofileGlobalExceptionMapper";
+    public static final String MICROPROFILE_REGISTER_EXCEPTION_MAPPER = "microprofileRegisterExceptionMapper";
     public static final String USE_ABSTRACTION_FOR_FILES = "useAbstractionForFiles";
     public static final String DYNAMIC_OPERATIONS = "dynamicOperations";
     public static final String SUPPORT_STREAMING = "supportStreaming";
@@ -118,6 +120,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     @Setter protected String microprofileFramework = MICROPROFILE_DEFAULT;
     @Setter protected String microprofileRestClientVersion = MICROPROFILE_REST_CLIENT_DEFAULT_VERSION;
     @Setter protected boolean microprofileMutiny = false;
+    @Setter protected boolean microProfileGlobalExceptionMapper = true;
+    @Setter protected boolean microProfileRegisterExceptionMapper = true;
     @Setter protected String configKey = null;
     @Setter(AccessLevel.PRIVATE) protected boolean configKeyFromClassName = false;
 
@@ -226,6 +230,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(CASE_INSENSITIVE_RESPONSE_HEADERS, "Make API response's headers case-insensitive. Available on " + OKHTTP_GSON + ", " + JERSEY2 + " libraries"));
         cliOptions.add(CliOption.newString(MICROPROFILE_FRAMEWORK, "Framework for microprofile. Possible values \"kumuluzee\""));
         cliOptions.add(CliOption.newString(MICROPROFILE_MUTINY, "Whether to use async types for microprofile (currently only Smallrye Mutiny is supported)."));
+        cliOptions.add(CliOption.newString(MICROPROFILE_REGISTER_EXCEPTION_MAPPER, "Should generated API Clients be annotated with @RegisterProvider(ApiExceptionMapper.class).").defaultValue("true"));
+        cliOptions.add(CliOption.newString(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER, "Should ApiExceptionMapper be annotated with @Provider making it a global exception mapper").defaultValue("true"));
         cliOptions.add(CliOption.newBoolean(USE_ABSTRACTION_FOR_FILES, "Use alternative types instead of java.io.File to allow passing bytes without a file on disk. Available on resttemplate, webclient, restclient, libraries"));
         cliOptions.add(CliOption.newBoolean(DYNAMIC_OPERATIONS, "Generate operations dynamically at runtime from an OAS", this.dynamicOperations));
         cliOptions.add(CliOption.newBoolean(SUPPORT_STREAMING, "Support streaming endpoint (beta)", this.supportStreaming));
@@ -374,6 +380,17 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 //            this.setMicroprofileFramework(additionalProperties.get(MICROPROFILE_FRAMEWORK).toString());
         }
         convertPropertyToStringAndWriteBack(MICROPROFILE_FRAMEWORK, this::setMicroprofileFramework);
+
+        convertPropertyToBooleanAndWriteBack(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER, this::setMicroProfileGlobalExceptionMapper);
+        convertPropertyToBooleanAndWriteBack(MICROPROFILE_REGISTER_EXCEPTION_MAPPER, this::setMicroProfileRegisterExceptionMapper);
+
+        if (!additionalProperties.containsKey(MICROPROFILE_REGISTER_EXCEPTION_MAPPER)) {
+            additionalProperties.put(MICROPROFILE_REGISTER_EXCEPTION_MAPPER, true);
+        }
+
+        if (!additionalProperties.containsKey(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER)) {
+            additionalProperties.put(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER, true);
+        }
 
         convertPropertyToBooleanAndWriteBack(MICROPROFILE_MUTINY, this::setMicroprofileMutiny);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -384,13 +384,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         convertPropertyToBooleanAndWriteBack(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER, this::setMicroProfileGlobalExceptionMapper);
         convertPropertyToBooleanAndWriteBack(MICROPROFILE_REGISTER_EXCEPTION_MAPPER, this::setMicroProfileRegisterExceptionMapper);
 
-        if (!additionalProperties.containsKey(MICROPROFILE_REGISTER_EXCEPTION_MAPPER)) {
-            additionalProperties.put(MICROPROFILE_REGISTER_EXCEPTION_MAPPER, true);
-        }
-
-        if (!additionalProperties.containsKey(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER)) {
-            additionalProperties.put(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER, true);
-        }
+        additionalProperties.put(MICROPROFILE_REGISTER_EXCEPTION_MAPPER, microProfileRegisterExceptionMapper);
+        additionalProperties.put(MICROPROFILE_GLOBAL_EXCEPTION_MAPPER, microProfileGlobalExceptionMapper);
 
         convertPropertyToBooleanAndWriteBack(MICROPROFILE_MUTINY, this::setMicroprofileMutiny);
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api.mustache
@@ -24,7 +24,9 @@ import {{rootJavaEEPackage}}.validation.constraints.*;
 import {{rootJavaEEPackage}}.validation.Valid;
 {{/useBeanValidation}}
 
+{{#microprofileRegisterExceptionMapper}}
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
+{{/microprofileRegisterExceptionMapper}}
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 {{#appName}}
@@ -41,7 +43,9 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 {{^microprofileServer}}
 @RegisterRestClient{{#configKey}}(configKey="{{configKey}}"){{/configKey}}{{#configKeyFromClassName}}{{#operations}}(configKey="{{configKey}}"){{/operations}}{{/configKeyFromClassName}}
 {{/microprofileServer}}
+{{#microprofileRegisterExceptionMapper}}
 @RegisterProvider(ApiExceptionMapper.class)
+{{/microprofileRegisterExceptionMapper}}
 @Path("{{#useAnnotatedBasePath}}{{contextPath}}{{/useAnnotatedBasePath}}{{commonPath}}")
 public interface {{classname}}  {
 {{#operations}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api_exception_mapper.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/api_exception_mapper.mustache
@@ -3,10 +3,14 @@ package {{apiPackage}};
 
 import {{rootJavaEEPackage}}.ws.rs.core.MultivaluedMap;
 import {{rootJavaEEPackage}}.ws.rs.core.Response;
+{{#microprofileGlobalExceptionMapper}}
 import {{rootJavaEEPackage}}.ws.rs.ext.Provider;
+{{/microprofileGlobalExceptionMapper}}
 import org.eclipse.microprofile.rest.client.ext.ResponseExceptionMapper;
 
+{{#microprofileGlobalExceptionMapper}}
 @Provider
+{{/microprofileGlobalExceptionMapper}}
 public class ApiExceptionMapper
     implements ResponseExceptionMapper<ApiException> {
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes issue https://github.com/OpenAPITools/openapi-generator/issues/20751 made by @Munken 

It is made configurable whether generated Microprofile API clients should RegisterProvider ApiExceptionMapper.
It is also made configurable whether ApiExceptionMapper should be annotated with @Provider, making it a global exception mapper.

Both properties default to true in order to make this a non-breaking change.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg 
