### PR TITLE
[JavaScript] Avoid undefined headers with skipDefaultUserAgent enabled

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/ApiClient.mustache
@@ -56,7 +56,6 @@ class ApiClient {
         }
 
         <={{ }}=>
-	{{^skipDefaultUserAgent}}
 	{{#emitJSDoc}}
 	/**
          * The default HTTP headers to be included for all API calls.
@@ -65,10 +64,11 @@ class ApiClient {
          */
 	{{/emitJSDoc}}
         this.defaultHeaders = {
+            {{^skipDefaultUserAgent}}
             'User-Agent': '{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{projectVersion}}/Javascript{{/httpUserAgent}}'
+            {{/skipDefaultUserAgent}}
         };
 
-	{{/skipDefaultUserAgent}}
         /**
          * The default HTTP timeout for all API calls.
          * @type {Number}

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -52,6 +52,14 @@ class ApiClient {
             'bearer_test': {type: 'bearer'}, // JWT
         }
 
+	/**
+         * The default HTTP headers to be included for all API calls.
+         * @type {Array.<String>}
+         * @default {}
+         */
+        this.defaultHeaders = {
+        };
+
         /**
          * The default HTTP timeout for all API calls.
          * @type {Number}


### PR DESCRIPTION
Prior to this commit, a JS client generated with skipDefaultUserAgent enabled results in a src/ApiClient.js file that doesn't define this.defaultHeaders. This breaks because this.defaultHeaders is later directly passed to a superagent request which expects an object and not undefined.

Fixes #20791.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Ping for NodeJS/Javascript	technical committee members as suggested in the checklist: @CodeNinjai, @frol, @cliffano.