### PR TITLE
fix deprecated old sbt build file syntax

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.11" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.6",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22" % "compile",

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "com.squareup.retrofit2" % "retrofit" % "2.11.0" % "compile",

--- a/modules/openapi-generator/src/main/resources/scala-akka-client/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-akka-client/build.sbt.mustache
@@ -31,4 +31,4 @@ scalacOptions := Seq(
   "-feature"
 )
 
-publishArtifact in (Compile, packageDoc) := false
+Compile / packageDoc / publishArtifact := false

--- a/modules/openapi-generator/src/main/resources/scala-pekko-client/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-pekko-client/build.sbt.mustache
@@ -26,4 +26,4 @@ scalacOptions := Seq(
   "-feature"
 )
 
-publishArtifact in (Compile, packageDoc) := false
+Compile / packageDoc / publishArtifact := false

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.sbt.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.sbt.mustache
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "{{artifactVersion}}",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",

--- a/samples/client/echo_api/java/feign-gson/build.sbt
+++ b/samples/client/echo_api/java/feign-gson/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "0.1.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.11" % "compile",

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.sbt
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/echo_api/java/okhttp-gson/build.sbt
+++ b/samples/client/echo_api/java/okhttp-gson/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "0.1.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/echo_api/java/resteasy/build.sbt
+++ b/samples/client/echo_api/java/resteasy/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "0.1.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22" % "compile",

--- a/samples/client/others/java/okhttp-gson-oneOf-array/build.sbt
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/others/java/okhttp-gson-oneOf/build.sbt
+++ b/samples/client/others/java/okhttp-gson-oneOf/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/others/java/okhttp-gson-streaming/build.sbt
+++ b/samples/client/others/java/okhttp-gson-streaming/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/feign-no-nullable/build.sbt
+++ b/samples/client/petstore/java/feign-no-nullable/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.11" % "compile",

--- a/samples/client/petstore/java/feign/build.sbt
+++ b/samples/client/petstore/java/feign/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.11" % "compile",

--- a/samples/client/petstore/java/google-api-client/build.sbt
+++ b/samples/client/petstore/java/google-api-client/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22",

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-3.1/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-3.1/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-swagger1/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson-swagger2/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/okhttp-gson/build.sbt
+++ b/samples/client/petstore/java/okhttp-gson/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",

--- a/samples/client/petstore/java/rest-assured-jackson/build.sbt
+++ b/samples/client/petstore/java/rest-assured-jackson/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.6",

--- a/samples/client/petstore/java/rest-assured/build.sbt
+++ b/samples/client/petstore/java/rest-assured/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.6",

--- a/samples/client/petstore/java/resteasy/build.sbt
+++ b/samples/client/petstore/java/resteasy/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.5.22" % "compile",

--- a/samples/client/petstore/java/retrofit2-play26/build.sbt
+++ b/samples/client/petstore/java/retrofit2-play26/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "com.squareup.retrofit2" % "retrofit" % "2.11.0" % "compile",

--- a/samples/client/petstore/java/retrofit2/build.sbt
+++ b/samples/client/petstore/java/retrofit2/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "com.squareup.retrofit2" % "retrofit" % "2.11.0" % "compile",

--- a/samples/client/petstore/java/retrofit2rx2/build.sbt
+++ b/samples/client/petstore/java/retrofit2rx2/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "com.squareup.retrofit2" % "retrofit" % "2.11.0" % "compile",

--- a/samples/client/petstore/java/retrofit2rx3/build.sbt
+++ b/samples/client/petstore/java/retrofit2rx3/build.sbt
@@ -5,8 +5,8 @@ lazy val root = (project in file(".")).
     version := "1.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
-    javacOptions in compile ++= Seq("-Xlint:deprecation"),
-    publishArtifact in (Compile, packageDoc) := false,
+    compile / javacOptions ++= Seq("-Xlint:deprecation"),
+    Compile / packageDoc / publishArtifact := false,
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "com.squareup.retrofit2" % "retrofit" % "2.11.0" % "compile",

--- a/samples/client/petstore/scala-akka/build.sbt
+++ b/samples/client/petstore/scala-akka/build.sbt
@@ -28,4 +28,4 @@ scalacOptions := Seq(
   "-feature"
 )
 
-publishArtifact in (Compile, packageDoc) := false
+Compile / packageDoc / publishArtifact := false

--- a/samples/client/petstore/scala-pekko/build.sbt
+++ b/samples/client/petstore/scala-pekko/build.sbt
@@ -26,4 +26,4 @@ scalacOptions := Seq(
   "-feature"
 )
 
-publishArtifact in (Compile, packageDoc) := false
+Compile / packageDoc / publishArtifact := false


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

old `in` syntax is deprecated since sbt 1.5 and will be removed sbt 2.x

- https://github.com/sbt/sbt/pull/6328
- https://github.com/sbt/sbt/pull/7703

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
