### PR TITLE
Discard mapped dmodels with matching explicit discriminator mappings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3664,7 +3664,8 @@ public class DefaultCodegen implements CodegenConfig {
         if (ModelUtils.isComposedSchema(schema) && !this.getLegacyDiscriminatorBehavior()) {
             List<MappedModel> otherDescendants = getOneOfAnyOfDescendants(schemaName, discriminatorPropertyName, schema);
             for (MappedModel otherDescendant : otherDescendants) {
-                if (!uniqueDescendants.contains(otherDescendant)) {
+                // add only if the model names are not the same
+                if (uniqueDescendants.stream().map(MappedModel::getModelName).noneMatch(it -> it.equals(otherDescendant.getModelName()))) {
                     uniqueDescendants.add(otherDescendant);
                 }
             }

--- a/samples/client/others/go/oneof-discriminator-lookup/model_object.go
+++ b/samples/client/others/go/oneof-discriminator-lookup/model_object.go
@@ -70,30 +70,6 @@ func (dst *Object) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	// check if the discriminator value is 'NestedObject1'
-	if jsonDict["type"] == "NestedObject1" {
-		// try to unmarshal JSON data into NestedObject1
-		err = json.Unmarshal(data, &dst.NestedObject1)
-		if err == nil {
-			return nil // data stored in dst.NestedObject1, return on the first match
-		} else {
-			dst.NestedObject1 = nil
-			return fmt.Errorf("failed to unmarshal Object as NestedObject1: %s", err.Error())
-		}
-	}
-
-	// check if the discriminator value is 'NestedObject2'
-	if jsonDict["type"] == "NestedObject2" {
-		// try to unmarshal JSON data into NestedObject2
-		err = json.Unmarshal(data, &dst.NestedObject2)
-		if err == nil {
-			return nil // data stored in dst.NestedObject2, return on the first match
-		} else {
-			dst.NestedObject2 = nil
-			return fmt.Errorf("failed to unmarshal Object as NestedObject2: %s", err.Error())
-		}
-	}
-
 	return nil
 }
 

--- a/samples/openapi3/client/petstore/go/go-petstore/model_filter_any.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_filter_any.go
@@ -66,38 +66,6 @@ func (dst *FilterAny) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	// check if the discriminator value is 'FilterTypeRange'
-	if jsonDict["type"] == "FilterTypeRange" {
-		// try to unmarshal JSON data into FilterTypeRange
-		err = json.Unmarshal(data, &dst.FilterTypeRange);
-		if err == nil {
-			jsonFilterTypeRange, _ := json.Marshal(dst.FilterTypeRange)
-			if string(jsonFilterTypeRange) == "{}" { // empty struct
-				dst.FilterTypeRange = nil
-			} else {
-				return nil // data stored in dst.FilterTypeRange, return on the first match
-			}
-		} else {
-			dst.FilterTypeRange = nil
-		}
-	}
-
-	// check if the discriminator value is 'FilterTypeRegex'
-	if jsonDict["type"] == "FilterTypeRegex" {
-		// try to unmarshal JSON data into FilterTypeRegex
-		err = json.Unmarshal(data, &dst.FilterTypeRegex);
-		if err == nil {
-			jsonFilterTypeRegex, _ := json.Marshal(dst.FilterTypeRegex)
-			if string(jsonFilterTypeRegex) == "{}" { // empty struct
-				dst.FilterTypeRegex = nil
-			} else {
-				return nil // data stored in dst.FilterTypeRegex, return on the first match
-			}
-		} else {
-			dst.FilterTypeRegex = nil
-		}
-	}
-
 	// try to unmarshal JSON data into FilterTypeRange
 	err = json.Unmarshal(data, &dst.FilterTypeRange);
 	if err == nil {

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Fruit.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/model/Fruit.java
@@ -30,9 +30,7 @@ import javax.annotation.Generated;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "fruitType", visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Apple.class, name = "APPLE"),
-  @JsonSubTypes.Type(value = Banana.class, name = "BANANA"),
-  @JsonSubTypes.Type(value = Apple.class, name = "Apple"),
-  @JsonSubTypes.Type(value = Banana.class, name = "Banana")
+  @JsonSubTypes.Type(value = Banana.class, name = "BANANA")
 })
 
 @Generated(value = "org.openapitools.codegen.languages.SpringCodegen", comments = "Generator version: 7.13.0-SNAPSHOT")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

See https://github.com/OpenAPITools/openapi-generator/issues/20938

This fixes the issue by checking if an explicit discriminator has been set already for a model name by checking for equality by model name instead of `MappedModel` (which included the mapping name).