### PR TITLE
update scala-akka-http-server generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-akka-http-server/multipartDirectives.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-http-server/multipartDirectives.mustache
@@ -70,7 +70,7 @@ trait MultipartDirectives {
 
 object MultipartDirectives extends MultipartDirectives with FileUploadDirectives {
   val tempFileFromFileInfo: FileInfo => File = {
-    file: FileInfo => Files.createTempFile(file.fileName, ".tmp").toFile()
+    (file: FileInfo) => Files.createTempFile(file.fileName, ".tmp").toFile()
   }
 }
 

--- a/samples/server/petstore/scala-akka-http-server/src/main/scala/org/openapitools/server/MultipartDirectives.scala
+++ b/samples/server/petstore/scala-akka-http-server/src/main/scala/org/openapitools/server/MultipartDirectives.scala
@@ -70,7 +70,7 @@ trait MultipartDirectives {
 
 object MultipartDirectives extends MultipartDirectives with FileUploadDirectives {
   val tempFileFromFileInfo: FileInfo => File = {
-    file: FileInfo => Files.createTempFile(file.fileName, ".tmp").toFile()
+    (file: FileInfo) => Files.createTempFile(file.fileName, ".tmp").toFile()
   }
 }
 

--- a/samples/server/petstore/scala-pekko-http-server/src/main/scala/org/openapitools/server/MultipartDirectives.scala
+++ b/samples/server/petstore/scala-pekko-http-server/src/main/scala/org/openapitools/server/MultipartDirectives.scala
@@ -70,7 +70,7 @@ trait MultipartDirectives {
 
 object MultipartDirectives extends MultipartDirectives with FileUploadDirectives {
   val tempFileFromFileInfo: FileInfo => File = {
-    file: FileInfo => Files.createTempFile(file.fileName, ".tmp").toFile()
+    (file: FileInfo) => Files.createTempFile(file.fileName, ".tmp").toFile()
   }
 }
 


### PR DESCRIPTION
Scala 3.x or latest Scala 2.13.x with migrate option( `-Xsource:3-cross` ) require parentheses in lambda params. 
 
```
Welcome to Scala 3.6.4 (11.0.26, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> { (x: Int) => x }
val res0: Int => Int = Lambda$1505/0x00000008007f0040@389008d1
                                                                                                                                             
scala> { x: Int => x }
-- Error: ----------------------------------------------------------------------
1 |{ x: Int => x }
  |         ^
  |         parentheses are required around the parameter of a lambda
```

```
$ scala -Xsource:3-cross
Welcome to Scala 2.13.16 -Xsource:3.0.0 (OpenJDK 64-Bit Server VM, Java 11.0.26).
Type in expressions for evaluation. Or try :help.

scala> { (x: Int) => x }
val res0: Int => Int = $Lambda$1088/0x00000008006b0840@591a4f8e

scala> { x: Int => x }
          ^
       error: parentheses are required around the parameter of a lambda
       Use '-Wconf:msg=lambda-parens:s' to silence this warning. [quickfixable]
       Scala 3 migration messages are issued as errors under -Xsource:3. Use -Wconf or @nowarn to demote them to warnings or suppress.
       Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration
```


<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
