### PR TITLE
Added go server generation to use http/net

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -49,7 +49,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
     /**
      * List of available routers
      */
-    private static final String[] ROUTERS = {"mux", "chi"};
+    private static final String[] ROUTERS = {"stdmux", "mux", "chi"};
 
     private final Logger LOGGER = LoggerFactory.getLogger(GoServerCodegen.class);
 

--- a/modules/openapi-generator/src/main/resources/go-server/Dockerfile.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/Dockerfile.mustache
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS build
+FROM golang:1.22 AS build
 WORKDIR /go/src
 COPY {{sourceFolder}} ./{{sourceFolder}}
 COPY main.go .

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -14,8 +14,9 @@ import (
 	{{/isBodyParam}}
 	"net/http"
 	"strings"
-{{#imports}}	"{{import}}"
-	{{/imports}}
+{{#imports}}
+    "{{import}}"
+{{/imports}}
 {{#hasPathParams}}
 
 {{#routers}}
@@ -112,7 +113,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{#isPathParam}}
 	{{#isNumber}}
 	{{paramName}}Param, err := parseNumericParameter[float32](
-		{{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
+		{{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
 		WithDefaultOrParse[float32]({{defaultValue}}, parseFloat32),{{/defaultValue}}{{^defaultValue}}{{#required}}
 		WithRequire[float32](parseFloat32),{{/required}}{{/defaultValue}}{{^defaultValue}}{{^required}}
 		WithParse[float32](parseFloat32),{{/required}}{{/defaultValue}}{{#minimum}}
@@ -126,7 +127,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isNumber}}
 	{{#isFloat}}
 	{{paramName}}Param, err := parseNumericParameter[float32](
-		{{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
+		{{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
 		WithDefaultOrParse[float32]({{defaultValue}}, parseFloat32),{{/defaultValue}}{{^defaultValue}}{{#required}}
 		WithRequire[float32](parseFloat32),{{/required}}{{/defaultValue}}{{^defaultValue}}{{^required}}
 		WithParse[float32](parseFloat32),{{/required}}{{/defaultValue}}{{#minimum}}
@@ -140,7 +141,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isFloat}}
 	{{#isDouble}}
 	{{paramName}}Param, err := parseNumericParameter[float64](
-		{{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
+		{{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
 		WithDefaultOrParse[float64]({{defaultValue}}, parseFloat64),{{/defaultValue}}{{^defaultValue}}{{#required}}
 		WithRequire[float64](parseFloat64),{{/required}}{{/defaultValue}}{{^defaultValue}}{{^required}}
 		WithParse[float64](parseFloat64),{{/required}}{{/defaultValue}}{{#minimum}}
@@ -154,7 +155,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isDouble}}
 	{{#isLong}}
 	{{paramName}}Param, err := parseNumericParameter[int64](
-		{{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
+		{{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
 		WithDefaultOrParse[int64]({{defaultValue}}, parseInt64),{{/defaultValue}}{{^defaultValue}}{{#required}}
 		WithRequire[int64](parseInt64),{{/required}}{{/defaultValue}}{{^defaultValue}}{{^required}}
 		WithParse[int64](parseInt64),{{/required}}{{/defaultValue}}{{#minimum}}
@@ -168,7 +169,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isLong}}
 	{{#isInteger}}
 	{{paramName}}Param, err := parseNumericParameter[int32](
-		{{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
+		{{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}},{{#defaultValue}}
 		WithDefaultOrParse[int32]({{defaultValue}}, parseInt32),{{/defaultValue}}{{^defaultValue}}{{#required}}
 		WithRequire[int32](parseInt32),{{/required}}{{/defaultValue}}{{^defaultValue}}{{^required}}
 		WithParse[int32](parseInt32),{{/required}}{{/defaultValue}}{{#minimum}}
@@ -181,7 +182,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	}
 	{{/isInteger}}
 	{{#isDateTime}}
-	{{paramName}}Param, err := parseTime({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}})
+	{{paramName}}Param, err := parseTime({{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}})
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
@@ -194,14 +195,14 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{^isInteger}}
 	{{^isDateTime}}
 	{{^isEnumRef}}
-	{{paramName}}Param := {{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}
+	{{paramName}}Param := {{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}}
 	if {{paramName}}Param == "" {
 		c.errorHandler(w, r, &RequiredError{"{{baseName}}"}, nil)
 		return
 	}
 	{{/isEnumRef}}
 	{{#isEnumRef}}
-	{{paramName}}Param, err := New{{dataType}}FromValue({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}})
+	{{paramName}}Param, err := New{{dataType}}FromValue({{#routers}}{{#stdmux}}r.PathValue("{{baseName}}"){{/stdmux}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}})
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return

--- a/modules/openapi-generator/src/main/resources/go-server/go.mod.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/go.mod.mustache
@@ -1,6 +1,6 @@
 module {{gitHost}}/{{gitUserId}}/{{gitRepoId}}
 
-go 1.18
+go 1.22
 
 {{#hasPathParams}}
 {{#routers}}

--- a/modules/openapi-generator/src/main/resources/go-server/logger.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/logger.mustache
@@ -4,6 +4,10 @@ package {{packageName}}
 import (
 	"net/http"
 {{#routers}}
+    {{#stdmux}}
+    "log"
+    "time"
+    {{/stdmux}}
 	{{#mux}}
 	"log"
 	"time"
@@ -15,6 +19,23 @@ import (
 )
 
 {{#routers}}
+{{#stdmux}}
+func Logger(inner http.Handler, name string) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        start := time.Now()
+
+        inner.ServeHTTP(w, r)
+
+        log.Printf(
+            "%s %s %s %s",
+            r.Method,
+            r.RequestURI,
+            name,
+            time.Since(start),
+        )
+    })
+}
+{{/stdmux}}
 {{#mux}}
 func Logger(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -4,6 +4,9 @@ package {{packageName}}
 import (
 	"net/http"
 {{#routers}}
+    {{#stdmux}}
+    "fmt"
+    {{/stdmux}}
 	{{#mux}}
 	"github.com/gorilla/mux"
 	{{#featureCORS}}
@@ -33,10 +36,32 @@ type Routes map[string]Route
 type Router interface {
 	Routes() Routes
 }
-
-// NewRouter creates a new router for any number of api routers
-func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}}chi.Router{{/chi}}{{/routers}} {
 {{#routers}}
+{{#stdmux}}
+{{#featureCORS}}
+func CORS(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Access-Control-Allow-Origin", "*")
+        w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+        w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+        if r.Method == http.MethodOptions {
+            w.WriteHeader(http.StatusNoContent)
+            return
+        }
+
+        next.ServeHTTP(w, r)
+    })
+}
+{{/featureCORS}}
+{{/stdmux}}
+{{/routers}}
+// NewRouter creates a new router for any number of api routers
+func NewRouter(routers ...Router) {{#routers}}{{#stdmux}}*http.ServeMux{{/stdmux}}{{#mux}}*mux.Router{{/mux}}{{#chi}}chi.Router{{/chi}}{{/routers}} {
+{{#routers}}
+    {{#stdmux}}
+    router := http.NewServeMux()
+    {{/stdmux}}
 	{{#mux}}
 	router := mux.NewRouter().StrictSlash(true)
 	{{/mux}}
@@ -49,9 +74,16 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 	{{/chi}}
 {{/routers}}
 	for _, api := range routers {
-		for {{#routers}}{{#mux}}name{{/mux}}{{#chi}}_{{/chi}}{{/routers}}, route := range api.Routes() {
+		for {{#routers}}{{#stdmux}}name{{/stdmux}}{{#mux}}name{{/mux}}{{#chi}}_{{/chi}}{{/routers}}, route := range api.Routes() {
 			var handler http.Handler = route.HandlerFunc
 {{#routers}}
+    {{#stdmux}}
+            handler = Logger(handler, name)
+            {{#featureCORS}}
+            handler = CORS(handler)
+            {{/featureCORS}}
+            router.HandleFunc(fmt.Sprintf("%s %s", route.Method, route.Pattern), handler.ServeHTTP)
+    {{/stdmux}}
 	{{#mux}}
 			handler = Logger(handler, name)
 			{{#featureCORS}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
issue - https://github.com/OpenAPITools/openapi-generator/issues/20900
- go ROUTER stdmux added.
- Followed the same logging as current mux.
- Other files modified use http/net method for pattern matching.
- A very simple CORS solution has been added.
- Dockerfile/go.mod uses 1.22 this should not have breaking changes.
- Tests are outstanding

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
