### PR TITLE
[protobuf-schema] Remove 'model/' prefix from Protobuf imports for mapped custom packages

### DIFF
--- a/bin/configs/protobuf-schema-config.yaml
+++ b/bin/configs/protobuf-schema-config.yaml
@@ -8,3 +8,7 @@ additionalProperties:
   numberedFieldNumberList: true
   startEnumsWithUnspecified: true
   wrapComplexType: false
+typeMappings:
+  object: "google.protobuf.Struct"
+importMappings:
+  google.protobuf.Struct: "google/protobuf/struct"

--- a/bin/configs/protobuf-schema.yaml
+++ b/bin/configs/protobuf-schema.yaml
@@ -4,3 +4,7 @@ inputSpec: modules/openapi-generator/src/test/resources/3_0/protobuf/petstore.ya
 templateDir: modules/openapi-generator/src/main/resources/protobuf-schema
 additionalProperties:
   packageName: petstore
+typeMappings:
+  object: "google.protobuf.Struct"
+importMappings:
+  google.protobuf.Struct: "google/protobuf/struct"

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -912,7 +912,11 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
 
     @Override
     public String toModelImport(String name) {
-        return underscore(name);
+        if ("".equals(modelPackage())) {
+            return name;
+        } else {
+            return modelPackage() + "/" + underscore(name);
+        }
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/protobuf-schema/api.mustache
+++ b/modules/openapi-generator/src/main/resources/protobuf-schema/api.mustache
@@ -6,7 +6,7 @@ package {{#lambda.lowercase}}{{{packageName}}}.{{{apiPackage}}}.{{{classname}}};
 import "google/protobuf/empty.proto";
 {{#imports}}
 {{#import}}
-import public "{{{modelPackage}}}/{{{.}}}.proto";
+import public "{{{import}}}.proto";
 {{/import}}
 {{/imports}}
 

--- a/modules/openapi-generator/src/main/resources/protobuf-schema/model.mustache
+++ b/modules/openapi-generator/src/main/resources/protobuf-schema/model.mustache
@@ -5,7 +5,7 @@ package {{#lambda.lowercase}}{{{packageName}}};{{/lambda.lowercase}}
 
 {{#imports}}
 {{#import}}
-import public "{{{modelPackage}}}/{{{import}}}.proto";
+import public "{{{.}}}.proto";
 {{/import}}
 {{/imports}}
 

--- a/modules/openapi-generator/src/test/resources/3_0/protobuf/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/protobuf/petstore.yaml
@@ -669,6 +669,8 @@ components:
         complete:
           type: boolean
           default: false
+        meta:
+          type: object
       xml:
         name: Order
     Category:

--- a/samples/config/petstore/protobuf-schema-config/models/order.proto
+++ b/samples/config/petstore/protobuf-schema-config/models/order.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 
 package petstore;
 
+import public "google/protobuf/struct.proto";
 
 message Order {
 
@@ -34,5 +35,7 @@ message Order {
   Status status = 5;
 
   bool complete = 6;
+
+  google.protobuf.Struct meta = 7;
 
 }

--- a/samples/config/petstore/protobuf-schema/models/order.proto
+++ b/samples/config/petstore/protobuf-schema/models/order.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 
 package petstore;
 
+import public "google/protobuf/struct.proto";
 
 message Order {
 
@@ -33,5 +34,7 @@ message Order {
   Status status = 355610639;
 
   bool complete = 62574280;
+
+  google.protobuf.Struct meta = 3347973;
 
 }


### PR DESCRIPTION
This PR fixes the issue by removing the "model/" prefix from imports that are explicitly mapped through importMapping. The generator now correctly handles standard protobuf types and ensures generated files compile successfully.

Example of Incorrect Import:
`import "model/google/protobuf/struct.proto"; 
`
Now:
`import "google/protobuf/struct.proto";
`


### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
