### PR TITLE
Add support for normalizing bearerAuth

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -646,3 +646,27 @@ Example:
 ```
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml -o /tmp/java-okhttp/ --openapi-normalizer FIX_DUPLICATED_OPERATIONID=true
 ```
+
+- `SET_BEARER_AUTH_FOR_NAME`: When set to the name of an openapi 2.0 securityDefinition, that securityDefinition will be converted to the openapi 3.0 bearerAuth securityScheme.
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/2_0/globalSecurity.json -o /tmp/java-okhttp/ --openapi-normalizer SET_BEARER_AUTH_FOR_NAME=api_key
+```
+Transforms this securityDefinition:
+```
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header"
+    },
+  },
+```
+Into this securityScheme:
+```
+  securitySchemes:
+    api_key:
+      scheme: bearer
+      type: http
+```

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.annotations.Test;
 
@@ -941,5 +942,27 @@ public class OpenAPINormalizerTest {
         ApiResponse apiResponse2 = openAPI.getComponents().getResponses().get("JustAnotherResponse");
         assertEquals(((Schema) apiResponse2.getContent().get("application/json").getSchema().getProperties().get("uuid")).getType(), "integer");
         assertEquals(((Schema) apiResponse2.getContent().get("application/json").getSchema().getProperties().get("label")).getType(), "string");
+    }
+
+    @Test
+    public void testOpenAPINormalizerBearerAuthSpec() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/2_0/globalSecurity.json");
+        SecurityScheme scheme = openAPI.getComponents().getSecuritySchemes().get("api_key");
+        assertEquals(scheme.getType(), SecurityScheme.Type.APIKEY);
+        assertEquals(scheme.getScheme(), null);
+        assertEquals(scheme.getName(), "api_key");
+        assertEquals(scheme.getIn(), SecurityScheme.In.HEADER);
+
+        Map<String, String> inputRules = Map.of(
+                "SET_BEARER_AUTH_FOR_NAME", "api_key"
+        );
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, inputRules);
+        openAPINormalizer.normalize();
+
+        SecurityScheme scheme2 = openAPI.getComponents().getSecuritySchemes().get("api_key");
+        assertEquals(scheme.getType(), SecurityScheme.Type.HTTP);
+        assertEquals(scheme.getScheme(), "bearer");
+        assertEquals(scheme.getName(), null);
+        assertEquals(scheme.getIn(), null);
     }
 }


### PR DESCRIPTION
Putting this up to help clarify my feature request in https://github.com/OpenAPITools/openapi-generator/issues/20842. I wanted to see if something like this would be considered. If so, I will proceed and add unit tests and documentation to get the PR ready for review. If not, I'll go the direction of putting this into a user defined template instead.

The openapi 2.0 spec did not support bearer authentication but it was added in openapi 3.0. In order to support client generation that includes support for bearerAuth, this change adds a new feature to the OpenapiNormalizer so that it can be configured to look for a specific securityDefinition name and convert it to bearerAuth.

Example:

openapi-generator-cli config file includes:
```
openapiNormalizer:
  DETECT_BEARER_AUTH_FROM_NAME: bearerAuth
```

Original spec includes:
```
  "securityDefinitions": {
    "basicAuth": {
      "type": "basic"
    },
    "bearerAuth": {
      "type": "apiKey",
      "name": "bearer",
      "in": "header"
    }
  },
```

Generated spec has:
```
components:
  securitySchemes:
    basicAuth:
      scheme: basic
      type: http
    bearerAuth:
      scheme: bearer
      type: http
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
