### PR TITLE
[Swift][client] fix parameters encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/APIHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/APIHelper.mustache
@@ -71,7 +71,7 @@ import Vapor{{/useVapor}}
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache
@@ -11,20 +11,49 @@ import FoundationNetworking
 @preconcurrency import PromiseKit{{/usePromiseKit}}{{#useVapor}}
 import Vapor{{/useVapor}}{{^useVapor}}
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache
@@ -17,43 +17,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -10,20 +10,49 @@ import FoundationNetworking
 #endif
 @preconcurrency import PromiseKit
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -16,43 +16,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -10,20 +10,49 @@ import FoundationNetworking
 #endif
 @preconcurrency import PromiseKit
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -16,43 +16,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ internal struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    internal static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    internal static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -70,7 +70,7 @@ public struct APIHelper {
     /// maps all values from source to query parameters
     ///
     /// explode attribute is respected: collection values might be either joined or split up into separate key value pairs
-    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: Any?, isExplode: Bool)]) -> [URLQueryItem]? {
+    public static func mapValuesToQueryItems(_ source: [String: (wrappedValue: (any Sendable)?, isExplode: Bool)]) -> [URLQueryItem]? {
         let destination = source.filter { $0.value.wrappedValue != nil }.reduce(into: [URLQueryItem]()) { result, item in
             if let collection = item.value.wrappedValue as? [Any?] {
 

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -15,43 +15,43 @@ extension QueryStringEncodable {
 }
 
 extension Bool: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Float: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int32: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Int64: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Double: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension Decimal: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension String: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension URL: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension UUID: QueryStringEncodable {
-    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -9,20 +9,49 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension Bool: QueryStringEncodable {}
-extension Float: QueryStringEncodable {}
-extension Int: QueryStringEncodable {}
-extension Int32: QueryStringEncodable {}
-extension Int64: QueryStringEncodable {}
-extension Double: QueryStringEncodable {}
-extension Decimal: QueryStringEncodable {}
-extension String: QueryStringEncodable {}
-extension URL: QueryStringEncodable {}
-extension UUID: QueryStringEncodable {}
-
 extension QueryStringEncodable {
     @_disfavoredOverload
     func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self) }
+}
+
+extension Bool: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Float: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int32: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Int64: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Double: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension Decimal: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension String: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension URL: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
+}
+
+extension UUID: QueryStringEncodable {
+    func encodeToQueryString(codableHelper: CodableHelper) -> String { String(describing: self)}
 }
 
 extension RawRepresentable where RawValue: QueryStringEncodable {


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/pull/20906 introduced two issues related to the parameters encoding.

The first problem is the following.

The default overload is disfavored and this is correct, this overload should be the last option to execute, if no other overload is compatible.
https://github.com/OpenAPITools/openapi-generator/blob/6e3b1996ed2f8a9cfb2fee1f60138b2ed4d77341/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache#L25-L28

Those protocol conformance should execute the previous default implementation, but actually those are codable, so it will execute the overload of the codable. 
https://github.com/OpenAPITools/openapi-generator/blob/6e3b1996ed2f8a9cfb2fee1f60138b2ed4d77341/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache#L14-L23

https://github.com/OpenAPITools/openapi-generator/blob/6e3b1996ed2f8a9cfb2fee1f60138b2ed4d77341/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache#L76-L83

To fix this, I created an implementation to the basic types.

The second problem is that the `Any` parameter should be `any Sendable`
https://github.com/OpenAPITools/openapi-generator/blob/6e3b1996ed2f8a9cfb2fee1f60138b2ed4d77341/modules/openapi-generator/src/main/resources/swift6/APIHelper.mustache#L74

Otherwise it will always prefer this overload.
https://github.com/OpenAPITools/openapi-generator/blob/6e3b1996ed2f8a9cfb2fee1f60138b2ed4d77341/modules/openapi-generator/src/main/resources/swift6/APIHelper.mustache#L103

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)