### PR TITLE
[Java] Extend JavaSpring apiClient.mustache with option to set contextId for FeignClient

### DIFF
--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -99,6 +99,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |unhandledException|Declare operation methods to throw a generic exception and allow unhandled exceptions (useful for Spring `@ControllerAdvice` directives).| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useEnumCaseInsensitive|Use `equalsIgnoreCase` when String for enum comparison| |false|
+|useFeignClientContextId|Whether to generate Feign client with contextId parameter.| |true|
 |useFeignClientUrl|Whether to generate Feign client with url parameter.| |true|
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -92,6 +92,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |unhandledException|Declare operation methods to throw a generic exception and allow unhandled exceptions (useful for Spring `@ControllerAdvice` directives).| |false|
 |useBeanValidation|Use BeanValidation API annotations| |true|
 |useEnumCaseInsensitive|Use `equalsIgnoreCase` when String for enum comparison| |false|
+|useFeignClientContextId|Whether to generate Feign client with contextId parameter.| |true|
 |useFeignClientUrl|Whether to generate Feign client with url parameter.| |true|
 |useJakartaEe|whether to use Jakarta EE namespace instead of javax| |false|
 |useOneOfInterfaces|whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -66,6 +66,7 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String INTERFACE_ONLY = "interfaceOnly";
     public static final String USE_FEIGN_CLIENT_URL = "useFeignClientUrl";
     public static final String USE_FEIGN_CLIENT = "useFeignClient";
+    public static final String USE_FEIGN_CLIENT_CONTEXT_ID = "useFeignClientContextId";
     public static final String DELEGATE_PATTERN = "delegatePattern";
     public static final String SINGLE_CONTENT_TYPES = "singleContentTypes";
     public static final String VIRTUAL_SERVICE = "virtualService";
@@ -124,6 +125,7 @@ public class SpringCodegen extends AbstractJavaCodegen
 
     @Setter protected boolean interfaceOnly = false;
     @Setter protected boolean useFeignClientUrl = true;
+    @Setter protected boolean useFeignClientContextId = true;
     @Setter protected boolean delegatePattern = false;
     protected boolean delegateMethod = false;
     @Setter protected boolean singleContentTypes = false;
@@ -200,6 +202,8 @@ public class SpringCodegen extends AbstractJavaCodegen
                 "Whether to generate only API interface stubs without the server files.", interfaceOnly));
         cliOptions.add(CliOption.newBoolean(USE_FEIGN_CLIENT_URL,
                 "Whether to generate Feign client with url parameter.", useFeignClientUrl));
+        cliOptions.add(CliOption.newBoolean(USE_FEIGN_CLIENT_CONTEXT_ID,
+                "Whether to generate Feign client with contextId parameter.", useFeignClientContextId));
         cliOptions.add(CliOption.newBoolean(DELEGATE_PATTERN,
                 "Whether to generate the server files using the delegate pattern", delegatePattern));
         cliOptions.add(CliOption.newBoolean(SINGLE_CONTENT_TYPES,
@@ -398,6 +402,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         convertPropertyToBooleanAndWriteBack(VIRTUAL_SERVICE, this::setVirtualService);
         convertPropertyToBooleanAndWriteBack(INTERFACE_ONLY, this::setInterfaceOnly);
         convertPropertyToBooleanAndWriteBack(USE_FEIGN_CLIENT_URL, this::setUseFeignClientUrl);
+        convertPropertyToBooleanAndWriteBack(USE_FEIGN_CLIENT_CONTEXT_ID, this::setUseFeignClientContextId);
         convertPropertyToBooleanAndWriteBack(DELEGATE_PATTERN, this::setDelegatePattern);
         convertPropertyToBooleanAndWriteBack(SINGLE_CONTENT_TYPES, this::setSingleContentTypes);
         convertPropertyToBooleanAndWriteBack(SKIP_DEFAULT_INTERFACE, this::setSkipDefaultInterface);

--- a/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/apiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/libraries/spring-cloud/apiClient.mustache
@@ -3,6 +3,6 @@ package {{package}};
 import org.springframework.cloud.openfeign.FeignClient;
 import {{configPackage}}.ClientConfiguration;
 
-@FeignClient(name="${{openbrace}}{{classVarName}}.name:{{classVarName}}{{closebrace}}", {{#useFeignClientUrl}}url="${{openbrace}}{{classVarName}}.url:{{basePath}}{{closebrace}}", {{/useFeignClientUrl}}configuration = ClientConfiguration.class)
+@FeignClient(name="${{openbrace}}{{classVarName}}.name:{{classVarName}}{{closebrace}}", {{#useFeignClientContextId}}contextId="${{openbrace}}{{classVarName}}.contextId:${{openbrace}}{{classVarName}}.name{{closebrace}}{{closebrace}}",{{/useFeignClientContextId}} {{#useFeignClientUrl}}url="${{openbrace}}{{classVarName}}.url:{{basePath}}{{closebrace}}",{{/useFeignClientUrl}} configuration = ClientConfiguration.class)
 public interface {{classname}}Client extends {{classname}} {
 }

--- a/samples/client/petstore/spring-cloud-auth/src/main/java/org/openapitools/api/SomeApiClient.java
+++ b/samples/client/petstore/spring-cloud-auth/src/main/java/org/openapitools/api/SomeApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${some.name:some}", url="${some.url:http://localhost}", configuration = ClientConfiguration.class)
+@FeignClient(name="${some.name:some}", contextId="${some.contextId:${some.name}}", url="${some.url:http://localhost}", configuration = ClientConfiguration.class)
 public interface SomeApiClient extends SomeApi {
 }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApiClient.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${pet.name:pet}", configuration = ClientConfiguration.class)
+@FeignClient(name="${pet.name:pet}", contextId="${pet.contextId:${pet.name}}",  configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/StoreApiClient.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${store.name:store}", configuration = ClientConfiguration.class)
+@FeignClient(name="${store.name:store}", contextId="${store.contextId:${store.name}}",  configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/UserApiClient.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/UserApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${user.name:user}", configuration = ClientConfiguration.class)
+@FeignClient(name="${user.name:user}", contextId="${user.contextId:${user.name}}",  configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApiClient.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${pet.name:pet}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${pet.name:pet}", contextId="${pet.contextId:${pet.name}}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApiClient.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${store.name:store}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${store.name:store}", contextId="${store.contextId:${store.name}}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApiClient.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${user.name:user}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${user.name:user}", contextId="${user.contextId:${user.name}}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/PetApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/PetApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${pet.name:pet}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${pet.name:pet}", contextId="${pet.contextId:${pet.name}}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/StoreApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${store.name:store}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${store.name:store}", contextId="${store.contextId:${store.name}}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/UserApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/UserApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${user.name:user}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${user.name:user}", contextId="${user.contextId:${user.name}}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${pet.name:pet}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${pet.name:pet}", contextId="${pet.contextId:${pet.name}}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${store.name:store}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${store.name:store}", contextId="${store.contextId:${store.name}}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${user.name:user}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${user.name:user}", contextId="${user.contextId:${user.name}}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${pet.name:pet}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${pet.name:pet}", contextId="${pet.contextId:${pet.name}}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${store.name:store}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${store.name:store}", contextId="${store.contextId:${store.name}}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${user.name:user}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${user.name:user}", contextId="${user.contextId:${user.name}}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${pet.name:pet}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${pet.name:pet}", contextId="${pet.contextId:${pet.name}}", url="${pet.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface PetApiClient extends PetApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${store.name:store}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${store.name:store}", contextId="${store.contextId:${store.name}}", url="${store.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface StoreApiClient extends StoreApi {
 }

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApiClient.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApiClient.java
@@ -3,6 +3,6 @@ package org.openapitools.api;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.openapitools.configuration.ClientConfiguration;
 
-@FeignClient(name="${user.name:user}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
+@FeignClient(name="${user.name:user}", contextId="${user.contextId:${user.name}}", url="${user.url:http://petstore.swagger.io/v2}", configuration = ClientConfiguration.class)
 public interface UserApiClient extends UserApi {
 }


### PR DESCRIPTION
This PR is based on #20941
Extended JavaSpring apiClient.mustache with option to set contextId for FeignClient.
Added new option `useFeignClientContextId` which allows to generate FeignClient with `contextId` parameter.
By default `contextId` will be equal to `name`. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
