### PR TITLE
Enhancement: Allow MergedSpecBuilder title, version and description to be configured to fix [#20822]

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -117,6 +117,24 @@ public class CodeGenMojo extends AbstractMojo {
     private String mergedFileName;
 
     /**
+     * Name that will appear in the info section of the merged spec
+     */
+    @Parameter(name = "mergedFileInfoName", property = "openapi.generator.maven.plugin.mergedFileInfoName", defaultValue = "merged spec")
+    private String mergedFileInfoName;
+
+    /**
+     * Description that will appear in the info section of the merged spec
+     */
+    @Parameter(name = "mergedFileInfoDescription", property = "openapi.generator.maven.plugin.mergedFileInfoDescription", defaultValue = "merged spec")
+    private String mergedFileInfoDescription;
+
+    /**
+     * Version that will appear in the info section of the merged spec
+     */
+    @Parameter(name = "mergedFileInfoVersion", property = "openapi.generator.maven.plugin.mergedFileInfoVersion", defaultValue = "1.0.0")
+    private String mergedFileInfoVersion;
+
+    /**
      * Git host, e.g. gitlab.com.
      */
     @Parameter(name = "gitHost", property = "openapi.generator.maven.plugin.gitHost")
@@ -545,7 +563,8 @@ public class CodeGenMojo extends AbstractMojo {
         }
 
         if (StringUtils.isNotBlank(inputSpecRootDirectory)) {
-            inputSpec = new MergedSpecBuilder(inputSpecRootDirectory, mergedFileName)
+            inputSpec = new MergedSpecBuilder(inputSpecRootDirectory, mergedFileName,
+                    mergedFileInfoName, mergedFileInfoDescription, mergedFileInfoVersion)
                     .buildMergedSpec();
             LOGGER.info("Merge input spec would be used - {}", inputSpec);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/MergedSpecBuilder.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/MergedSpecBuilder.java
@@ -25,10 +25,21 @@ public class MergedSpecBuilder {
 
     private final String inputSpecRootDirectory;
     private final String mergeFileName;
+    private final String mergedFileInfoName;
+    private final String mergedFileInfoDescription;
+    private final String mergedFileInfoVersion;
 
     public MergedSpecBuilder(final String rootDirectory, final String mergeFileName) {
+        this(rootDirectory, mergeFileName, "merged spec", "merged spec", "1.0.0");
+    }
+
+    public MergedSpecBuilder(final String rootDirectory, final String mergeFileName,
+                             final String mergedFileInfoName, final String mergedFileInfoDescription, final String mergedFileInfoVersion) {
         this.inputSpecRootDirectory = rootDirectory;
         this.mergeFileName = mergeFileName;
+        this.mergedFileInfoName = mergedFileInfoName;
+        this.mergedFileInfoDescription = mergedFileInfoDescription;
+        this.mergedFileInfoVersion = mergedFileInfoVersion;
     }
 
     public String buildMergedSpec() {
@@ -80,8 +91,8 @@ public class MergedSpecBuilder {
         return mergedFilePath.toString();
     }
 
-    private static Map<String, Object> generatedMergedSpec(String openapiVersion, List<SpecWithPaths> allPaths) {
-        Map<String, Object> spec = generateHeader(openapiVersion);
+    private Map<String, Object> generatedMergedSpec(String openapiVersion, List<SpecWithPaths> allPaths) {
+        Map<String, Object> spec = generateHeader(openapiVersion, mergedFileInfoName, mergedFileInfoDescription, mergedFileInfoVersion);
         Map<String, Object> paths = new HashMap<>();
         spec.put("paths", paths);
 
@@ -97,13 +108,13 @@ public class MergedSpecBuilder {
         return spec;
     }
 
-    private static Map<String, Object> generateHeader(String openapiVersion) {
+    private static Map<String, Object> generateHeader(String openapiVersion, String title, String description, String version) {
         Map<String, Object> map = new HashMap<>();
         map.put("openapi", openapiVersion);
         map.put("info", ImmutableMap.of(
-                "title", "merged spec",
-                "description", "merged spec",
-                "version", "1.0.0"
+                "title", title,
+                "description", description,
+                "version", version
         ));
         map.put("servers", Collections.singleton(
                 ImmutableMap.of("url", "http://localhost:8080")


### PR DESCRIPTION
Allow MergedSpecBuilder title, version and description to be configured to fix [#20822](https://github.com/OpenAPITools/openapi-generator/issues/20822)

I have made small changes to MErgedSpecBuilder and CodeGenMojo to allow users of the openapi-generator-maven-plugin to add a custom info header in merged open api files.

Before making this change, the fields in the info header were hard-coded as `title="merged spec"`, `description="merged spec"` and `version=1.0.0`

Now, through the use of 3 maven plugin tags, the setting of these fields by the user of the plugin is now possible. An example is provided below. With these changes, one can easily verify that the new plugin configuration is being adopted. The new info header values will appear in the open api file and any generated documentation too.

```
<configuration>
	<inputSpecRootDirectory>some-directory</inputSpecRootDirectory>
	<mergedFileName>openapi-file</mergedFileName>  <!-- Merged output file -->
	<mergedFileInfoName>My Info Name/Title</mergedFileInfoName>
	<mergedFileInfoDescription>My Description</mergedFileInfoDescription>
	<mergedFileInfoVersion>1.0.0</mergedFileInfoVersion>
	<generatorName>openapi-yaml</generatorName>  <!-- Change based on required language -->
</configuration>`
```
The default values remain the same as before. Old functionality is not impacted at all.

cc @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
