### PR TITLE
[swift6] Add typed throws to Validation functions

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/Validation.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Validation.mustache
@@ -48,9 +48,8 @@ extension NumericRule: Sendable where T: Sendable {}
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ extension NumericRule: Sendable where T: Sendable {}
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ extension NumericRule: Sendable where T: Sendable {}
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ extension NumericRule: Sendable where T: Sendable {}
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ extension NumericRule: Sendable where T: Sendable {}
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ internal struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    internal static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    internal static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ internal struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ internal struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    internal static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    internal static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ internal struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    internal static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    internal static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ internal struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    internal static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    internal static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)

--- a/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
+++ b/samples/client/petstore/swift6/vaporLibrary/Sources/PetstoreClient/Infrastructure/Validation.swift
@@ -48,9 +48,8 @@ public struct Validator {
     /// - Parameter string: The String you wish to validate.
     /// - Parameter rule: The StringRule you wish to use for validation.
     /// - Returns: A validated string.
-    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule,
-    ///           `NSError` if the rule.pattern is invalid.
-    public static func validate(_ string: String, against rule: StringRule) throws -> String {
+    /// - Throws: `ValidationError<StringValidationErrorKind>` if the string is invalid against the rule or if the rule.pattern is invalid.
+    public static func validate(_ string: String, against rule: StringRule) throws(ValidationError<StringValidationErrorKind>) -> String {
         var error = ValidationError<StringValidationErrorKind>(kinds: [])
         if let minLength = rule.minLength, !(minLength <= string.count) {
             error.kinds.insert(.minLength)
@@ -59,9 +58,9 @@ public struct Validator {
             error.kinds.insert(.maxLength)
         }
         if let pattern = rule.pattern {
-            let matches = try NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+            let matches = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
                 .matches(in: string, range: .init(location: 0, length: string.utf16.count))
-            if matches.isEmpty {
+            if matches?.isEmpty != false {
                 error.kinds.insert(.pattern)
             }
         }
@@ -76,7 +75,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated integer.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & BinaryInteger>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -108,7 +107,7 @@ public struct Validator {
     /// - Parameter rule: The NumericRule you wish to use for validation.
     /// - Returns: A validated fractional number.
     /// - Throws: `ValidationError<NumericValidationErrorKind>` if the numeric is invalid against the rule.
-    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws -> T {
+    public static func validate<T: Comparable & FloatingPoint>(_ numeric: T, against rule: NumericRule<T>) throws(ValidationError<NumericValidationErrorKind>) -> T {
         var error = ValidationError<NumericValidationErrorKind>(kinds: [])
         if let minimum = rule.minimum {
             if !rule.exclusiveMinimum, minimum > numeric {
@@ -140,7 +139,7 @@ public struct Validator {
     /// - Parameter rule: The ArrayRule you wish to use for validation.
     /// - Returns: A validated array.
     /// - Throws: `ValidationError<ArrayValidationErrorKind>` if the string is invalid against the rule.
-    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws -> Array<AnyHashable> {
+    public static func validate(_ array: Array<AnyHashable>, against rule: ArrayRule) throws(ValidationError<ArrayValidationErrorKind>) -> Array<AnyHashable> {
         var error = ValidationError<ArrayValidationErrorKind>(kinds: [])
         if let minItems = rule.minItems, !(minItems <= array.count) {
             error.kinds.insert(.minItems)


### PR DESCRIPTION
Swift 6 allows for the `throws` keyword to specify the type of error being thrown. In the case of Validation, this will save one unboxing/casting operation and make the result easier to use.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)