### PR TITLE
#20868 - [REQ] [JAVA] [restClient] replace Deprecated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -658,7 +658,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -754,7 +754,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -763,7 +763,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -666,7 +666,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -612,7 +612,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -672,7 +672,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -681,7 +681,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -610,7 +610,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/ApiClient.java
@@ -615,7 +615,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -615,7 +615,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -636,7 +636,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -610,7 +610,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -630,7 +630,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -630,7 +630,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -630,7 +630,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -673,7 +673,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -682,7 +682,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -673,7 +673,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -682,7 +682,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -673,7 +673,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -682,7 +682,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -736,7 +736,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -745,7 +745,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -731,7 +731,7 @@ public class ApiClient extends JavaTimeFormatter {
             finalUri += "?" + queryUri;
         }
         String expandedPath = this.expandPath(finalUri, uriParams);
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(expandedPath);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(expandedPath);
 
         URI uri;
         try {
@@ -740,7 +740,7 @@ public class ApiClient extends JavaTimeFormatter {
             throw new RestClientException("Could not build URL: " + builder.toUriString(), ex);
         }
 
-        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromHttpUrl(basePath).toUriString() + finalUri, uriParams);
+        final BodyBuilder requestBuilder = RequestEntity.method(method, UriComponentsBuilder.fromUriString(basePath).toUriString() + finalUri, uriParams);
         if (accept != null) {
             requestBuilder.accept(accept.toArray(new MediaType[accept.size()]));
         }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -656,7 +656,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -636,7 +636,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -656,7 +656,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -656,7 +656,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -656,7 +656,7 @@ public class ApiClient extends JavaTimeFormatter {
         MediaType contentType, String[] authNames) {
         updateParamsForAuth(authNames, queryParams, headerParams, cookieParams);
 
-        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(basePath).path(path);
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(basePath).path(path);
 
         String finalUri = builder.build(false).toUriString();
         Map<String, Object> uriParams = new HashMap<>();


### PR DESCRIPTION
Replace all UriComponentsBuilder.fromHttpUrl() with UriComponentsBuilder.fromUriString() because UriComponentsBuilder.fromHttpUrl will be removed in the near future.
