### PR TITLE
[go-server] move errMsg helpers to helpers file

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/helpers.mustache
@@ -15,6 +15,10 @@ import (
 	"time"
 )
 
+const errMsgRequiredMissing = "required parameter is missing"
+const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
+const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
+
 // Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -34,10 +34,6 @@ type Router interface {
 	Routes() Routes
 }
 
-const errMsgRequiredMissing = "required parameter is missing"
-const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
-const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
-
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}}chi.Router{{/chi}}{{/routers}} {
 {{#routers}}

--- a/samples/openapi3/server/petstore/go/go-petstore/go/helpers.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/helpers.go
@@ -24,6 +24,10 @@ import (
 	"time"
 )
 
+const errMsgRequiredMissing = "required parameter is missing"
+const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
+const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
+
 // Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
@@ -30,10 +30,6 @@ type Router interface {
 	Routes() Routes
 }
 
-const errMsgRequiredMissing = "required parameter is missing"
-const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
-const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
-
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()

--- a/samples/server/others/go-server/no-body-path-params/go/helpers.go
+++ b/samples/server/others/go-server/no-body-path-params/go/helpers.go
@@ -24,6 +24,10 @@ import (
 	"time"
 )
 
+const errMsgRequiredMissing = "required parameter is missing"
+const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
+const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
+
 // Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {

--- a/samples/server/others/go-server/no-body-path-params/go/routers.go
+++ b/samples/server/others/go-server/no-body-path-params/go/routers.go
@@ -30,10 +30,6 @@ type Router interface {
 	Routes() Routes
 }
 
-const errMsgRequiredMissing = "required parameter is missing"
-const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
-const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
-
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)

--- a/samples/server/petstore/go-api-server/go/helpers.go
+++ b/samples/server/petstore/go-api-server/go/helpers.go
@@ -24,6 +24,10 @@ import (
 	"time"
 )
 
+const errMsgRequiredMissing = "required parameter is missing"
+const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
+const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
+
 // Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -30,10 +30,6 @@ type Router interface {
 	Routes() Routes
 }
 
-const errMsgRequiredMissing = "required parameter is missing"
-const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
-const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
-
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)

--- a/samples/server/petstore/go-chi-server/go/helpers.go
+++ b/samples/server/petstore/go-chi-server/go/helpers.go
@@ -24,6 +24,10 @@ import (
 	"time"
 )
 
+const errMsgRequiredMissing = "required parameter is missing"
+const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
+const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
+
 // Response return a ImplResponse struct filled
 func Response(code int, body interface{}) ImplResponse {
 	return ImplResponse {

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -30,10 +30,6 @@ type Router interface {
 	Routes() Routes
 }
 
-const errMsgRequiredMissing = "required parameter is missing"
-const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
-const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
-
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Related to https://github.com/OpenAPITools/openapi-generator/issues/20817

Missed moving the errMsgs from the router to the helper file in this MR: https://github.com/OpenAPITools/openapi-generator/pull/20823

Apologies about that! This MR is to complete the move so everything helper is together and router is standalone

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)