### PR TITLE
Features/multi-content-type closes #20871

### DIFF
--- a/modules/openapi-generator-gradle-plugin/gradle.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle.properties
@@ -10,3 +10,8 @@ signing.keyId=unset
 signing.password=unset
 # signing.secretKeyRingFile=unset
 # END placeholders
+
+systemProp.http.proxyHost=s4de3qsydie.gdc-esn01.t-systems.com
+systemProp.http.proxyPort=3128
+systemProp.https.proxyHost=s4de3qsydie.gdc-esn01.t-systems.com
+systemProp.https.proxyPort=3128

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -128,7 +128,7 @@ public interface CodegenConfig {
 
     CodegenModel fromModel(String name, Schema schema);
 
-    CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, List<Server> servers);
+    CodegenOperation fromOperation(String resourcePath, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers);
 
     List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> schemas);
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConfig.java
@@ -130,6 +130,11 @@ public interface CodegenConfig {
 
     CodegenOperation fromOperation(String resourcePath, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers);
 
+    // Overloaded version without contentTypeIndex
+      default CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, List<Server> servers) {
+        return fromOperation(resourcePath, httpMethod, null, operation, servers);
+    }
+
     List<CodegenSecurity> fromSecurity(Map<String, SecurityScheme> schemas);
 
     List<CodegenServer> fromServers(List<Server> servers);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4690,7 +4690,7 @@ public class DefaultCodegen implements CodegenConfig {
                     ((!(this instanceof RustAxumServerCodegen) && contentType.startsWith("application/x-www-form-urlencoded")) ||
                             contentType.startsWith("multipart"))) {
                 // process form parameters
-                formParams = fromRequestBodyToFormParameters(requestBody, imports);
+                formParams = fromRequestBodyToFormParameters(requestBody, imports, contentTypeIndex);
                 op.isMultipart = contentType.startsWith("multipart");
                 for (CodegenParameter cp : formParams) {
                     setParameterEncodingValues(cp, requestBody.getContent().get(contentType));
@@ -7189,10 +7189,10 @@ public class DefaultCodegen implements CodegenConfig {
         return null;
     }
 
-    public List<CodegenParameter> fromRequestBodyToFormParameters(RequestBody body, Set<String> imports) {
+    public List<CodegenParameter> fromRequestBodyToFormParameters(RequestBody body, Set<String> imports, int ContentTypeIndex) {
         List<CodegenParameter> parameters = new ArrayList<>();
         LOGGER.debug("debugging fromRequestBodyToFormParameters= {}", body);
-        Schema schema = ModelUtils.getSchemaFromRequestBody(body);
+        Schema schema = ModelUtils.getSchemaFromRequestBody(body, ContentTypeIndex);
         schema = ModelUtils.getReferencedSchema(this.openAPI, schema);
 
         Schema original = null;
@@ -7251,6 +7251,11 @@ public class DefaultCodegen implements CodegenConfig {
 
         return parameters;
     }
+
+    public List<CodegenParameter> fromRequestBodyToFormParameters(RequestBody body, Set<String> imports) {
+        return fromRequestBodyToFormParameters(body, imports, 0);
+    }
+    
 
     public CodegenParameter fromFormProperty(String name, Schema propertySchema, Set<String> imports) {
         CodegenParameter codegenParameter = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4712,7 +4712,7 @@ public class DefaultCodegen implements CodegenConfig {
                     bodyParameterName = (String) requestBody.getExtensions().get("x-codegen-request-body-name");
                 }
 
-                bodyParam = fromRequestBody(requestBody, imports, bodyParameterName);
+                bodyParam = fromRequestBody(requestBody, imports, bodyParameterName, contentTypeIndex);
 
                 if (bodyParam != null) {
                     bodyParam.description = escapeText(requestBody.getDescription());
@@ -7831,7 +7831,8 @@ public class DefaultCodegen implements CodegenConfig {
         return cmtContent;
     }
 
-    public CodegenParameter fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName) {
+    public CodegenParameter fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName,
+                                          Integer contentTypeIndex) {
         if (body == null) {
             LOGGER.error("body in fromRequestBody cannot be null!");
             throw new RuntimeException("body in fromRequestBody cannot be null!");
@@ -7848,7 +7849,7 @@ public class DefaultCodegen implements CodegenConfig {
 
         String name = null;
         LOGGER.debug("Request body = {}", body);
-        Schema schema = ModelUtils.getSchemaFromRequestBody(body);
+        Schema schema = ModelUtils.getSchemaFromRequestBody(body, contentTypeIndex);
         if (schema == null) {
             LOGGER.error("Schema cannot be null in the request body: {}", body);
             return null;
@@ -7979,6 +7980,10 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         return codegenParameter;
+    }
+
+    public CodegenParameter fromRequestBody(RequestBody body, Set<String> imports, String bodyParameterName) {
+        return fromRequestBody(body, imports, bodyParameterName, 0);
     }
 
     protected void addRequiredVarsMap(Schema schema, IJsonSchemaValidationProperties property) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4514,6 +4514,7 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          int contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
         LOGGER.debug("fromOperation => operation: {}", operation);
@@ -4681,7 +4682,7 @@ public class DefaultCodegen implements CodegenConfig {
         CodegenParameter bodyParam = null;
         RequestBody requestBody = ModelUtils.getReferencedRequestBody(this.openAPI, operation.getRequestBody());
         if (requestBody != null) {
-            String contentType = getContentType(requestBody);
+            String contentType = getContentType(requestBody, contentTypeIndex);
             if (contentType != null) {
                 contentType = contentType.toLowerCase(Locale.ROOT);
             }
@@ -6991,12 +6992,12 @@ public class DefaultCodegen implements CodegenConfig {
         additionalProperties.put(propertyKey, value);
     }
 
-    protected String getContentType(RequestBody requestBody) {
-        if (requestBody == null || requestBody.getContent() == null || requestBody.getContent().isEmpty()) {
+    protected String getContentType(RequestBody requestBody, int contentTypeIndex) {
+        if (requestBody == null || requestBody.getContent() == null || requestBody.getContent().size() < contentTypeIndex + 1) {
             LOGGER.debug("Cannot determine the content type. Returning null.");
             return null;
         }
-        return new ArrayList<>(requestBody.getContent().keySet()).get(0);
+        return new ArrayList<>(requestBody.getContent().keySet()).get(contentTypeIndex);
     }
 
     private void setOauth2Info(CodegenSecurity codegenSecurity, OAuthFlow flow) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4514,7 +4514,7 @@ public class DefaultCodegen implements CodegenConfig {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
-                                          int contentTypeIndex,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
         LOGGER.debug("fromOperation => operation: {}", operation);
@@ -5103,7 +5103,7 @@ public class DefaultCodegen implements CodegenConfig {
                             // distinguish between normal operations and callback requests
                             op.getExtensions().put("x-callback-request", true);
 
-                            CodegenOperation co = fromOperation(expression, method, op, servers);
+                            CodegenOperation co = fromOperation(expression, method, 0, op, servers);
                             if (genId) {
                                 co.operationIdOriginal = null;
                                 // legacy (see `fromOperation()`)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -1574,16 +1574,16 @@ public class DefaultGenerator implements Generator {
                             httpMethod, resourcePath, operation.getOperationId());
                 } else {
 
-                    ///
+                    // get content types list - if available
                     List<String> contentTypes = new ArrayList<>(List.of("dummy"));
                     RequestBody requestBody = ModelUtils.getReferencedRequestBody(this.openAPI, operation.getRequestBody());
                     if (requestBody != null) {
                         contentTypes = new ArrayList<>(requestBody.getContent().keySet());
                     }
 
+                    // iterate through content types
                     for (int contentTypeIndex = 0; contentTypeIndex < contentTypes.size(); contentTypeIndex++) {
-                    
-                    ///                     
+                                                           
                         CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, contentTypeIndex, operation, path.getServers());
                         codegenOperation.tags = new ArrayList<>(tags);
                         config.addOperationToGroup(config.sanitizeTag(tag.getName()), resourcePath, operation, codegenOperation, operations);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractAdaCodegen.java
@@ -577,8 +577,8 @@ abstract public class AbstractAdaCodegen extends DefaultCodegen implements Codeg
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         // Add a vendor extension attribute that provides a map of auth methods and the scopes
         // which are expected by the operation.  This map is then used by postProcessOperationsWithModels

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractApexCodegen.java
@@ -555,10 +555,10 @@ public abstract class AbstractApexCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
 
         CodegenOperation op = super.fromOperation(
-                path, httpMethod, operation, null);
+                path, httpMethod, contentTypeIndex, operation, null);
 
         if (op.getHasExamples()) {
             // prepare examples for Apex test classes

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -619,8 +619,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        final CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        final CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         for (CodegenResponse r : op.responses) {
             // By default, only set types are automatically added to operation imports, not sure why.
             // Add all container type imports here, by default 'dart:core' imports are skipped

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2083,8 +2083,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         op.path = sanitizePath(op.path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
@@ -543,9 +543,10 @@ public abstract class AbstractJuliaCodegen extends DefaultCodegen {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         // collect all reserved names
         HashSet<String> reservedNames = new HashSet<String>();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/BashClientCodegen.java
@@ -590,10 +590,10 @@ public class BashClientCodegen extends DefaultCodegen implements CodegenConfig {
 
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod,
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex,
                                           Operation operation, List<Server> servers) {
         Map<String, Schema> definitions = ModelUtils.getSchemas(this.openAPI);
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         /**
          * Check if the operation has a Bash codegen specific description

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -947,9 +947,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         if (this.operationParameterSorting == SortingMethod.ALPHABETICAL) {
             Collections.sort(op.allParams, parameterComparatorByName);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppPistacheServerCodegen.java
@@ -290,8 +290,8 @@ public class CppPistacheServerCodegen extends AbstractCppCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse apiResponse = findMethodResponse(operation.getResponses());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -295,8 +295,8 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod,Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         if (operation.getResponses() != null && !operation.getResponses().isEmpty()) {
             ApiResponse methodResponse = findMethodResponse(operation.getResponses());

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -507,8 +507,8 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
 
     @Override
-    public CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(resourcePath, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String resourcePath, String httpMethod,Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(resourcePath, httpMethod, contentTypeIndex, operation, servers);
 
         List<String> path = pathToServantRoute(op.path, op.pathParams);
         List<String> type = pathToClientType(op.path, op.pathParams);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellYesodServerCodegen.java
@@ -388,8 +388,8 @@ public class HaskellYesodServerCodegen extends DefaultCodegen implements Codegen
     }
 
     @Override
-    public CodegenOperation fromOperation(String resourcePath, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(resourcePath, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String resourcePath, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(resourcePath, httpMethod, contentTypeIndex, operation, servers);
 
         String path = pathToYesodPath(op.path, op.pathParams);
         String resource = pathToYesodResource(op.path, op.pathParams);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -280,8 +280,8 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod,Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         // We use two templates, one for the API interface and one for the impl class.
         // Add to the normal imports for this operation only those imports used in both
         // the API and the impl. Create a vendor extension on the operation to record the

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -272,8 +272,8 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         op.allParams.forEach(p -> p.vendorExtensions.put(X_IS_MULTIPART_FORM_PARAM, op.isMultipart && p.isFormParam));
         op.vendorExtensions.put(X_HAS_RETURN_TYPE, op.returnType != null && !op.returnType.equals("void"));

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
@@ -281,8 +281,8 @@ public class JavaHelidonServerCodegen extends JavaHelidonCommonCodegen {
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         if (HELIDON_SE.equals(getLibrary())) {
             if (isJackson()) {
                 codegenOperation.imports.add("ObjectMapper");

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaVertXServerCodegen.java
@@ -224,9 +224,9 @@ public class JavaVertXServerCodegen extends AbstractJavaCodegen {
 
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
         CodegenOperation codegenOperation =
-                super.fromOperation(path, httpMethod, operation, servers);
+                super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         codegenOperation.imports.add("MainApiException");
         return codegenOperation;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/K6ClientCodegen.java
@@ -528,7 +528,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
 
                 // optionally group and order operations - see `X_OPERATION_GROUPING` K6 vendor
                 // extension
-                final CodegenOperation cgOperation = super.fromOperation(path, method.name(), operation, null);
+                final CodegenOperation cgOperation = super.fromOperation(path, method.name(),0, operation, null);
                 Optional<OperationGrouping> operationGrouping = extractOperationGrouping(cgOperation);
                 if (operationGrouping.isPresent()) {
                     groupName = operationGrouping.get().groupName;
@@ -932,7 +932,7 @@ public class K6ClientCodegen extends DefaultCodegen implements CodegenConfig {
 
                 final PathItem.HttpMethod method = methodOperation.getKey();
                 final Operation operation = methodOperation.getValue();
-                final CodegenOperation cgOperation = super.fromOperation(path, method.name(), operation, null);
+                final CodegenOperation cgOperation = super.fromOperation(path, method.name(),0, operation, null);
 
                 if (cgOperation.getHasVendorExtensions()
                         && cgOperation.vendorExtensions.containsKey(X_OPERATION_DATAEXTRACT)

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpDataTransferClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpDataTransferClientCodegen.java
@@ -193,7 +193,7 @@ public class PhpDataTransferClientCodegen extends AbstractPhpCodegen {
     }
 
     @Override
-    protected String getContentType(RequestBody requestBody) {
+    protected String getContentType(RequestBody requestBody, int contentTypeIndex) {
         //Awfully nasty workaround to skip formParams generation
         return null;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpFlightServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpFlightServerCodegen.java
@@ -303,9 +303,10 @@ public class PhpFlightServerCodegen extends AbstractPhpCodegen {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         op.path = encodePath(path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSlim4ServerCodegen.java
@@ -360,9 +360,10 @@ public class PhpSlim4ServerCodegen extends AbstractPhpCodegen {
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         op.path = encodePath(path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -425,8 +425,8 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         String underscoredOperationId = underscore(op.operationId);
         op.vendorExtensions.put("x-operation-id", underscoredOperationId);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -440,9 +440,9 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
         Map<String, Schema> definitions = ModelUtils.getSchemas(this.openAPI);
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         String pathFormatString = op.path;
         for (CodegenParameter param : op.pathParams) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaAkkaHttpServerCodegen.java
@@ -294,8 +294,8 @@ public class ScalaAkkaHttpServerCodegen extends AbstractScalaCodegen implements 
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         addPathMatcher(codegenOperation);
         return codegenOperation;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sClientCodegen.java
@@ -397,9 +397,10 @@ public class ScalaHttp4sClientCodegen extends AbstractScalaCodegen implements Co
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         op.path = encodePath(path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttp4ClientCodegen.java
@@ -186,9 +186,10 @@ public class ScalaSttp4ClientCodegen extends AbstractScalaCodegen implements Cod
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         op.path = encodePath(path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaSttpClientCodegen.java
@@ -202,9 +202,10 @@ public class ScalaSttpClientCodegen extends AbstractScalaCodegen implements Code
     @Override
     public CodegenOperation fromOperation(String path,
                                           String httpMethod,
+                                          Integer contentTypeIndex,
                                           Operation operation,
                                           List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation op = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         op.path = encodePath(path);
         return op;
     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -986,7 +986,7 @@ public class SpringCodegen extends AbstractJavaCodegen
      * templates.
      */
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
+    public CodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
 
         // add Pageable import only if x-spring-paginated explicitly used
         // this allows to use a custom Pageable schema without importing Spring Pageable.
@@ -996,7 +996,7 @@ public class SpringCodegen extends AbstractJavaCodegen
 
         Set<String> provideArgsClassSet = reformatProvideArgsParams(operation);
 
-        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, operation, servers);
+        CodegenOperation codegenOperation = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
 
         // add org.springframework.format.annotation.DateTimeFormat when needed
         codegenOperation.allParams.stream().filter(p -> p.isDate || p.isDateTime).findFirst()

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
@@ -200,8 +200,8 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
     }
 
     @Override
-    public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+    public CodegenOperation fromOperation(String path, String httpMethod,Integer ContentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation op = super.fromOperation(path, httpMethod,ContentTypeIndex, operation, servers);
         if (op.returnType != null) {
             op.returnType = normalizeType(op.returnType);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -565,8 +565,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     }
 
     @Override
-    public ExtendedCodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
-        CodegenOperation superOp = super.fromOperation(path, httpMethod, operation, servers);
+    public ExtendedCodegenOperation fromOperation(String path, String httpMethod, Integer contentTypeIndex, Operation operation, List<Server> servers) {
+        CodegenOperation superOp = super.fromOperation(path, httpMethod, contentTypeIndex, operation, servers);
         ExtendedCodegenOperation op = new ExtendedCodegenOperation(superOp);
 
         if (this.getSagasAndRecords()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -71,7 +71,7 @@ public class DefaultCodegenTest {
         final OpenAPI openApi = TestUtils.parseFlattenSpec("src/test/resources/3_0/additional-properties-deeply-nested.yaml");
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/ping");
-        CodegenOperation operation = codegen.fromOperation("/ping", "post", path.getPost(), path.getServers());
+        CodegenOperation operation = codegen.fromOperation("/ping", "post",0, path.getPost(), path.getServers());
         Assertions.assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("Person")).size(), 1);
     }
 
@@ -81,7 +81,7 @@ public class DefaultCodegenTest {
         final OpenAPI openApi = TestUtils.parseFlattenSpec("src/test/resources/3_0/optionalResponse.yaml");
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/api/Users/{userId}");
-        CodegenOperation operation = codegen.fromOperation("/api/Users/{userId}", "get", path.getGet(), path.getServers());
+        CodegenOperation operation = codegen.fromOperation("/api/Users/{userId}", "get",0, path.getGet(), path.getServers());
         Assertions.assertTrue(operation.isResponseOptional);
     }
 
@@ -91,7 +91,7 @@ public class DefaultCodegenTest {
         final OpenAPI openApi = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_12445.yaml");
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/pets/petType/{type}");
-        CodegenOperation operation = codegen.fromOperation("/pets/petType/{type}", "get", path.getGet(), path.getServers());
+        CodegenOperation operation = codegen.fromOperation("/pets/petType/{type}", "get",0, path.getGet(), path.getServers());
         Assertions.assertEquals(Sets.intersection(operation.imports, Sets.newHashSet("PetByType")).size(), 1);
     }
 
@@ -158,7 +158,7 @@ public class DefaultCodegenTest {
         Assertions.assertEquals(createProducesInfo.size(), 0);
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
-        CodegenOperation coCreate = codegen.fromOperation("somepath", "post", createOperation, null);
+        CodegenOperation coCreate = codegen.fromOperation("somepath", "post",0, createOperation, null);
         Assertions.assertTrue(coCreate.hasConsumes);
         Assertions.assertEquals(coCreate.consumes.size(), 2);
         Assertions.assertFalse(coCreate.hasProduces);
@@ -173,7 +173,7 @@ public class DefaultCodegenTest {
         Assertions.assertEquals(updateProducesInfo.size(), 1);
         Assertions.assertTrue(updateProducesInfo.contains("application/xml"), "contains 'application/xml'");
 
-        CodegenOperation coUpdate = codegen.fromOperation("somepath", "post", updateOperationWithRef, null);
+        CodegenOperation coUpdate = codegen.fromOperation("somepath", "post",0, updateOperationWithRef, null);
         Assertions.assertTrue(coUpdate.hasConsumes);
         Assertions.assertEquals(coUpdate.consumes.size(), 1);
         Assertions.assertEquals(coUpdate.consumes.get(0).get("mediaType"), "application/json");
@@ -189,19 +189,19 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation textOperation = openAPI.getPaths().get("/ping/text").getGet();
-        CodegenOperation coText = codegen.fromOperation("/ping/text", "get", textOperation, null);
+        CodegenOperation coText = codegen.fromOperation("/ping/text", "get",0, textOperation, null);
         Assertions.assertTrue(coText.hasProduces);
         Assertions.assertEquals(coText.produces.size(), 1);
         Assertions.assertEquals(coText.produces.get(0).get("mediaType"), "text/plain");
 
         Operation jsonOperation = openAPI.getPaths().get("/ping/json").getGet();
-        CodegenOperation coJson = codegen.fromOperation("/ping/json", "get", jsonOperation, null);
+        CodegenOperation coJson = codegen.fromOperation("/ping/json", "get",0, jsonOperation, null);
         Assertions.assertTrue(coJson.hasProduces);
         Assertions.assertEquals(coJson.produces.size(), 1);
         Assertions.assertEquals(coJson.produces.get(0).get("mediaType"), "application/json");
 
         Operation issue443Operation = openAPI.getPaths().get("/other/issue443").getGet();
-        CodegenOperation coIssue443 = codegen.fromOperation("/other/issue443", "get", issue443Operation, null);
+        CodegenOperation coIssue443 = codegen.fromOperation("/other/issue443", "get",0, issue443Operation, null);
         Assertions.assertTrue(coIssue443.hasProduces);
         Assertions.assertEquals(coIssue443.produces.size(), 2);
         Assertions.assertEquals(coIssue443.produces.get(0).get("mediaType"), "application/json");
@@ -599,7 +599,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation operation = openAPI.getPaths().get("/test").getGet();
-        CodegenOperation co = codegen.fromOperation("/test", "get", operation, null);
+        CodegenOperation co = codegen.fromOperation("/test", "get",0, operation, null);
 
         Assertions.assertEquals(co.produces.size(), 1);
         Assertions.assertEquals(co.produces.get(0).get("mediaType"), "application/json");
@@ -616,7 +616,7 @@ public class DefaultCodegenTest {
 
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
-        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
+        CodegenOperation co = codegen.fromOperation("/some/path", "get",0, operation, null);
         Assertions.assertEquals(co.path, "/some/path");
         Assertions.assertEquals(co.allParams.size(), 2);
         List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
@@ -633,7 +633,7 @@ public class DefaultCodegenTest {
         DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
         Operation operation = openAPI.getPaths().get("/form-param-poc/{id}").getPut();
-        CodegenOperation co = codegen.fromOperation("/form-param-poc/{id}", "put", operation, null);
+        CodegenOperation co = codegen.fromOperation("/form-param-poc/{id}", "put",0, operation, null);
         Assertions.assertEquals(co.path, "/form-param-poc/{id}");
         Assertions.assertEquals(co.allParams.size(), 2);
         List<String> allParamsNames = co.allParams.stream().map(p -> p.paramName).collect(Collectors.toList());
@@ -1052,7 +1052,7 @@ public class DefaultCodegenTest {
         String path = "/example5/multiple_responses";
 
         Operation operation = openAPI.getPaths().get(path).getGet();
-        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET",0, operation, null);
         List<Map<String, String>> examples = codegenOperation.examples;
 
         Assertions.assertEquals(examples.size(), 4);
@@ -1102,7 +1102,7 @@ public class DefaultCodegenTest {
 
         String path = "/person/display/{personId}";
         Operation operation = openAPI.getPaths().get(path).getGet();
-        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET",0, operation, null);
         verifyPersonDiscriminator(codegenOperation.discriminator);
 
         Schema person = openAPI.getComponents().getSchemas().get("Person");
@@ -1655,7 +1655,7 @@ public class DefaultCodegenTest {
         String path = "/mypets";
 
         Operation operation = openAPI.getPaths().get(path).getGet();
-        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET",0, operation, null);
         verifyMyPetsDiscriminator(codegenOperation.discriminator);
 
         Schema pet = openAPI.getComponents().getSchemas().get("MyPets");
@@ -1825,7 +1825,7 @@ public class DefaultCodegenTest {
 
         final String path = "/streams";
         Operation subscriptionOperation = openAPI.getPaths().get("/streams").getPost();
-        CodegenOperation op = codegen.fromOperation(path, "post", subscriptionOperation, null);
+        CodegenOperation op = codegen.fromOperation(path, "post",0, subscriptionOperation, null);
 
         Assertions.assertFalse(op.isCallbackRequest);
         Assertions.assertNotNull(op.operationId);
@@ -1878,9 +1878,9 @@ public class DefaultCodegenTest {
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
-        CodegenOperation co1 = codegen.fromOperation("/here", "get", operation2, null);
+        CodegenOperation co1 = codegen.fromOperation("/here", "get",0, operation2, null);
         Assertions.assertEquals(co1.path, "/here");
-        CodegenOperation co2 = codegen.fromOperation("some/path", "get", operation2, null);
+        CodegenOperation co2 = codegen.fromOperation("some/path", "get",0, operation2, null);
         Assertions.assertEquals(co2.path, "/some/path");
     }
 
@@ -1898,7 +1898,7 @@ public class DefaultCodegenTest {
         final DefaultCodegen codegen = new DefaultCodegen();
         codegen.setOpenAPI(openAPI);
 
-        CodegenOperation co = codegen.fromOperation("/here", "get", myOperation, null);
+        CodegenOperation co = codegen.fromOperation("/here", "get",0, myOperation, null);
         Assertions.assertEquals(co.responses.get(0).message, "Error");
         Assertions.assertEquals(co.responses.get(1).message, "Default");
     }
@@ -2572,6 +2572,7 @@ public class DefaultCodegenTest {
         final CodegenOperation operation = cg.fromOperation(
                 "/users/me",
                 "post",
+                0,
                 path.getPost(),
                 path.getServers());
         Assertions.assertEquals(operation.formParams.size(), 3,
@@ -2710,14 +2711,14 @@ public class DefaultCodegenTest {
 
         path = "/ref_array_with_validations_in_items/{items}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertEquals(co.pathParams.get(0).getItems().getMaximum(), "7");
         assertEquals(co.bodyParams.get(0).getItems().getMaximum(), "7");
         assertEquals(co.responses.get(0).getItems().getMaximum(), "7");
 
         path = "/array_with_validations_in_items/{items}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertEquals(co.pathParams.get(0).getItems().getMaximum(), "7");
         assertEquals(co.bodyParams.get(0).getItems().getMaximum(), "7");
         assertEquals(co.responses.get(0).getItems().getMaximum(), "7");
@@ -2847,7 +2848,7 @@ public class DefaultCodegenTest {
 
         path = "/ref_additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         mapWithAddPropsUnset = co.queryParams.get(0);
         assertEquals(mapWithAddPropsUnset.getAdditionalProperties(), anyTypeSchema);
         assertTrue(mapWithAddPropsUnset.getAdditionalPropertiesIsAnyType());
@@ -2863,7 +2864,7 @@ public class DefaultCodegenTest {
 
         path = "/additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         mapWithAddPropsUnset = co.queryParams.get(0);
         assertEquals(mapWithAddPropsUnset.getAdditionalProperties(), anyTypeSchema);
         assertTrue(mapWithAddPropsUnset.getAdditionalPropertiesIsAnyType());
@@ -2908,7 +2909,7 @@ public class DefaultCodegenTest {
 
         path = "/ref_additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         mapWithAddPropsUnset = co.responses.get(0);
         assertEquals(mapWithAddPropsUnset.getAdditionalProperties(), anyTypeSchema);
         assertTrue(mapWithAddPropsUnset.getAdditionalPropertiesIsAnyType());
@@ -2924,7 +2925,7 @@ public class DefaultCodegenTest {
 
         path = "/additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         mapWithAddPropsUnset = co.responses.get(0);
         assertEquals(mapWithAddPropsUnset.getAdditionalProperties(), anyTypeSchema);
         assertTrue(mapWithAddPropsUnset.getAdditionalPropertiesIsAnyType());
@@ -3008,7 +3009,7 @@ public class DefaultCodegenTest {
 
         path = "/ref_date_with_validation/{date}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertFalse(co.pathParams.get(0).isString);
         assertTrue(co.pathParams.get(0).isDate);
         assertFalse(co.bodyParams.get(0).isString);
@@ -3018,7 +3019,7 @@ public class DefaultCodegenTest {
 
         path = "/date_with_validation/{date}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertFalse(co.pathParams.get(0).isString);
         assertTrue(co.pathParams.get(0).isDate);
         assertFalse(co.bodyParams.get(0).isString);
@@ -3040,7 +3041,7 @@ public class DefaultCodegenTest {
 
         path = "/ref_date_time_with_validation/{dateTime}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertFalse(co.pathParams.get(0).isString);
         assertTrue(co.pathParams.get(0).isDateTime);
         assertFalse(co.bodyParams.get(0).isString);
@@ -3050,7 +3051,7 @@ public class DefaultCodegenTest {
 
         path = "/date_time_with_validation/{dateTime}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertFalse(co.pathParams.get(0).isString);
         assertTrue(co.pathParams.get(0).isDateTime);
         assertFalse(co.bodyParams.get(0).isString);
@@ -3060,14 +3061,14 @@ public class DefaultCodegenTest {
 
         path = "/null/{param}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertTrue(co.pathParams.get(0).isNull);
         assertTrue(co.bodyParams.get(0).isNull);
         assertTrue(co.responses.get(0).isNull);
 
         path = "/ref_null/{param}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertTrue(co.pathParams.get(0).isNull);
         assertTrue(co.bodyParams.get(0).isNull);
         assertTrue(co.responses.get(0).isNull);
@@ -3166,7 +3167,7 @@ public class DefaultCodegenTest {
 
         String path = "/queryParametersWithValidation";
         Operation operation = openAPI.getPaths().get(path).getPost();
-        CodegenOperation co = codegen.fromOperation(path, "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation(path, "POST",0, operation, null);
         List<CodegenParameter> params = co.queryParams;
         assertEquals(params.size(), 50);
         for (CodegenParameter param : params) {
@@ -3182,7 +3183,7 @@ public class DefaultCodegenTest {
 
         String path = "/headerParametersWithValidation";
         Operation operation = openAPI.getPaths().get(path).getPost();
-        CodegenOperation co = codegen.fromOperation(path, "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation(path, "POST",0, operation, null);
         List<CodegenParameter> params = co.headerParams;
         assertEquals(params.size(), 50);
         for (CodegenParameter param : params) {
@@ -3198,7 +3199,7 @@ public class DefaultCodegenTest {
 
         String path = "/cookieParametersWithValidation";
         Operation operation = openAPI.getPaths().get(path).getPost();
-        CodegenOperation co = codegen.fromOperation(path, "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation(path, "POST",0, operation, null);
         List<CodegenParameter> params = co.cookieParams;
         assertEquals(params.size(), 50);
         for (CodegenParameter param : params) {
@@ -3214,7 +3215,7 @@ public class DefaultCodegenTest {
 
         String path = "/pathParametersWithValidation";
         Operation operation = openAPI.getPaths().get(path).getPost();
-        CodegenOperation co = codegen.fromOperation(path, "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation(path, "POST",0, operation, null);
         List<CodegenParameter> params = co.pathParams;
         assertEquals(params.size(), 50);
         for (CodegenParameter param : params) {
@@ -3288,7 +3289,7 @@ public class DefaultCodegenTest {
         for (String modelName : modelNames) {
             path = "/" + modelName;
             operation = openAPI.getPaths().get(path).getPost();
-            co = codegen.fromOperation(path, "POST", operation, null);
+            co = codegen.fromOperation(path, "POST",0, operation, null);
             assertTrue(co.bodyParam.getHasValidation());
             assertTrue(co.responses.get(0).getHasValidation());
         }
@@ -3326,7 +3327,7 @@ public class DefaultCodegenTest {
 
         path = "/object_with_optional_and_required_props/{objectData}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertEquals(co.pathParams.get(0).vars, vars);
         assertEquals(co.pathParams.get(0).requiredVars, requiredVars);
         assertEquals(co.bodyParams.get(0).vars, vars);
@@ -3440,13 +3441,13 @@ public class DefaultCodegenTest {
 
         path = "/array_with_validations_in_items/{items}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertFalse(co.pathParams.get(0).getHasVars());
         assertFalse(co.bodyParam.getHasVars());
 
         path = "/object_with_optional_and_required_props/{objectData}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertTrue(co.pathParams.get(0).getHasVars());
         assertTrue(co.bodyParam.getHasVars());
     }
@@ -3464,12 +3465,12 @@ public class DefaultCodegenTest {
 
         path = "/additional_properties/";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         assertFalse(co.responses.get(0).getHasVars());
 
         path = "/object_with_optional_and_required_props/{objectData}";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         // does not have vars because the inline schema was extracted into a component ref
         assertFalse(co.responses.get(0).getHasVars());
     }
@@ -3582,7 +3583,7 @@ public class DefaultCodegenTest {
 
         String path = "/schemasInQueryParamsAndResponses";
         Operation operation = openAPI.getPaths().get(path).getPost();
-        CodegenOperation co = codegen.fromOperation(path, "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation(path, "POST",0, operation, null);
 
         HashSet<String> modelNamesWithoutRequired = new HashSet(Arrays.asList(
                 "EmptyObject",
@@ -3632,7 +3633,7 @@ public class DefaultCodegenTest {
 
         String path = "/schemasInQueryParamsAndResponses";
         Operation operation = openAPI.getPaths().get(path).getPost();
-        CodegenOperation co = codegen.fromOperation(path, "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation(path, "POST",0, operation, null);
 
         HashSet<String> modelNamesWithoutRequired = new HashSet(Arrays.asList(
                 "EmptyObject",
@@ -3740,7 +3741,7 @@ public class DefaultCodegenTest {
 
         path = "/UnboundedInteger";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         cpa = co.pathParams.get(0);
         assertTrue(cpa.isUnboundedInteger);
         assertTrue(cpa.isInteger);
@@ -3759,7 +3760,7 @@ public class DefaultCodegenTest {
 
         path = "/Int32";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         cpa = co.pathParams.get(0);
         assertFalse(cpa.isUnboundedInteger);
         assertTrue(cpa.isInteger);
@@ -3778,7 +3779,7 @@ public class DefaultCodegenTest {
 
         path = "/Int64";
         operation = openAPI.getPaths().get(path).getPost();
-        co = codegen.fromOperation(path, "POST", operation, null);
+        co = codegen.fromOperation(path, "POST",0, operation, null);
         cpa = co.pathParams.get(0);
         assertFalse(cpa.isUnboundedInteger);
         assertFalse(cpa.isInteger);
@@ -3813,7 +3814,7 @@ public class DefaultCodegenTest {
         codegen.processOpts();
         path = "/dotDelimiter";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertEquals(co.operationId, "usersGetAll");
 
         codegen.additionalProperties().put(CodegenConstants.REMOVE_OPERATION_ID_PREFIX, "True");
@@ -3822,7 +3823,7 @@ public class DefaultCodegenTest {
         codegen.processOpts();
         path = "/dotDelimiter";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertEquals(co.operationId, "getAll");
 
         codegen.additionalProperties().put(CodegenConstants.REMOVE_OPERATION_ID_PREFIX, "True");
@@ -3831,7 +3832,7 @@ public class DefaultCodegenTest {
         codegen.processOpts();
         path = "/dotDelimiter";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertEquals(co.operationId, "getAll");
 
         codegen.additionalProperties().put(CodegenConstants.REMOVE_OPERATION_ID_PREFIX, "True");
@@ -3840,7 +3841,7 @@ public class DefaultCodegenTest {
         codegen.processOpts();
         path = "/underscoreDelimiter";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertEquals(co.operationId, "usersGetAll");
 
         codegen.additionalProperties().put(CodegenConstants.REMOVE_OPERATION_ID_PREFIX, "True");
@@ -3849,7 +3850,7 @@ public class DefaultCodegenTest {
         codegen.processOpts();
         path = "/underscoreDelimiter";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertEquals(co.operationId, "getAll");
 
         codegen.additionalProperties().put(CodegenConstants.REMOVE_OPERATION_ID_PREFIX, "True");
@@ -3858,7 +3859,7 @@ public class DefaultCodegenTest {
         codegen.processOpts();
         path = "/underscoreDelimiter";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertEquals(co.operationId, "getAll");
     }
 
@@ -3936,42 +3937,42 @@ public class DefaultCodegenTest {
         CodegenResponse cr;
 
         path = "/ComposedObject";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsMap());
 
         path = "/ComposedNumber";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsNumber());
 
         path = "/ComposedInteger";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsUnboundedInteger());
 
         path = "/ComposedString";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsString());
 
         path = "/ComposedBool";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsBoolean());
 
         path = "/ComposedArray";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsArray());
 
         path = "/ComposedNone";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsNull());
 
         path = "/ComposedAnyType";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cr = co.responses.get(0);
         assertTrue(cr.getIsAnyType());
     }
@@ -3986,37 +3987,37 @@ public class DefaultCodegenTest {
         CodegenParameter cp;
 
         path = "/ComposedNumber";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsNumber());
 
         path = "/ComposedInteger";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsUnboundedInteger());
 
         path = "/ComposedString";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsString());
 
         path = "/ComposedBool";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsBoolean());
 
         path = "/ComposedArray";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsArray());
 
         path = "/ComposedNone";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsNull());
 
         path = "/ComposedAnyType";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.bodyParam;
         assertTrue(cp.getIsAnyType());
     }
@@ -4031,42 +4032,42 @@ public class DefaultCodegenTest {
         CodegenParameter cp;
 
         path = "/ComposedObject";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsMap());
 
         path = "/ComposedNumber";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsNumber());
 
         path = "/ComposedInteger";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsUnboundedInteger());
 
         path = "/ComposedString";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsString());
 
         path = "/ComposedBool";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsBoolean());
 
         path = "/ComposedArray";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsArray());
 
         path = "/ComposedNone";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsNull());
 
         path = "/ComposedAnyType";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         cp = co.queryParams.get(0);
         assertTrue(cp.getIsAnyType());
     }
@@ -4081,7 +4082,7 @@ public class DefaultCodegenTest {
         CodegenParameter cp;
 
         path = "/TxRxByteArray";
-        co = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        co = codegen.fromOperation(path, "POST",0, openAPI.getPaths().get(path).getPost(), null);
         cp = co.bodyParam;
         assertTrue(cp.isByteArray);
         assertFalse(cp.getIsString());
@@ -4111,7 +4112,7 @@ public class DefaultCodegenTest {
 
         path = "/pet/{petId}";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         //assertTrue(co.hasErrorResponseObject);
         cr = co.responses.get(0);
         assertTrue(cr.is2xx);
@@ -4124,7 +4125,7 @@ public class DefaultCodegenTest {
 
         path = "/pet";
         operation = openAPI.getPaths().get(path).getPut();
-        co = codegen.fromOperation(path, "PUT", operation, null);
+        co = codegen.fromOperation(path, "PUT",0, operation, null);
         assertTrue(co.hasErrorResponseObject);
 
         // 200 response
@@ -4142,7 +4143,7 @@ public class DefaultCodegenTest {
 
         path = "/pet/findByTags";
         operation = openAPI.getPaths().get(path).getGet();
-        co = codegen.fromOperation(path, "GET", operation, null);
+        co = codegen.fromOperation(path, "GET",0, operation, null);
         assertFalse(co.hasErrorResponseObject);
         cr = co.responses.get(0);
         assertTrue(cr.is2xx);
@@ -4159,7 +4160,7 @@ public class DefaultCodegenTest {
         CodegenOperation co;
 
         path = "/jsonQueryParams";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         CodegenParameter coordinatesInlineSchema = co.queryParams.get(0);
         LinkedHashMap<String, CodegenMediaType> content = coordinatesInlineSchema.getContent();
         assertNotNull(content);
@@ -4191,7 +4192,7 @@ public class DefaultCodegenTest {
         CodegenOperation co;
 
         path = "/inlineRequestBodySchemasDifferingByContentType";
-        co = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        co = codegen.fromOperation(path, "POST",0, openAPI.getPaths().get(path).getPost(), null);
         CodegenParameter bodyParameter = co.bodyParam;
         LinkedHashMap<String, CodegenMediaType> content = bodyParameter.getContent();
         assertNotNull(content);
@@ -4211,7 +4212,7 @@ public class DefaultCodegenTest {
         // but the schema it references is not string type
 
         path = "/refRequestBodySchemasDifferingByContentType";
-        co = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        co = codegen.fromOperation(path, "POST",0, openAPI.getPaths().get(path).getPost(), null);
         bodyParameter = co.bodyParam;
         content = bodyParameter.getContent();
         assertNotNull(content);
@@ -4229,7 +4230,7 @@ public class DefaultCodegenTest {
         assertTrue(cp.isString);
 
         path = "/requestBodyWithEncodingTypes";
-        co = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        co = codegen.fromOperation(path, "POST",0, openAPI.getPaths().get(path).getPost(), null);
         List<CodegenParameter> formParams = co.formParams;
 
         assertEquals(formParams.get(0).paramName, "intParam");
@@ -4300,7 +4301,7 @@ public class DefaultCodegenTest {
         CodegenOperation co;
 
         path = "/jsonQueryParams";
-        co = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        co = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
         CodegenParameter coordinatesInlineSchema = co.queryParams.get(0);
         LinkedHashMap<String, CodegenMediaType> content = coordinatesInlineSchema.getContent();
         assertNotNull(content);
@@ -4927,7 +4928,7 @@ public class DefaultCodegenTest {
         CodegenOperation co;
 
         path = "/inlineRequestBodySchemasDifferingByContentType";
-        co = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        co = codegen.fromOperation(path, "POST",0, openAPI.getPaths().get(path).getPost(), null);
         CodegenParameter bodyParameter = co.bodyParam;
         LinkedHashMap<String, CodegenMediaType> content = bodyParameter.getContent();
         assertNotNull(content);
@@ -4949,7 +4950,7 @@ public class DefaultCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation operation = openAPI.getWebhooks().get("newPet").getPost();
-        CodegenOperation co = codegen.fromOperation("newPet", "get", operation, null);
+        CodegenOperation co = codegen.fromOperation("newPet", "get",0, operation, null);
 
         Assertions.assertEquals(co.path, "/newPet");
         Assertions.assertEquals(co.operationId, "newPetGet");
@@ -4983,7 +4984,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/content-data.yaml");
         codegen.setOpenAPI(openAPI);
         String path = "/jsonQueryParams";
-        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET",0, openAPI.getPaths().get(path).getGet(), null);
 
         // When & Then
         assertThat(codegenOperation.hasSingleParam).isFalse();
@@ -4996,7 +4997,7 @@ public class DefaultCodegenTest {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         codegen.setOpenAPI(openAPI);
         String path = "/fake/inline-additionalProperties";
-        CodegenOperation codegenOperation = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "POST",0, openAPI.getPaths().get(path).getPost(), null);
 
         // When & Then
         assertThat(codegenOperation.hasSingleParam).isTrue();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpOperationTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpOperationTest.java
@@ -53,7 +53,7 @@ public class CSharpOperationTest {
 
         final String path = "/pet/{petId}/uploadImage";
         final Operation postOperation = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation codegenOperation = codegen.fromOperation(path, "post", postOperation, null);
+        final CodegenOperation codegenOperation = codegen.fromOperation(path, "post",0, postOperation, null);
 
         return codegenOperation.allParams.get(2).dataType;
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/DartModelTest.java
@@ -559,7 +559,7 @@ public class DartModelTest {
 
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "DateTime");
         Assert.assertEquals(op.bodyParam.dataType, "DateTime");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/elm/ElmClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/elm/ElmClientCodegenTest.java
@@ -49,7 +49,7 @@ public class ElmClientCodegenTest {
                 .operationId("opId")
                 .addParametersItem(new QueryParameter().name("listOfUuid").schema(p));
 
-        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
+        CodegenOperation co = codegen.fromOperation("/some/path", "get",0, operation, null);
 
         OperationMap operationMap = new OperationMap();
         operationMap.setOperation(co);
@@ -75,7 +75,7 @@ public class ElmClientCodegenTest {
                 .operationId("opId")
                 .addParametersItem(new QueryParameter().name("listOfDateTime").schema(p));
 
-        CodegenOperation co = codegen.fromOperation("/some/path", "get", operation, null);
+        CodegenOperation co = codegen.fromOperation("/some/path", "get",0, operation, null);
 
         OperationMap operationMap = new OperationMap();
         operationMap.setOperation(co);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -74,7 +74,7 @@ public class GoClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/fake";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
         Assert.assertEquals(op.formParams.size(), 2);
         CodegenParameter bp = op.formParams.get(0);
         Assert.assertFalse(bp.isPrimitiveType);
@@ -87,7 +87,7 @@ public class GoClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/pet/{id}";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
         Assert.assertEquals(op.allParams.size(), 9);
         CodegenParameter cp = op.allParams.get(0);
         Assert.assertEquals(cp.paramName, "id");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaCXFClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaCXFClientCodegenTest.java
@@ -61,7 +61,7 @@ public class JavaCXFClientCodegenTest {
                         .addApiResponse("400", new ApiResponse().description("Error")));
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema());
         final JavaCXFClientCodegen codegen = new JavaCXFClientCodegen();
-        final CodegenOperation co = codegen.fromOperation("getAllPets", "GET", operation, null);
+        final CodegenOperation co = codegen.fromOperation("getAllPets", "GET",0, operation, null);
 
         OperationMap operationMap = new OperationMap();
         operationMap.setOperation(co);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -368,7 +368,7 @@ public class JavaClientCodegenTest {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
         Operation operation = openAPI.getPaths().get("/ping").getPost();
 
-        CodegenOperation co = new JavaClientCodegen().fromOperation("/ping", "POST", operation, null);
+        CodegenOperation co = new JavaClientCodegen().fromOperation("/ping", "POST",0, operation, null);
 
         assertThat(co.allParams).hasSize(1)
                 .first().hasFieldOrPropertyWithValue("baseType", "MessageEventCoreWithTimeListEntries");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaModelTest.java
@@ -1246,7 +1246,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET",0, operation, null);
 
         Assert.assertEquals(co.bodyParams.size(), 1);
         CodegenParameter cp1 = co.bodyParams.get(0);
@@ -1277,7 +1277,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET",0, operation, null);
 
         Assert.assertEquals(co.responses.size(), 1);
         CodegenResponse cr = co.responses.get(0);
@@ -1326,7 +1326,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET",0, operation, null);
 
         Assert.assertEquals(co.bodyParams.size(), 1);
         CodegenParameter cp1 = co.bodyParams.get(0);
@@ -1361,7 +1361,7 @@ public class JavaModelTest {
         OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema("Pet", new ObjectSchema().addProperties("name", new StringSchema()));
         final DefaultCodegen codegen = new JavaClientCodegen();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation co = codegen.fromOperation("testSchema", "GET", operation, null);
+        final CodegenOperation co = codegen.fromOperation("testSchema", "GET",0, operation, null);
 
         Assert.assertEquals(co.responses.size(), 1);
         CodegenResponse cr = co.responses.get(0);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJaxrsResteasyServerCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJaxrsResteasyServerCodegenModelTest.java
@@ -60,7 +60,7 @@ public class JavaJaxrsResteasyServerCodegenModelTest extends JavaJaxrsBaseTest {
         // make sure that the operation parameters omit character suffixes.
         String route = "/numericqueryparams";
         Operation op = openAPI.getPaths().get(route).getGet();
-        CodegenOperation co = codegen.fromOperation(route, "GET", op, null);
+        CodegenOperation co = codegen.fromOperation(route, "GET",0, op, null);
         CodegenParameter int64Param = co.queryParams.get(0);
         CodegenParameter floatParam = co.queryParams.get(1);
         CodegenParameter doubleParam = co.queryParams.get(2);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -594,7 +594,7 @@ public class SpringCodegenTest {
         // make sure that the operation parameters omit character suffixes
         String route = "/numericqueryparams";
         Operation op = openAPI.getPaths().get(route).getGet();
-        CodegenOperation co = codegen.fromOperation(route, "GET", op, null);
+        CodegenOperation co = codegen.fromOperation(route, "GET",0, op, null);
         CodegenParameter int64Param = co.queryParams.get(0);
         CodegenParameter floatParam = co.queryParams.get(1);
         CodegenParameter doubleParam = co.queryParams.get(2);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/javascript/JavascriptClientCodegenTest.java
@@ -105,7 +105,7 @@ public class JavascriptClientCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation textOperation = openAPI.getPaths().get("/user").getPost();
-        CodegenOperation coText = codegen.fromOperation("/user", "post", textOperation, null);
+        CodegenOperation coText = codegen.fromOperation("/user", "post",0, textOperation, null);
 
         for (CodegenResponse cr : coText.responses) {
             Assert.assertTrue(cr.isDefault);
@@ -123,7 +123,7 @@ public class JavascriptClientCodegenTest {
 
         final String requestPath = "/multipart-array";
         Operation textOperation = openAPI.getPaths().get(requestPath).getPost();
-        CodegenOperation operation = codegen.fromOperation(requestPath, "post", textOperation, null);
+        CodegenOperation operation = codegen.fromOperation(requestPath, "post",0, textOperation, null);
         CodegenParameter codegenParameter = operation.allParams.get(0);
 
         Assert.assertEquals(codegenParameter.collectionFormat, "passthrough");
@@ -136,7 +136,7 @@ public class JavascriptClientCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation textOperation = openAPI.getPaths().get("/pet").getPost();
-        CodegenOperation coText = codegen.fromOperation("/user", "post", textOperation, null);
+        CodegenOperation coText = codegen.fromOperation("/user", "post",0, textOperation, null);
 
         for (Map<String, String> consume : coText.consumes) {
             if ("application/json".equals(consume.get("mediaType"))) {
@@ -156,7 +156,7 @@ public class JavascriptClientCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation textOperation = openAPI.getPaths().get("/pet/{petId}").getGet();
-        CodegenOperation coText = codegen.fromOperation("/user", "get", textOperation, null);
+        CodegenOperation coText = codegen.fromOperation("/user", "get",0, textOperation, null);
 
         for (Map<String, String> consume : coText.produces) {
             if ("application/json".equals(consume.get("mediaType"))) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/markdown/MarkdownSampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/markdown/MarkdownSampleGeneratorTest.java
@@ -21,7 +21,7 @@ public class MarkdownSampleGeneratorTest {
 
         final String requestPath = "/v1/MyRequest";
         Operation textOperation = openAPI.getPaths().get(requestPath).getPut();
-        CodegenOperation operation = codegen.fromOperation(requestPath, "put", textOperation, null);
+        CodegenOperation operation = codegen.fromOperation(requestPath, "put",0, textOperation, null);
         CodegenParameter codegenParameter = operation.allParams.get(0);
         Assert.assertNotNull(codegenParameter);
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/objc/ObjcModelTest.java
@@ -342,7 +342,7 @@ public class ObjcModelTest {
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
         codegen.setOpenAPI(openAPI);
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertTrue(op.bodyParam.isBinary);
         Assert.assertTrue(op.responses.get(0).isBinary);
@@ -361,7 +361,7 @@ public class ObjcModelTest {
         final PathItem animalOps = animalPaths.get("/animals");
         Assert.assertNotNull(animalOps.getPost());
 
-        final CodegenOperation animalCo = codegen.fromOperation("/animals", "POST", animalOps.getPost(), null);
+        final CodegenOperation animalCo = codegen.fromOperation("/animals", "POST",0, animalOps.getPost(), null);
         Assert.assertEquals(animalCo.imports.size(), 1);
         Assert.assertTrue(animalCo.imports.contains("OAIAnimal"));
 
@@ -369,7 +369,7 @@ public class ObjcModelTest {
         final PathItem insectOps = insectPaths.get("/insects");
         Assert.assertNotNull(insectOps.getPost());
 
-        final CodegenOperation insectCo = codegen.fromOperation("/insects", "POST", insectOps.getPost(), null);
+        final CodegenOperation insectCo = codegen.fromOperation("/insects", "POST",0, insectOps.getPost(), null);
         Assert.assertEquals(insectCo.imports.size(), 1);
         Assert.assertTrue(insectCo.imports.contains("OAIInsect"));
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/perl/PerlClientCodegenTest.java
@@ -64,7 +64,7 @@ public class PerlClientCodegenTest {
         codegen.setOpenAPI(openAPI);
 
         Operation operation = openAPI.getPaths().get("/issue677").getPost();
-        CodegenOperation co = codegen.fromOperation("/issue677", "POST", operation, null);
+        CodegenOperation co = codegen.fromOperation("/issue677", "POST",0, operation, null);
         Assert.assertNotNull(co);
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/php/PhpModelTest.java
@@ -378,7 +378,7 @@ public class PhpModelTest {
 
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "\\DateTime");
         Assert.assertEquals(op.bodyParam.dataType, "\\DateTime");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -95,7 +95,7 @@ public class PythonClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         // pattern_no_forward_slashes '^pattern$'
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/'
@@ -171,7 +171,7 @@ public class PythonClientCodegenTest {
 
         final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
         final Operation operation = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
+        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get",0, operation, null);
         Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
         Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
     }
@@ -448,14 +448,14 @@ public class PythonClientCodegenTest {
         // path parameter
         String path = "/store/order/{orderId}";
         Operation p = openAPI.getPaths().get(path).getGet();
-        CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).containerType, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "orderId");
 
         // query parameter
         path = "/user/login";
         p = openAPI.getPaths().get(path).getGet();
-        op = codegen.fromOperation(path, "get", p, null);
+        op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).containerType, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "username");
         Assert.assertEquals(op.allParams.get(1).containerType, null);
@@ -464,14 +464,14 @@ public class PythonClientCodegenTest {
         // body parameter
         path = "/user/createWithList";
         p = openAPI.getPaths().get(path).getPost();
-        op = codegen.fromOperation(path, "post", p, null);
+        op = codegen.fromOperation(path, "post",0, p, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "User");
         Assert.assertEquals(op.allParams.get(0).containerType, "array");
         Assert.assertEquals(op.allParams.get(0).containerTypeMapped, "List");
 
         path = "/pet";
         p = openAPI.getPaths().get(path).getPost();
-        op = codegen.fromOperation(path, "post", p, null);
+        op = codegen.fromOperation(path, "post",0, p, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "Pet");
         Assert.assertEquals(op.allParams.get(0).containerType, null);
         Assert.assertEquals(op.allParams.get(0).containerTypeMapped, null);
@@ -486,7 +486,7 @@ public class PythonClientCodegenTest {
         // query parameter
         String path = "/query_parameter_dict";
         Operation p = openAPI.getPaths().get(path).getGet();
-        CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).containerType, "map");
         Assert.assertEquals(op.allParams.get(0).containerTypeMapped, "Dict");
         Assert.assertEquals(op.allParams.get(0).baseName, "dict_string_integer");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonPydanticV1ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonPydanticV1ClientCodegenTest.java
@@ -90,7 +90,7 @@ public class PythonPydanticV1ClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         // pattern_no_forward_slashes '^pattern$'
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/'
@@ -166,7 +166,7 @@ public class PythonPydanticV1ClientCodegenTest {
 
         final String path = "/api/v1beta3/namespaces/{namespaces}/bindings";
         final Operation operation = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get", operation, null);
+        final CodegenOperation codegenOperation = codegen.fromOperation(path, "get",0, operation, null);
         Assert.assertEquals(codegenOperation.returnType, "V1beta3Binding");
         Assert.assertEquals(codegenOperation.returnBaseType, "V1beta3Binding");
     }
@@ -443,14 +443,14 @@ public class PythonPydanticV1ClientCodegenTest {
         // path parameter
         String path = "/store/order/{orderId}";
         Operation p = openAPI.getPaths().get(path).getGet();
-        CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).containerType, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "orderId");
 
         // query parameter
         path = "/user/login";
         p = openAPI.getPaths().get(path).getGet();
-        op = codegen.fromOperation(path, "get", p, null);
+        op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).containerType, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "username");
         Assert.assertEquals(op.allParams.get(1).containerType, null);
@@ -459,14 +459,14 @@ public class PythonPydanticV1ClientCodegenTest {
         // body parameter
         path = "/user/createWithList";
         p = openAPI.getPaths().get(path).getPost();
-        op = codegen.fromOperation(path, "post", p, null);
+        op = codegen.fromOperation(path, "post",0, p, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "User");
         Assert.assertEquals(op.allParams.get(0).containerType, "array");
         Assert.assertEquals(op.allParams.get(0).containerTypeMapped, "List");
 
         path = "/pet";
         p = openAPI.getPaths().get(path).getPost();
-        op = codegen.fromOperation(path, "post", p, null);
+        op = codegen.fromOperation(path, "post",0, p, null);
         Assert.assertEquals(op.allParams.get(0).baseName, "Pet");
         Assert.assertEquals(op.allParams.get(0).containerType, null);
         Assert.assertEquals(op.allParams.get(0).containerTypeMapped, null);
@@ -481,7 +481,7 @@ public class PythonPydanticV1ClientCodegenTest {
         // query parameter
         String path = "/query_parameter_dict";
         Operation p = openAPI.getPaths().get(path).getGet();
-        CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).containerType, "map");
         Assert.assertEquals(op.allParams.get(0).containerTypeMapped, "Dict");
         Assert.assertEquals(op.allParams.get(0).baseName, "dict_string_integer");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientCodegenTest.java
@@ -142,7 +142,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/fake";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.formParams.size(), 2);
         CodegenParameter fp = op.formParams.get(0);
         Assert.assertEquals(fp.dataType, "Array<String>");
@@ -163,7 +163,7 @@ public class RubyClientCodegenTest {
         CodegenModel model = codegen.fromModel("Pet", schema);
         ModelMap modelMap = new ModelMap();
         modelMap.setModel(model);
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         OperationMap operations = new OperationMap();
         operations.setOperation(op);
@@ -302,7 +302,7 @@ public class RubyClientCodegenTest {
         final String path = "/pet/{petId}";
 
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.pathParams.size(), 1);
         CodegenParameter pp = op.pathParams.get(0);
@@ -324,7 +324,7 @@ public class RubyClientCodegenTest {
         final String path = "/pet/{petId}";
 
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         // path parameter x-nullable test
         Assert.assertEquals(op.pathParams.size(), 1);
@@ -628,7 +628,7 @@ public class RubyClientCodegenTest {
         final String path = "/store/order/{orderId}";
 
         final Operation p = openAPI.getPaths().get(path).getDelete();
-        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "delete",0, p, null);
 
         OperationMap operations = new OperationMap();
         operations.setOperation(op);
@@ -651,7 +651,7 @@ public class RubyClientCodegenTest {
         final String path = "/store/order/{orderId}";
 
         final Operation p = openAPI.getPaths().get(path).getDelete();
-        final CodegenOperation op = codegen.fromOperation(path, "delete", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "delete",0, p, null);
 
         OperationMap operations = new OperationMap();
         operations.setOperation(op);
@@ -678,7 +678,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         // pattern_no_forward_slashes '^pattern$'
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/i'
@@ -699,7 +699,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/animals";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         Assert.assertEquals(op.allParams.get(0).dataType, "VerySpecialStringInRuby");
 
         final Schema schema = openAPI.getComponents().getSchemas().get("Animal");
@@ -719,7 +719,7 @@ public class RubyClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/ping";
         final Operation p = openAPI.getPaths().get(path).getGet();
-        final CodegenOperation op = codegen.fromOperation(path, "get", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "get",0, p, null);
         // pattern_no_forward_slashes '^pattern$'
         Assert.assertEquals(op.allParams.get(0).pattern, "/^pattern$/");
         // pattern_two_slashes '/^pattern$/'

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift5/Swift5ClientCodegenTest.java
@@ -111,7 +111,7 @@ public class Swift5ClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "URL");
         Assert.assertEquals(op.bodyParam.dataType, "URL");
@@ -126,7 +126,7 @@ public class Swift5ClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "Date");
         Assert.assertEquals(op.bodyParam.dataType, "Date");
@@ -141,7 +141,7 @@ public class Swift5ClientCodegenTest {
         codegen.processOpts();
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "Date");
         Assert.assertEquals(op.bodyParam.dataType, "Date");
@@ -157,7 +157,7 @@ public class Swift5ClientCodegenTest {
 
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "OpenAPIDateWithoutTime");
         Assert.assertEquals(op.bodyParam.dataType, "OpenAPIDateWithoutTime");
@@ -297,7 +297,7 @@ public class Swift5ClientCodegenTest {
         codegen.processOpts();
         final String path = "/as/token.oauth2";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.formParams.size(), 6);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/swift6/Swift6ClientCodegenTest.java
@@ -118,7 +118,7 @@ public class Swift6ClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "URL");
         Assert.assertEquals(op.bodyParam.dataType, "URL");
@@ -133,7 +133,7 @@ public class Swift6ClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "Date");
         Assert.assertEquals(op.bodyParam.dataType, "Date");
@@ -148,7 +148,7 @@ public class Swift6ClientCodegenTest {
         codegen.processOpts();
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "Date");
         Assert.assertEquals(op.bodyParam.dataType, "Date");
@@ -164,7 +164,7 @@ public class Swift6ClientCodegenTest {
 
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "OpenAPIDateWithoutTime");
         Assert.assertEquals(op.bodyParam.dataType, "OpenAPIDateWithoutTime");
@@ -306,7 +306,7 @@ public class Swift6ClientCodegenTest {
         codegen.processOpts();
         final String path = "/as/token.oauth2";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.formParams.size(), 6);
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -59,7 +59,7 @@ public class TypeScriptClientCodegenTest {
         final OpenAPI openApi = TestUtils.parseFlattenSpec("src/test/resources/3_0/composed-schemas.yaml");
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/pets");
-        CodegenOperation operation = codegen.fromOperation("/pets", "patch", path.getPatch(), path.getServers());
+        CodegenOperation operation = codegen.fromOperation("/pets", "patch",0, path.getPatch(), path.getServers());
         // TODO revise the commented test below as oneOf is no longer defined inline
         //but instead defined using $ref with the new inline model resolver in 6.x
         //Assert.assertEquals(operation.imports, Sets.newHashSet("Cat", "Dog"));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -59,7 +59,7 @@ public class TypeScriptFetchClientCodegenTest {
         final OpenAPI openApi = TestUtils.parseFlattenSpec("src/test/resources/3_0/optionalResponse.yaml");
         codegen.setOpenAPI(openApi);
         PathItem path = openApi.getPaths().get("/api/Users/{userId}");
-        CodegenOperation operation = codegen.fromOperation("/api/Users/{userId}", "get", path.getGet(), path.getServers());
+        CodegenOperation operation = codegen.fromOperation("/api/Users/{userId}", "get",0, path.getGet(), path.getServers());
         Assert.assertEquals(operation.isResponseOptional, true);
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -122,7 +122,7 @@ public class TypeScriptAngularClientCodegenTest {
         final TypeScriptAngularClientCodegen codegen = new TypeScriptAngularClientCodegen();
         codegen.setOpenAPI(openAPI);
 
-        CodegenOperation co1 = codegen.fromOperation("/another-fake/dummy/", "get", operation1, null);
+        CodegenOperation co1 = codegen.fromOperation("/another-fake/dummy/", "get",0, operation1, null);
         org.testng.Assert.assertEquals(co1.operationId, "_123testSpecialTags");
 
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnestjs/TypeScriptNestjsClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptnestjs/TypeScriptNestjsClientCodegenTest.java
@@ -35,7 +35,7 @@ public class TypeScriptNestjsClientCodegenTest {
         final TypeScriptNestjsClientCodegen codegen = new TypeScriptNestjsClientCodegen();
         codegen.setOpenAPI(openAPI);
 
-        CodegenOperation co1 = codegen.fromOperation("/another-fake/dummy/", "get", operation1, null);
+        CodegenOperation co1 = codegen.fromOperation("/another-fake/dummy/", "get",0, operation1, null);
         org.testng.Assert.assertEquals(co1.operationId, "_123testSpecialTags");
 
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/wsdl/WsdlSchemaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/wsdl/WsdlSchemaCodegenTest.java
@@ -53,12 +53,12 @@ public class WsdlSchemaCodegenTest {
 
         String requestPathWithId = "/store/order/{orderId}";
         Operation textOperationGet = openAPI.getPaths().get(requestPathWithId).getGet();
-        CodegenOperation opGet = codegen.fromOperation(requestPathWithId, "get", textOperationGet, null);
+        CodegenOperation opGet = codegen.fromOperation(requestPathWithId, "get",0, textOperationGet, null);
         String newOperationIdWithId = codegen.generateOperationId(opGet);
 
         String requestPathWithoutId = "/store/order";
         Operation textOperationPost = openAPI.getPaths().get(requestPathWithoutId).getPost();
-        CodegenOperation opPost = codegen.fromOperation(requestPathWithoutId, "post", textOperationPost, null);
+        CodegenOperation opPost = codegen.fromOperation(requestPathWithoutId, "post",0, textOperationPost, null);
         String newOperationIdWithoutId = codegen.generateOperationId(opPost);
 
         Assert.assertEquals(newOperationIdWithId, "GetStoreOrderByOrderid");

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/xojo/client/XojoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/xojo/client/XojoClientCodegenTest.java
@@ -87,7 +87,7 @@ public class XojoClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/binaryResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "FolderItem");
         Assert.assertEquals(op.bodyParam.dataType, "FolderItem");
@@ -102,7 +102,7 @@ public class XojoClientCodegenTest {
         codegen.setOpenAPI(openAPI);
         final String path = "/tests/dateResponse";
         final Operation p = openAPI.getPaths().get(path).getPost();
-        final CodegenOperation op = codegen.fromOperation(path, "post", p, null);
+        final CodegenOperation op = codegen.fromOperation(path, "post",0, p, null);
 
         Assert.assertEquals(op.returnType, "Date");
         Assert.assertEquals(op.bodyParam.dataType, "Date");


### PR DESCRIPTION
Some swagger files use multiple content types pro operation. It is allowed by REST-API and currently in use. But OpenAPI generator handles only the first one, others are ignored. This PR extends the current behaviour to be able handle all of the content types under a specific operation. If there is only one, the behaviour is unchanged. 

If an operation have multiple content types a matching function call shall be generated pro content type, eg:
myFunction(<parameter list 0>)
myFunction_1(<parameter list 1>)

See further details on https://github.com/OpenAPITools/openapi-generator/issues/20871