### PR TITLE
[Swift][client] add identifier to each request

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/APIs.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/APIs.mustache
@@ -83,6 +83,7 @@ import Alamofire{{/useAlamofire}}
 }{{^useVapor}}
 
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class RequestBuilder<T>: @unchecked Sendable {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let id: UUID = UUID()
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var credential: URLCredential?
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var headers: [String: String]
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let parameters: [String: Any]?

--- a/modules/openapi-generator/src/main/resources/swift6/APIs.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/APIs.mustache
@@ -82,8 +82,7 @@ import Alamofire{{/useAlamofire}}
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static let shared = {{projectName}}APIConfiguration()
 }{{^useVapor}}
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class RequestBuilder<T>: @unchecked Sendable {
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let id: UUID = UUID()
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}open{{/nonPublicApi}} class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var credential: URLCredential?
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} var headers: [String: String]
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -61,8 +61,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -62,6 +62,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -61,8 +61,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -62,6 +62,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ internal class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 internal class RequestBuilder<T>: @unchecked Sendable {
+    internal let id: UUID = UUID()
     internal var credential: URLCredential?
     internal var headers: [String: String]
     internal let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ internal class PetstoreClientAPIConfiguration: @unchecked Sendable {
     internal static let shared = PetstoreClientAPIConfiguration()
 }
 
-internal class RequestBuilder<T>: @unchecked Sendable {
-    internal let id: UUID = UUID()
+internal class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     internal var credential: URLCredential?
     internal var headers: [String: String]
     internal let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/swift6_test_all.sh
+++ b/samples/client/petstore/swift6/swift6_test_all.sh
@@ -3,17 +3,6 @@ set -e
 
 DIRECTORY=`dirname $0`
 
-# example project with unit tests
-(cd $DIRECTORY/alamofireLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/apiNonStaticMethod/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/asyncAwaitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-# (cd $DIRECTORY/combineLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/combineDeferredLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/default/SwaggerClientTests/ && ./run_xcodebuild.sh)
-# (cd $DIRECTORY/promisekitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/rxswiftLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/urlsessionLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-
 # spm build
 (cd $DIRECTORY/alamofireLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/apiNonStaticMethod/ && ./run_spmbuild.sh)
@@ -23,10 +12,20 @@ DIRECTORY=`dirname $0`
 (cd $DIRECTORY/default/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/objcCompatible/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/oneOf/ && ./run_spmbuild.sh)
-# (cd $DIRECTORY/promisekitLibrary/ && ./run_spmbuild.sh)
+# (cd $DIRECTORY/promisekitLibrary/ && ./run_spmbuild.sh) # Commented to save time in CI, building Swift5 and Swift6 is taking too much time, and making CI fail
 (cd $DIRECTORY/resultLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/rxswiftLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/urlsessionLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/validation/ && ./run_spmbuild.sh)
-# #(cd $DIRECTORY/vaporLibrary/ && ./run_spmbuild.sh)
+# (cd $DIRECTORY/vaporLibrary/ && ./run_spmbuild.sh) # Commented because it's not working
 
+# example project with unit tests
+(cd $DIRECTORY/alamofireLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/apiNonStaticMethod/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/asyncAwaitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+# (cd $DIRECTORY/combineLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh) # Commented to save time in CI, building Swift5 and Swift6 is taking too much time, and making CI fail
+(cd $DIRECTORY/combineDeferredLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/default/SwaggerClientTests/ && ./run_xcodebuild.sh)
+# (cd $DIRECTORY/promisekitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh) # Commented to save time in CI, building Swift5 and Swift6 is taking too much time, and making CI fail
+(cd $DIRECTORY/rxswiftLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/urlsessionLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -50,6 +50,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIs.swift
@@ -49,8 +49,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -48,6 +48,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
 }
 
 open class RequestBuilder<T>: @unchecked Sendable {
+    public let id: UUID = UUID()
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIs.swift
@@ -47,8 +47,7 @@ open class PetstoreClientAPIConfiguration: @unchecked Sendable {
     public static let shared = PetstoreClientAPIConfiguration()
 }
 
-open class RequestBuilder<T>: @unchecked Sendable {
-    public let id: UUID = UUID()
+open class RequestBuilder<T>: @unchecked Sendable, Identifiable {
     public var credential: URLCredential?
     public var headers: [String: String]
     public let parameters: [String: Any]?


### PR DESCRIPTION
Currently there is no way to identify a request between retries, which it a bit limiting.
This PR adds an identifier to a request that keeps the same between retries.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)