### PR TITLE
feat(typescript-angular): update enum definitions to use 'as const' for improved type safety

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelEnum.mustache
@@ -13,8 +13,6 @@ export enum {{classname}} {
 }
 {{/stringEnums}}
 {{^stringEnums}}
-export type {{classname}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
-
 export const {{classname}} = {
 {{#allowableValues}}
 {{#enumVars}}
@@ -22,9 +20,11 @@ export const {{classname}} = {
 
     /**
      * {{.}}
-     */{{/enumDescription}}
-    {{name}}: {{{value}}} as {{classname}}{{^-last}},{{/-last}}
+     */
+{{/enumDescription}}
+    {{name}}: {{{value}}}{{^-last}},{{/-last}}
 {{/enumVars}}
 {{/allowableValues}}
-};
+} as const;
+export type {{classname}} = typeof {{classname}}[keyof typeof {{classname}}];
 {{/stringEnums}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/modelGenericEnums.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/modelGenericEnums.mustache
@@ -15,14 +15,14 @@ export enum {{classname}}{{enumName}} {
 };
 {{/stringEnums}}
 {{^stringEnums}}
-    export type {{enumName}} = {{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}} | {{/-last}}{{/enumVars}}{{/allowableValues}};
     export const {{enumName}} = {
     {{#allowableValues}}
     {{#enumVars}}
-        {{name}}: {{{value}}} as {{enumName}}{{^-last}},{{/-last}}
+        {{name}}: {{{value}}}{{^-last}},{{/-last}}
     {{/enumVars}}
     {{/allowableValues}}
-    };
+    } as const;
+    export type {{enumName}} = typeof {{enumName}}[keyof typeof {{enumName}}];
 {{/stringEnums}}
     {{/isEnum}}
 {{/vars}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/typescriptangular/TypeScriptAngularClientCodegenTest.java
@@ -439,4 +439,29 @@ public class TypeScriptAngularClientCodegenTest {
         final String fileContents = Files.readString(Paths.get(output + "/api.base.service.ts"));
         assertThat(fileContents).containsOnlyOnce("basePath = '/relative/url'");
     }
+
+    @Test
+    public void testEnumAsConst() throws IOException {
+        // GIVEN
+        final String specPath = "src/test/resources/3_0/enum.yaml";
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        // WHEN
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("typescript-angular")
+            .setInputSpec(specPath)
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+
+        Generator generator = new DefaultGenerator();
+        generator.opts(clientOptInput).generate();
+
+        // THEN
+        final String fileContents = Files.readString(Paths.get(output + "/model/type.ts"));
+        assertThat(fileContents).containsOnlyOnce("} as const;");
+        assertThat(fileContents).doesNotContain(" as Type");
+    }
 }

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-any/builds/default/model/pet.ts
@@ -26,12 +26,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/default/model/pet.ts
@@ -26,12 +26,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/model/pet.ts
@@ -26,12 +26,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-any/builds/default/model/pet.ts
@@ -26,12 +26,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v14-provided-in-root/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v14-query-param-object-format/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v14-query-param-object-format/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v15-provided-in-root/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        SHIPPED: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        SHIPPED: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v16-provided-in-root/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v19/builds/default/model/order.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/model/order.ts
@@ -24,12 +24,12 @@ export interface Order {
     complete?: boolean;
 }
 export namespace Order {
-    export type StatusEnum = 'placed' | 'approved' | 'delivered';
     export const StatusEnum = {
-        Placed: 'placed' as StatusEnum,
-        Approved: 'approved' as StatusEnum,
-        Delivered: 'delivered' as StatusEnum
-    };
+        Placed: 'placed',
+        Approved: 'approved',
+        Delivered: 'delivered'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 

--- a/samples/client/petstore/typescript-angular-v19/builds/default/model/pet.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/model/pet.ts
@@ -27,12 +27,12 @@ export interface Pet {
     status?: Pet.StatusEnum;
 }
 export namespace Pet {
-    export type StatusEnum = 'available' | 'pending' | 'sold';
     export const StatusEnum = {
-        Available: 'available' as StatusEnum,
-        Pending: 'pending' as StatusEnum,
-        Sold: 'sold' as StatusEnum
-    };
+        Available: 'available',
+        Pending: 'pending',
+        Sold: 'sold'
+    } as const;
+    export type StatusEnum = typeof StatusEnum[keyof typeof StatusEnum];
 }
 
 


### PR DESCRIPTION

fixes #20809 

The description of #20809 details the change :)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
