### PR TITLE
[Swift][client] make alamofire version more flexible and build projects on CI before running unit tests

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/Cartfile.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Cartfile.mustache
@@ -1,4 +1,4 @@
 {{#useAlamofire}}
-github "Alamofire/Alamofire" = 5.10.2{{/useAlamofire}}{{#usePromiseKit}}
+github "Alamofire/Alamofire" ~> 5.10{{/useAlamofire}}{{#usePromiseKit}}
 github "mxcl/PromiseKit" ~> 8.1{{/usePromiseKit}}{{#useRxSwift}}
 github "ReactiveX/RxSwift" ~> 6.8{{/useRxSwift}}

--- a/modules/openapi-generator/src/main/resources/swift6/Package.swift.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Package.swift.mustache
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         {{#useAlamofire}}
-        .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.10.2"),
+        .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.10.2")),
         {{/useAlamofire}}
         {{#usePromiseKit}}
         .package(url: "https://github.com/mxcl/PromiseKit", .upToNextMajor(from: "8.1.2")),

--- a/modules/openapi-generator/src/main/resources/swift6/Podspec.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Podspec.mustache
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   {{/podDocumentationURL}}
   s.source_files = '{{swiftPackagePath}}{{^swiftPackagePath}}{{#useSPMFileStructure}}Sources/{{projectName}}{{/useSPMFileStructure}}{{^useSPMFileStructure}}{{projectName}}/Classes{{/useSPMFileStructure}}{{/swiftPackagePath}}/**/*.swift'
   {{#useAlamofire}}
-  s.dependency 'Alamofire', '5.10.2'
+  s.dependency 'Alamofire', '~> 5.10'
   {{/useAlamofire}}
   {{#usePromiseKit}}
   s.dependency 'PromiseKit/CorePromise', '~> 8.1'

--- a/samples/client/petstore/swift6/alamofireLibrary/Cartfile
+++ b/samples/client/petstore/swift6/alamofireLibrary/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" = 5.10.2
+github "Alamofire/Alamofire" ~> 5.10

--- a/samples/client/petstore/swift6/alamofireLibrary/Package.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.10.2"),
+        .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.10.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/samples/client/petstore/swift6/alamofireLibrary/PetstoreClient.podspec
+++ b/samples/client/petstore/swift6/alamofireLibrary/PetstoreClient.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'Sources/PetstoreClient/**/*.swift'
-  s.dependency 'Alamofire', '5.10.2'
+  s.dependency 'Alamofire', '~> 5.10'
 end

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Cartfile
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Cartfile
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" = 5.10.2
+github "Alamofire/Alamofire" ~> 5.10
 github "mxcl/PromiseKit" ~> 8.1
 github "ReactiveX/RxSwift" ~> 6.8

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Package.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.10.2"),
+        .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.10.2")),
         .package(url: "https://github.com/mxcl/PromiseKit", .upToNextMajor(from: "8.1.2")),
         .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.8.0")),
     ],

--- a/samples/client/petstore/swift6/apiNonStaticMethod/PetstoreClient.podspec
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/PetstoreClient.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/openapitools/openapi-generator'
   s.summary = 'PetstoreClient'
   s.source_files = 'Sources/PetstoreClient/**/*.swift'
-  s.dependency 'Alamofire', '5.10.2'
+  s.dependency 'Alamofire', '~> 5.10'
   s.dependency 'PromiseKit/CorePromise', '~> 8.1'
   s.dependency 'RxSwift', '~> 6.8'
 end

--- a/samples/client/petstore/swift6/swift6_test_all.sh
+++ b/samples/client/petstore/swift6/swift6_test_all.sh
@@ -3,17 +3,6 @@ set -e
 
 DIRECTORY=`dirname $0`
 
-# example project with unit tests
-(cd $DIRECTORY/alamofireLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/apiNonStaticMethod/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/asyncAwaitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-# (cd $DIRECTORY/combineLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/combineDeferredLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/default/SwaggerClientTests/ && ./run_xcodebuild.sh)
-# (cd $DIRECTORY/promisekitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/rxswiftLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-(cd $DIRECTORY/urlsessionLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
-
 # spm build
 (cd $DIRECTORY/alamofireLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/apiNonStaticMethod/ && ./run_spmbuild.sh)
@@ -23,10 +12,20 @@ DIRECTORY=`dirname $0`
 (cd $DIRECTORY/default/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/objcCompatible/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/oneOf/ && ./run_spmbuild.sh)
-# (cd $DIRECTORY/promisekitLibrary/ && ./run_spmbuild.sh)
+# (cd $DIRECTORY/promisekitLibrary/ && ./run_spmbuild.sh) # Commented to save time in CI, building Swift5 and Swift6 is taking too much time, and making CI fail
 (cd $DIRECTORY/resultLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/rxswiftLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/urlsessionLibrary/ && ./run_spmbuild.sh)
 (cd $DIRECTORY/validation/ && ./run_spmbuild.sh)
-# #(cd $DIRECTORY/vaporLibrary/ && ./run_spmbuild.sh)
+# (cd $DIRECTORY/vaporLibrary/ && ./run_spmbuild.sh) # Commented because it's not working
 
+# example project with unit tests
+(cd $DIRECTORY/alamofireLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/apiNonStaticMethod/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/asyncAwaitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+# (cd $DIRECTORY/combineLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh) # Commented to save time in CI, building Swift5 and Swift6 is taking too much time, and making CI fail
+(cd $DIRECTORY/combineDeferredLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/default/SwaggerClientTests/ && ./run_xcodebuild.sh)
+# (cd $DIRECTORY/promisekitLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh) # Commented to save time in CI, building Swift5 and Swift6 is taking too much time, and making CI fail
+(cd $DIRECTORY/rxswiftLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)
+(cd $DIRECTORY/urlsessionLibrary/SwaggerClientTests/ && ./run_xcodebuild.sh)


### PR DESCRIPTION
[Swift][client] make alamofire version more flexible and build projects on CI before running unit tests

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)