### PR TITLE
fix: #20826 Update urllib3 requirement for Python generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/README_onlypackage.mustache
+++ b/modules/openapi-generator/src/main/resources/python/README_onlypackage.mustache
@@ -26,7 +26,7 @@ This python library package is generated without supporting files like setup.py 
 
 To be able to use it, you will need these dependencies in your own package that uses this library:
 
-* urllib3 >= 1.25.3, < 3.0.0
+* urllib3 >= 2.1.0, < 3.0.0
 * python-dateutil >= 2.8.2
 {{#asyncio}}
 * aiohttp >= 3.8.4

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -12,7 +12,7 @@ include = ["{{packageName}}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 {{#asyncio}}
 aiohttp = ">= 3.8.4"

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 {{#asyncio}}
 aiohttp >= 3.8.4

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -14,7 +14,7 @@ NAME = "{{{projectName}}}"
 VERSION = "{{packageVersion}}"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
 {{#asyncio}}
     "aiohttp >= 3.8.4",

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -12,7 +12,7 @@ include = ["openapi_client/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/setup.py
@@ -25,7 +25,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -12,7 +12,7 @@ include = ["openapi_client/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 pydantic = ">= 2"
 typing-extensions = ">= 4.7.1"

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -25,7 +25,7 @@ NAME = "openapi-client"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pydantic >= 2",
     "typing-extensions >= 4.7.1",

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -12,7 +12,7 @@ include = ["petstore_api/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 aiohttp >= 3.8.4
 aiohttp-retry >= 2.8.3

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -24,7 +24,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "aiohttp >= 3.8.4",
     "aiohttp-retry >= 2.8.3",

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -12,7 +12,7 @@ include = ["petstore_api/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3, < 3.0.0"
+urllib3 = ">= 2.1.0, < 3.0.0"
 python-dateutil = ">= 2.8.2"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -1,4 +1,4 @@
-urllib3 >= 1.25.3, < 3.0.0
+urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 pem >= 19.3.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -24,7 +24,7 @@ NAME = "petstore-api"
 VERSION = "1.0.0"
 PYTHON_REQUIRES = ">= 3.8"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 3.0.0",
+    "urllib3 >= 2.1.0, < 3.0.0",
     "python-dateutil >= 2.8.2",
     "pem >= 19.3.0",
     "pycryptodome >= 3.9.0",

--- a/samples/openapi3/client/petstore/python/tests/test_api_exception.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_exception.py
@@ -14,15 +14,20 @@ import sys
 import unittest
 
 import petstore_api
+from petstore_api import Configuration
 from petstore_api.rest import ApiException
 
 from .util import id_gen
 
+HOST = 'http://localhost/v2'
 
 class ApiExceptionTests(unittest.TestCase):
 
     def setUp(self):
-        self.api_client = petstore_api.ApiClient()
+        config = Configuration()
+        config.host = HOST
+        config.access_token = 'ACCESS_TOKEN'
+        self.api_client = petstore_api.ApiClient(config)
         self.pet_api = petstore_api.PetApi(self.api_client)
         self.setUpModels()
 


### PR DESCRIPTION
This PR updates urllib3's requirement for the Python generator. As described in #20826, older versions of the library were incompatible with the new `ca_cert_data` parameter added in PR #20697.

Fixes #20826.

---
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
