### PR TITLE
[kotlin][client] make kotlinx serialization configurable

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -126,42 +126,70 @@ import java.util.concurrent.atomic.AtomicLong
         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, {{failOnUnknownProperties}})
 {{/jackson}}
 {{#kotlinx_serialization}}
-    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))
+    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val kotlinSerializationAdapters: SerializersModule
         get() { return kotlinxSerializationAdapters }
 
+    private var isAdaptersInitialized = false
+
     @JvmStatic
-    val kotlinxSerializationAdapters = SerializersModule {
-        contextual(BigDecimal::class, BigDecimalAdapter)
-        contextual(BigInteger::class, BigIntegerAdapter)
-        {{^kotlinx-datetime}}
-        contextual(LocalDate::class, LocalDateAdapter)
-        contextual(LocalDateTime::class, LocalDateTimeAdapter)
-        contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
-        {{/kotlinx-datetime}}
-        contextual(UUID::class, UUIDAdapter)
-        contextual(AtomicInteger::class, AtomicIntegerAdapter)
-        contextual(AtomicLong::class, AtomicLongAdapter)
-        contextual(AtomicBoolean::class, AtomicBooleanAdapter)
-        contextual(URI::class, URIAdapter)
-        contextual(URL::class, URLAdapter)
-        contextual(StringBuilder::class, StringBuilderAdapter)
+    val kotlinxSerializationAdapters: SerializersModule by lazy {
+        isAdaptersInitialized = true
+        SerializersModule {
+            contextual(BigDecimal::class, BigDecimalAdapter)
+            contextual(BigInteger::class, BigIntegerAdapter)
+            {{^kotlinx-datetime}}
+            contextual(LocalDate::class, LocalDateAdapter)
+            contextual(LocalDateTime::class, LocalDateTimeAdapter)
+            contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
+            {{/kotlinx-datetime}}
+            contextual(UUID::class, UUIDAdapter)
+            contextual(AtomicInteger::class, AtomicIntegerAdapter)
+            contextual(AtomicLong::class, AtomicLongAdapter)
+            contextual(AtomicBoolean::class, AtomicBooleanAdapter)
+            contextual(URI::class, URIAdapter)
+            contextual(URL::class, URLAdapter)
+            contextual(StringBuilder::class, StringBuilderAdapter)
+
+            apply(kotlinxSerializationAdaptersConfiguration)
+        }
     }
 
-    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"))
+    var kotlinxSerializationAdaptersConfiguration: SerializersModuleBuilder.() -> Unit = {}
+        set(value) {
+            check(!isAdaptersInitialized) {
+                "Cannot configure kotlinxSerializationAdaptersConfiguration after kotlinxSerializationAdapters has been initialized."
+            }
+            field = value
+        }
+
+    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val jvmJson: Json
         get() { return kotlinxSerializationJson }
 
+    private var isJsonInitialized = false
+
     @JvmStatic
     val kotlinxSerializationJson: Json by lazy {
+        isJsonInitialized = true
         Json {
             serializersModule = kotlinxSerializationAdapters
             encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
+
+            apply(kotlinxSerializationJsonConfiguration)
         }
     }
+
+    var kotlinxSerializationJsonConfiguration: JsonBuilder.() -> Unit = {}
+        set(value) {
+            check(!isJsonInitialized) {
+                "Cannot configure kotlinxSerializationJsonConfiguration after kotlinxSerializationJson has been initialized."
+            }
+            field = value
+        }
 {{/kotlinx_serialization}}
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/jvm-common/infrastructure/Serializer.kt.mustache
@@ -50,7 +50,9 @@ import org.threeten.bp.OffsetDateTime
 {{/threetenbp}}
 import java.util.UUID
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleBuilder
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -7,7 +7,9 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleBuilder
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -15,39 +15,67 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 object Serializer {
-    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))
+    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val kotlinSerializationAdapters: SerializersModule
         get() { return kotlinxSerializationAdapters }
 
+    private var isAdaptersInitialized = false
+
     @JvmStatic
-    val kotlinxSerializationAdapters = SerializersModule {
-        contextual(BigDecimal::class, BigDecimalAdapter)
-        contextual(BigInteger::class, BigIntegerAdapter)
-        contextual(LocalDate::class, LocalDateAdapter)
-        contextual(LocalDateTime::class, LocalDateTimeAdapter)
-        contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
-        contextual(UUID::class, UUIDAdapter)
-        contextual(AtomicInteger::class, AtomicIntegerAdapter)
-        contextual(AtomicLong::class, AtomicLongAdapter)
-        contextual(AtomicBoolean::class, AtomicBooleanAdapter)
-        contextual(URI::class, URIAdapter)
-        contextual(URL::class, URLAdapter)
-        contextual(StringBuilder::class, StringBuilderAdapter)
+    val kotlinxSerializationAdapters: SerializersModule by lazy {
+        isAdaptersInitialized = true
+        SerializersModule {
+            contextual(BigDecimal::class, BigDecimalAdapter)
+            contextual(BigInteger::class, BigIntegerAdapter)
+            contextual(LocalDate::class, LocalDateAdapter)
+            contextual(LocalDateTime::class, LocalDateTimeAdapter)
+            contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
+            contextual(UUID::class, UUIDAdapter)
+            contextual(AtomicInteger::class, AtomicIntegerAdapter)
+            contextual(AtomicLong::class, AtomicLongAdapter)
+            contextual(AtomicBoolean::class, AtomicBooleanAdapter)
+            contextual(URI::class, URIAdapter)
+            contextual(URL::class, URLAdapter)
+            contextual(StringBuilder::class, StringBuilderAdapter)
+
+            apply(kotlinxSerializationAdaptersConfiguration)
+        }
     }
 
-    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"))
+    var kotlinxSerializationAdaptersConfiguration: SerializersModuleBuilder.() -> Unit = {}
+        set(value) {
+            check(!isAdaptersInitialized) {
+                "Cannot configure kotlinxSerializationAdaptersConfiguration after kotlinxSerializationAdapters has been initialized."
+            }
+            field = value
+        }
+
+    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val jvmJson: Json
         get() { return kotlinxSerializationJson }
 
+    private var isJsonInitialized = false
+
     @JvmStatic
     val kotlinxSerializationJson: Json by lazy {
+        isJsonInitialized = true
         Json {
             serializersModule = kotlinxSerializationAdapters
             encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
+
+            apply(kotlinxSerializationJsonConfiguration)
         }
     }
+
+    var kotlinxSerializationJsonConfiguration: JsonBuilder.() -> Unit = {}
+        set(value) {
+            check(!isJsonInitialized) {
+                "Cannot configure kotlinxSerializationJsonConfiguration after kotlinxSerializationJson has been initialized."
+            }
+            field = value
+        }
 }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -7,7 +7,9 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleBuilder
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -15,39 +15,67 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 object Serializer {
-    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))
+    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val kotlinSerializationAdapters: SerializersModule
         get() { return kotlinxSerializationAdapters }
 
+    private var isAdaptersInitialized = false
+
     @JvmStatic
-    val kotlinxSerializationAdapters = SerializersModule {
-        contextual(BigDecimal::class, BigDecimalAdapter)
-        contextual(BigInteger::class, BigIntegerAdapter)
-        contextual(LocalDate::class, LocalDateAdapter)
-        contextual(LocalDateTime::class, LocalDateTimeAdapter)
-        contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
-        contextual(UUID::class, UUIDAdapter)
-        contextual(AtomicInteger::class, AtomicIntegerAdapter)
-        contextual(AtomicLong::class, AtomicLongAdapter)
-        contextual(AtomicBoolean::class, AtomicBooleanAdapter)
-        contextual(URI::class, URIAdapter)
-        contextual(URL::class, URLAdapter)
-        contextual(StringBuilder::class, StringBuilderAdapter)
+    val kotlinxSerializationAdapters: SerializersModule by lazy {
+        isAdaptersInitialized = true
+        SerializersModule {
+            contextual(BigDecimal::class, BigDecimalAdapter)
+            contextual(BigInteger::class, BigIntegerAdapter)
+            contextual(LocalDate::class, LocalDateAdapter)
+            contextual(LocalDateTime::class, LocalDateTimeAdapter)
+            contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
+            contextual(UUID::class, UUIDAdapter)
+            contextual(AtomicInteger::class, AtomicIntegerAdapter)
+            contextual(AtomicLong::class, AtomicLongAdapter)
+            contextual(AtomicBoolean::class, AtomicBooleanAdapter)
+            contextual(URI::class, URIAdapter)
+            contextual(URL::class, URLAdapter)
+            contextual(StringBuilder::class, StringBuilderAdapter)
+
+            apply(kotlinxSerializationAdaptersConfiguration)
+        }
     }
 
-    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"))
+    var kotlinxSerializationAdaptersConfiguration: SerializersModuleBuilder.() -> Unit = {}
+        set(value) {
+            check(!isAdaptersInitialized) {
+                "Cannot configure kotlinxSerializationAdaptersConfiguration after kotlinxSerializationAdapters has been initialized."
+            }
+            field = value
+        }
+
+    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val jvmJson: Json
         get() { return kotlinxSerializationJson }
 
+    private var isJsonInitialized = false
+
     @JvmStatic
     val kotlinxSerializationJson: Json by lazy {
+        isJsonInitialized = true
         Json {
             serializersModule = kotlinxSerializationAdapters
             encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
+
+            apply(kotlinxSerializationJsonConfiguration)
         }
     }
+
+    var kotlinxSerializationJsonConfiguration: JsonBuilder.() -> Unit = {}
+        set(value) {
+            check(!isJsonInitialized) {
+                "Cannot configure kotlinxSerializationJsonConfiguration after kotlinxSerializationJson has been initialized."
+            }
+            field = value
+        }
 }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -7,7 +7,9 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.UUID
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.SerializersModuleBuilder
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/Serializer.kt
@@ -15,39 +15,67 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 object Serializer {
-    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"))
+    @Deprecated("Use Serializer.kotlinxSerializationAdapters instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationAdapters"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val kotlinSerializationAdapters: SerializersModule
         get() { return kotlinxSerializationAdapters }
 
+    private var isAdaptersInitialized = false
+
     @JvmStatic
-    val kotlinxSerializationAdapters = SerializersModule {
-        contextual(BigDecimal::class, BigDecimalAdapter)
-        contextual(BigInteger::class, BigIntegerAdapter)
-        contextual(LocalDate::class, LocalDateAdapter)
-        contextual(LocalDateTime::class, LocalDateTimeAdapter)
-        contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
-        contextual(UUID::class, UUIDAdapter)
-        contextual(AtomicInteger::class, AtomicIntegerAdapter)
-        contextual(AtomicLong::class, AtomicLongAdapter)
-        contextual(AtomicBoolean::class, AtomicBooleanAdapter)
-        contextual(URI::class, URIAdapter)
-        contextual(URL::class, URLAdapter)
-        contextual(StringBuilder::class, StringBuilderAdapter)
+    val kotlinxSerializationAdapters: SerializersModule by lazy {
+        isAdaptersInitialized = true
+        SerializersModule {
+            contextual(BigDecimal::class, BigDecimalAdapter)
+            contextual(BigInteger::class, BigIntegerAdapter)
+            contextual(LocalDate::class, LocalDateAdapter)
+            contextual(LocalDateTime::class, LocalDateTimeAdapter)
+            contextual(OffsetDateTime::class, OffsetDateTimeAdapter)
+            contextual(UUID::class, UUIDAdapter)
+            contextual(AtomicInteger::class, AtomicIntegerAdapter)
+            contextual(AtomicLong::class, AtomicLongAdapter)
+            contextual(AtomicBoolean::class, AtomicBooleanAdapter)
+            contextual(URI::class, URIAdapter)
+            contextual(URL::class, URLAdapter)
+            contextual(StringBuilder::class, StringBuilderAdapter)
+
+            apply(kotlinxSerializationAdaptersConfiguration)
+        }
     }
 
-    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"))
+    var kotlinxSerializationAdaptersConfiguration: SerializersModuleBuilder.() -> Unit = {}
+        set(value) {
+            check(!isAdaptersInitialized) {
+                "Cannot configure kotlinxSerializationAdaptersConfiguration after kotlinxSerializationAdapters has been initialized."
+            }
+            field = value
+        }
+
+    @Deprecated("Use Serializer.kotlinxSerializationJson instead", replaceWith = ReplaceWith("Serializer.kotlinxSerializationJson"), level = DeprecationLevel.ERROR)
     @JvmStatic
     val jvmJson: Json
         get() { return kotlinxSerializationJson }
 
+    private var isJsonInitialized = false
+
     @JvmStatic
     val kotlinxSerializationJson: Json by lazy {
+        isJsonInitialized = true
         Json {
             serializersModule = kotlinxSerializationAdapters
             encodeDefaults = true
             ignoreUnknownKeys = true
             isLenient = true
+
+            apply(kotlinxSerializationJsonConfiguration)
         }
     }
+
+    var kotlinxSerializationJsonConfiguration: JsonBuilder.() -> Unit = {}
+        set(value) {
+            check(!isJsonInitialized) {
+                "Cannot configure kotlinxSerializationJsonConfiguration after kotlinxSerializationJson has been initialized."
+            }
+            field = value
+        }
 }


### PR DESCRIPTION
Currently the kotlinx serializer and adapter are not configurable from the outside.
This PR fixes that and also changes the level of some old deprecation warning to error.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)