### PR TITLE
[Nim] Fix compilation in case of schema with enum constraint with an enum value being not a valid nim identifier

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/NimClientCodegen.java
@@ -355,15 +355,21 @@ public class NimClientCodegen extends DefaultCodegen implements CodegenConfig {
         }
     }
 
+    private boolean isValidIdentifier(String identifier) {
+        //see https://nim-lang.org/docs/manual.html#lexical-analysis-identifiers-amp-keywords
+        return identifier.matches("^(?:[A-Z]|[a-z]|[\\x80-\\xff])(_?(?:[A-Z]|[a-z]|[\\x80-\\xff]|[0-9]))*$");
+    }
+
     @Override
     public String toEnumVarName(String name, String datatype) {
         name = name.replace(" ", "_");
         name = StringUtils.camelize(name);
 
-        if (name.matches("\\d.*")) { // starts with number
-            return "`" + name + "`";
-        } else {
+        // starts with number or contains any character not allowed,see
+        if (isValidIdentifier(name)) {
             return name;
+        } else {
+            return "`" + name + "`";
         }
     }
 


### PR DESCRIPTION
This is a fix for bug https://github.com/OpenAPITools/openapi-generator/issues/20779

In case of a schema with an enum constraint, nim code generation creates a nim objtect type enum with the enum values of this schema enum.
It must be valid identifier otherwise the code can not compile.
The fix is to 
1/ detect if it is a valid nim identifier, job done with the isValidIdentifier private function, using a pattern based on the definition of a nim valid identifier (see https://nim-lang.org/docs/manual.html#lexical-analysis-identifiers-amp-keywords)
2/ If it is not a valid identifier, we surround the identifier with backticks.


 
- [X ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@hokamoto 