### PR TITLE
[Rust Server] Bump up env_logger to 0.11

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -154,7 +154,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -84,7 +84,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -74,7 +74,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -79,8 +79,6 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }
-audit = "0.7.3"
-cargo-audit = "0.21.2"
 
 [dev-dependencies]
 clap = "2.25"

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -79,10 +79,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 
 # Bearer authentication
 jsonwebtoken = { version = "9.3.0", optional = false }
+audit = "0.7.3"
+cargo-audit = "0.21.2"
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -74,7 +74,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -88,7 +88,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -74,7 +74,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -74,7 +74,7 @@ jsonwebtoken = { version = "9.3.0", optional = false }
 
 [dev-dependencies]
 clap = "2.25"
-env_logger = "0.7"
+env_logger = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 native-tls = "0.2"
 


### PR DESCRIPTION
Bump up env_logger dependency for Rust Server to 0.11.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

 	@frol @farcaller @richardwhiuk @paladinzh @jacob-pro
