### PR TITLE
[OCaml] Fix default optional list

### DIFF
--- a/modules/openapi-generator/src/main/resources/ocaml/model.mustache
+++ b/modules/openapi-generator/src/main/resources/ocaml/model.mustache
@@ -16,10 +16,30 @@ type t = {
     (* {{{.}}} *)
     {{/description}}
     {{#isEnum}}
-    {{{name}}}: {{^isMap}}Enums.{{/isMap}}{{{datatypeWithEnum}}}{{^isContainer}}{{#required}}{{#defaultValue}}[@default {{{.}}}]{{/defaultValue}}{{/required}}{{/isContainer}}{{^isContainer}}{{#required}}{{#isNullable}} option [@default {{#defaultValue}}Some({{{.}}}){{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}]{{/isNullable}}{{/required}}{{/isContainer}}{{^isContainer}}{{^required}} option [@default {{#defaultValue}}Some({{{.}}}){{/defaultValue}}{{^defaultValue}}None{{/defaultValue}}]{{/required}}{{/isContainer}}; [@key "{{{baseName}}}"]
+      {{{name}}}: {{^isMap}}Enums.{{/isMap}}{{{datatypeWithEnum}}}
+        {{^isContainer}}
+          {{#required}}
+            {{#defaultValue}}[@default {{{.}}}]{{/defaultValue}}
+            {{#isNullable}} option [@default
+              {{#defaultValue}}Some({{{.}}}){{/defaultValue}}
+                {{^defaultValue}}None{{/defaultValue}}
+            ]
+            {{/isNullable}}
+          {{/required}}
+          {{^required}} option [@default
+            {{#defaultValue}}Some({{{.}}}){{/defaultValue}}
+            {{^defaultValue}}None{{/defaultValue}}
+          ]
+          {{/required}}
+        {{/isContainer}}; [@key "{{{baseName}}}"]
     {{/isEnum}}
     {{^isEnum}}
-    {{{name}}}: {{{datatypeWithEnum}}}{{^isContainer}}{{#required}}{{#isNullable}} option{{/isNullable}}{{/required}}{{/isContainer}}{{^isContainer}}{{^required}} option [@default None]{{/required}}{{/isContainer}}; [@key "{{{baseName}}}"]
+      {{{name}}}: {{{datatypeWithEnum}}}
+        {{^isContainer}}
+          {{#required}}{{#isNullable}} option{{/isNullable}}{{/required}}
+          {{^required}} option [@default None]{{/required}}
+        {{/isContainer}}
+        ; [@key "{{{baseName}}}"]
     {{/isEnum}}
 {{/vars}}
 } [@@deriving yojson { strict = false }, show ];;

--- a/modules/openapi-generator/src/main/resources/ocaml/model.mustache
+++ b/modules/openapi-generator/src/main/resources/ocaml/model.mustache
@@ -39,6 +39,7 @@ type t = {
           {{#required}}{{#isNullable}} option{{/isNullable}}{{/required}}
           {{^required}} option [@default None]{{/required}}
         {{/isContainer}}
+        {{#isArray}}{{^required}} [@default []]{{/required}}{{/isArray}}
         ; [@key "{{{baseName}}}"]
     {{/isEnum}}
 {{/vars}}

--- a/samples/client/petstore/ocaml/src/models/api_response.ml
+++ b/samples/client/petstore/ocaml/src/models/api_response.ml
@@ -10,14 +10,17 @@ type t = {
       code: int32
           
            option [@default None]
+        
         ; [@key "code"]
       _type: string
           
            option [@default None]
+        
         ; [@key "type"]
       message: string
           
            option [@default None]
+        
         ; [@key "message"]
 } [@@deriving yojson { strict = false }, show ];;
 

--- a/samples/client/petstore/ocaml/src/models/api_response.ml
+++ b/samples/client/petstore/ocaml/src/models/api_response.ml
@@ -7,9 +7,18 @@
  *)
 
 type t = {
-    code: int32 option [@default None]; [@key "code"]
-    _type: string option [@default None]; [@key "type"]
-    message: string option [@default None]; [@key "message"]
+      code: int32
+          
+           option [@default None]
+        ; [@key "code"]
+      _type: string
+          
+           option [@default None]
+        ; [@key "type"]
+      message: string
+          
+           option [@default None]
+        ; [@key "message"]
 } [@@deriving yojson { strict = false }, show ];;
 
 (** Describes the result of uploading an image resource *)

--- a/samples/client/petstore/ocaml/src/models/category.ml
+++ b/samples/client/petstore/ocaml/src/models/category.ml
@@ -7,8 +7,14 @@
  *)
 
 type t = {
-    id: int64 option [@default None]; [@key "id"]
-    name: string option [@default None]; [@key "name"]
+      id: int64
+          
+           option [@default None]
+        ; [@key "id"]
+      name: string
+          
+           option [@default None]
+        ; [@key "name"]
 } [@@deriving yojson { strict = false }, show ];;
 
 (** A category for a pet *)

--- a/samples/client/petstore/ocaml/src/models/category.ml
+++ b/samples/client/petstore/ocaml/src/models/category.ml
@@ -10,10 +10,12 @@ type t = {
       id: int64
           
            option [@default None]
+        
         ; [@key "id"]
       name: string
           
            option [@default None]
+        
         ; [@key "name"]
 } [@@deriving yojson { strict = false }, show ];;
 

--- a/samples/client/petstore/ocaml/src/models/order.ml
+++ b/samples/client/petstore/ocaml/src/models/order.ml
@@ -10,18 +10,22 @@ type t = {
       id: int64
           
            option [@default None]
+        
         ; [@key "id"]
       pet_id: int64
           
            option [@default None]
+        
         ; [@key "petId"]
       quantity: int32
           
            option [@default None]
+        
         ; [@key "quantity"]
       ship_date: string
           
            option [@default None]
+        
         ; [@key "shipDate"]
     (* Order Status *)
       status: Enums.status
@@ -33,6 +37,7 @@ type t = {
       complete: bool
           
            option [@default None]
+        
         ; [@key "complete"]
 } [@@deriving yojson { strict = false }, show ];;
 

--- a/samples/client/petstore/ocaml/src/models/order.ml
+++ b/samples/client/petstore/ocaml/src/models/order.ml
@@ -7,13 +7,33 @@
  *)
 
 type t = {
-    id: int64 option [@default None]; [@key "id"]
-    pet_id: int64 option [@default None]; [@key "petId"]
-    quantity: int32 option [@default None]; [@key "quantity"]
-    ship_date: string option [@default None]; [@key "shipDate"]
+      id: int64
+          
+           option [@default None]
+        ; [@key "id"]
+      pet_id: int64
+          
+           option [@default None]
+        ; [@key "petId"]
+      quantity: int32
+          
+           option [@default None]
+        ; [@key "quantity"]
+      ship_date: string
+          
+           option [@default None]
+        ; [@key "shipDate"]
     (* Order Status *)
-    status: Enums.status option [@default None]; [@key "status"]
-    complete: bool option [@default None]; [@key "complete"]
+      status: Enums.status
+           option [@default
+            
+            None
+          ]
+        ; [@key "status"]
+      complete: bool
+          
+           option [@default None]
+        ; [@key "complete"]
 } [@@deriving yojson { strict = false }, show ];;
 
 (** An order for a pets from the pet store *)

--- a/samples/client/petstore/ocaml/src/models/pet.ml
+++ b/samples/client/petstore/ocaml/src/models/pet.ml
@@ -7,13 +7,29 @@
  *)
 
 type t = {
-    id: int64 option [@default None]; [@key "id"]
-    category: Category.t option [@default None]; [@key "category"]
-    name: string; [@key "name"]
-    photo_urls: string list; [@key "photoUrls"]
-    tags: Tag.t list; [@key "tags"]
+      id: int64
+          
+           option [@default None]
+        ; [@key "id"]
+      category: Category.t
+          
+           option [@default None]
+        ; [@key "category"]
+      name: string
+          
+          
+        ; [@key "name"]
+      photo_urls: string list
+        ; [@key "photoUrls"]
+      tags: Tag.t list
+        ; [@key "tags"]
     (* pet status in the store *)
-    status: Enums.pet_status option [@default None]; [@key "status"]
+      status: Enums.pet_status
+           option [@default
+            
+            None
+          ]
+        ; [@key "status"]
 } [@@deriving yojson { strict = false }, show ];;
 
 (** A pet for sale in the pet store *)

--- a/samples/client/petstore/ocaml/src/models/pet.ml
+++ b/samples/client/petstore/ocaml/src/models/pet.ml
@@ -10,18 +10,23 @@ type t = {
       id: int64
           
            option [@default None]
+        
         ; [@key "id"]
       category: Category.t
           
            option [@default None]
+        
         ; [@key "category"]
       name: string
           
           
+        
         ; [@key "name"]
       photo_urls: string list
+        
         ; [@key "photoUrls"]
       tags: Tag.t list
+         [@default []]
         ; [@key "tags"]
     (* pet status in the store *)
       status: Enums.pet_status

--- a/samples/client/petstore/ocaml/src/models/tag.ml
+++ b/samples/client/petstore/ocaml/src/models/tag.ml
@@ -10,10 +10,12 @@ type t = {
       id: int64
           
            option [@default None]
+        
         ; [@key "id"]
       name: string
           
            option [@default None]
+        
         ; [@key "name"]
 } [@@deriving yojson { strict = false }, show ];;
 

--- a/samples/client/petstore/ocaml/src/models/tag.ml
+++ b/samples/client/petstore/ocaml/src/models/tag.ml
@@ -7,8 +7,14 @@
  *)
 
 type t = {
-    id: int64 option [@default None]; [@key "id"]
-    name: string option [@default None]; [@key "name"]
+      id: int64
+          
+           option [@default None]
+        ; [@key "id"]
+      name: string
+          
+           option [@default None]
+        ; [@key "name"]
 } [@@deriving yojson { strict = false }, show ];;
 
 (** A tag for a pet *)

--- a/samples/client/petstore/ocaml/src/models/user.ml
+++ b/samples/client/petstore/ocaml/src/models/user.ml
@@ -10,35 +10,43 @@ type t = {
       id: int64
           
            option [@default None]
+        
         ; [@key "id"]
       username: string
           
            option [@default None]
+        
         ; [@key "username"]
       first_name: string
           
            option [@default None]
+        
         ; [@key "firstName"]
       last_name: string
           
            option [@default None]
+        
         ; [@key "lastName"]
       email: string
           
            option [@default None]
+        
         ; [@key "email"]
       password: string
           
            option [@default None]
+        
         ; [@key "password"]
       phone: string
           
            option [@default None]
+        
         ; [@key "phone"]
     (* User Status *)
       user_status: int32
           
            option [@default None]
+        
         ; [@key "userStatus"]
 } [@@deriving yojson { strict = false }, show ];;
 

--- a/samples/client/petstore/ocaml/src/models/user.ml
+++ b/samples/client/petstore/ocaml/src/models/user.ml
@@ -7,15 +7,39 @@
  *)
 
 type t = {
-    id: int64 option [@default None]; [@key "id"]
-    username: string option [@default None]; [@key "username"]
-    first_name: string option [@default None]; [@key "firstName"]
-    last_name: string option [@default None]; [@key "lastName"]
-    email: string option [@default None]; [@key "email"]
-    password: string option [@default None]; [@key "password"]
-    phone: string option [@default None]; [@key "phone"]
+      id: int64
+          
+           option [@default None]
+        ; [@key "id"]
+      username: string
+          
+           option [@default None]
+        ; [@key "username"]
+      first_name: string
+          
+           option [@default None]
+        ; [@key "firstName"]
+      last_name: string
+          
+           option [@default None]
+        ; [@key "lastName"]
+      email: string
+          
+           option [@default None]
+        ; [@key "email"]
+      password: string
+          
+           option [@default None]
+        ; [@key "password"]
+      phone: string
+          
+           option [@default None]
+        ; [@key "phone"]
     (* User Status *)
-    user_status: int32 option [@default None]; [@key "userStatus"]
+      user_status: int32
+          
+           option [@default None]
+        ; [@key "userStatus"]
 } [@@deriving yojson { strict = false }, show ];;
 
 (** A User who is purchasing from the pet store *)


### PR DESCRIPTION
Add a default value for non-required lists.
Also, indent the model template to make it easier to read and maintain.

I have kept 2 commits to easily review the cleanup vs the actual fix, and its impact on the sample petstore.

Closes https://github.com/OpenAPITools/openapi-generator/issues/20777

@cgensoul

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
