### PR TITLE
Javalin fixes and validation

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/beanValidation.mustache
@@ -1,0 +1,4 @@
+{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
+    @field:jakarta.validation.Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{!
+}}{{^isContainer}}{{^isPrimitiveType}}{{^isNumber}}{{^isUuid}}{{^isDateTime}}
+    @field:jakarta.validation.Valid{{/isDateTime}}{{/isUuid}}{{/isNumber}}{{/isPrimitiveType}}{{/isContainer}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/beanValidationModel.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/beanValidationModel.mustache
@@ -1,0 +1,38 @@
+{{!
+format: email
+}}{{#isEmail}}
+    @field:jakarta.validation.constraints.Email{{/isEmail}}{{!
+pattern set
+}}{{#pattern}}
+    @field:jakarta.validation.constraints.Pattern(regexp="{{{pattern}}}"{{#vendorExtensions.x-pattern-message}}, message="{{vendorExtensions.x-pattern-message}}"{{/vendorExtensions.x-pattern-message}}){{/pattern}}{{!
+minLength && maxLength set
+}}{{#minLength}}{{#maxLength}}
+    @field:jakarta.validation.constraints.Size(min={{minLength}},max={{maxLength}}){{/maxLength}}{{/minLength}}{{!
+minLength set, maxLength not
+}}{{#minLength}}{{^maxLength}}
+    @field:jakarta.validation.constraints.Size(min={{minLength}}){{/maxLength}}{{/minLength}}{{!
+minLength not set, maxLength set
+}}{{^minLength}}{{#maxLength}}
+    @field:jakarta.validation.constraints.Size(max={{.}}){{/maxLength}}{{/minLength}}{{!
+@Size: minItems && maxItems set
+}}{{#minItems}}{{#maxItems}}
+    @field:jakarta.validation.constraints.Size(min={{minItems}},max={{maxItems}}) {{/maxItems}}{{/minItems}}{{!
+@Size: minItems set, maxItems not
+}}{{#minItems}}{{^maxItems}}
+    @field:jakarta.validation.constraints.Size(min={{minItems}}){{/maxItems}}{{/minItems}}{{!
+@Size: minItems not set && maxItems set
+}}{{^minItems}}{{#maxItems}}
+    @field:jakarta.validation.constraints.Size(max={{.}}){{/maxItems}}{{/minItems}}{{!
+check for integer or long / all others=decimal type with @Decimal*
+isInteger set
+}}{{#isInteger}}{{#minimum}}
+    @field:jakarta.validation.constraints.Min({{.}}){{/minimum}}{{#maximum}}
+    @field:jakarta.validation.constraints.Max({{.}}){{/maximum}}{{/isInteger}}{{!
+isLong set
+}}{{#isLong}}{{#minimum}}
+    @field:jakarta.validation.constraints.Min({{.}}L){{/minimum}}{{#maximum}}
+    @field:jakarta.validation.constraints.Max({{.}}L){{/maximum}}{{/isLong}}{{!
+Not Integer, not Long => we have a decimal value!
+}}{{^isInteger}}{{^isLong}}{{#minimum}}
+    @field:jakarta.validation.constraints.DecimalMin("{{.}}"){{/minimum}}{{#maximum}}
+    @field:jakarta.validation.constraints.DecimalMax("{{.}}"){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/data_class_opt_var.mustache
@@ -1,0 +1,6 @@
+{{#description}}
+    /* {{{.}}} */
+{{/description}}
+    {{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}
+    @field:com.fasterxml.jackson.annotation.JsonProperty("{{{baseName}}}")
+    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{{classname}}}.{{{nameInPascalCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/data_class_req_var.mustache
@@ -1,0 +1,6 @@
+{{#description}}
+    /* {{{.}}} */
+{{/description}}
+    {{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}
+    @field:com.fasterxml.jackson.annotation.JsonProperty("{{{baseName}}}")
+    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{{classname}}}.{{{nameInPascalCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{^isNumber}}{{{defaultValue}}}{{/isNumber}}{{#isNumber}}{{{dataType}}}("{{{defaultValue}}}"){{/isNumber}}{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/paramDefault.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/paramDefault.mustache
@@ -1,0 +1,2 @@
+{{#defaultValue}} ?:{{#isInteger}}{{{defaultValue}}}{{/isInteger}}{{#isLong}}{{{defaultValue}}}L{{/isLong}}{{#isShort}}{{{defaultValue}}}.toShort(){{/isShort}}{{#isDouble}}{{{defaultValue}}}.toDouble(){{/isDouble}}{{#isFloat}}{{{defaultValue}}}f{{/isFloat}}{{#isEnum}}{{{dataType}}}.valueOf("{{{defaultValue}}}"){{/isEnum}}{{#isBoolean}}{{{defaultValue}}}{{/isBoolean}}{{#isString}}"{{{defaultValue}}}"{{/isString}}{{#isUuid}}"UUID.fromString({{{defaultValue}}})"{{/isUuid}}{{#isUuid}}"UUID.fromString({{{defaultValue}}})"{{/isUuid}}
+{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/pathParams.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/pathParams.mustache
@@ -1,1 +1,1 @@
-{{#isPathParam}}ctx.pathParamAsClass<{{{dataType}}}>("{{baseName}}").get(){{/isPathParam}}
+{{#isPathParam}}ctx.pathParamAsClass<{{{dataType}}}>("{{baseName}}").get(){{>paramDefault}}{{/isPathParam}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/queryParams.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin5/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#isQueryParam}}{{#isArray}}ctx.queryParams("{{baseName}}"){{/isArray}}{{^isArray}}ctx.queryParamAsClass<String>("{{baseName}}").get(){{/isArray}}{{/isQueryParam}}
+{{#isQueryParam}}{{#isArray}}ctx.queryParams("{{baseName}}"){{/isArray}}{{^isArray}}ctx.queryParamAsClass<String>("{{baseName}}").get(){{>paramDefault}}{{/isArray}}{{/isQueryParam}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/beanValidation.mustache
@@ -1,0 +1,4 @@
+{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}
+    @field:jakarta.validation.Valid{{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{!
+}}{{^isContainer}}{{^isPrimitiveType}}{{^isNumber}}{{^isUuid}}{{^isDateTime}}
+    @field:jakarta.validation.Valid{{/isDateTime}}{{/isUuid}}{{/isNumber}}{{/isPrimitiveType}}{{/isContainer}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/beanValidationModel.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/beanValidationModel.mustache
@@ -1,0 +1,38 @@
+{{!
+format: email
+}}{{#isEmail}}
+    @field:jakarta.validation.constraints.Email{{/isEmail}}{{!
+pattern set
+}}{{#pattern}}
+    @field:jakarta.validation.constraints.Pattern(regexp="{{{pattern}}}"{{#vendorExtensions.x-pattern-message}}, message="{{vendorExtensions.x-pattern-message}}"{{/vendorExtensions.x-pattern-message}}){{/pattern}}{{!
+minLength && maxLength set
+}}{{#minLength}}{{#maxLength}}
+    @field:jakarta.validation.constraints.Size(min={{minLength}},max={{maxLength}}){{/maxLength}}{{/minLength}}{{!
+minLength set, maxLength not
+}}{{#minLength}}{{^maxLength}}
+    @field:jakarta.validation.constraints.Size(min={{minLength}}){{/maxLength}}{{/minLength}}{{!
+minLength not set, maxLength set
+}}{{^minLength}}{{#maxLength}}
+    @field:jakarta.validation.constraints.Size(max={{.}}){{/maxLength}}{{/minLength}}{{!
+@Size: minItems && maxItems set
+}}{{#minItems}}{{#maxItems}}
+    @field:jakarta.validation.constraints.Size(min={{minItems}},max={{maxItems}}) {{/maxItems}}{{/minItems}}{{!
+@Size: minItems set, maxItems not
+}}{{#minItems}}{{^maxItems}}
+    @field:jakarta.validation.constraints.Size(min={{minItems}}){{/maxItems}}{{/minItems}}{{!
+@Size: minItems not set && maxItems set
+}}{{^minItems}}{{#maxItems}}
+    @field:jakarta.validation.constraints.Size(max={{.}}){{/maxItems}}{{/minItems}}{{!
+check for integer or long / all others=decimal type with @Decimal*
+isInteger set
+}}{{#isInteger}}{{#minimum}}
+    @field:jakarta.validation.constraints.Min({{.}}){{/minimum}}{{#maximum}}
+    @field:jakarta.validation.constraints.Max({{.}}){{/maximum}}{{/isInteger}}{{!
+isLong set
+}}{{#isLong}}{{#minimum}}
+    @field:jakarta.validation.constraints.Min({{.}}L){{/minimum}}{{#maximum}}
+    @field:jakarta.validation.constraints.Max({{.}}L){{/maximum}}{{/isLong}}{{!
+Not Integer, not Long => we have a decimal value!
+}}{{^isInteger}}{{^isLong}}{{#minimum}}
+    @field:jakarta.validation.constraints.DecimalMin("{{.}}"){{/minimum}}{{#maximum}}
+    @field:jakarta.validation.constraints.DecimalMax("{{.}}"){{/maximum}}{{/isLong}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/data_class_opt_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/data_class_opt_var.mustache
@@ -1,0 +1,6 @@
+{{#description}}
+    /* {{{.}}} */
+{{/description}}
+    {{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}
+    @field:com.fasterxml.jackson.annotation.JsonProperty("{{{baseName}}}")
+    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{{classname}}}.{{{nameInPascalCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = {{{defaultValue}}}{{^defaultValue}}null{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/data_class_req_var.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/data_class_req_var.mustache
@@ -1,0 +1,6 @@
+{{#description}}
+    /* {{{.}}} */
+{{/description}}
+    {{#useBeanValidation}}{{>beanValidation}}{{>beanValidationModel}}{{/useBeanValidation}}
+    @field:com.fasterxml.jackson.annotation.JsonProperty("{{{baseName}}}")
+    {{>modelMutable}} {{{name}}}: {{#isEnum}}{{{classname}}}.{{{nameInPascalCase}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}}?{{/isNullable}}{{#defaultValue}} = {{^isNumber}}{{{defaultValue}}}{{/isNumber}}{{#isNumber}}{{{dataType}}}("{{{defaultValue}}}"){{/isNumber}}{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/headerParams.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/headerParams.mustache
@@ -1,1 +1,1 @@
-{{#isHeaderParam}}ctx.header("{{baseName}}"){{/isHeaderParam}}
+{{#isHeaderParam}}ctx.header("{{baseName}}"){{#required}}{{^defaultValue}} ?: throw io.javalin.http.BadRequestResponse("Required header {{baseName}} not present") {{/defaultValue}}{{#defaultValue}}{{>paramDefault}}{{/defaultValue}}{{/required}}{{/isHeaderParam}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/paramDefault.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/paramDefault.mustache
@@ -1,0 +1,2 @@
+{{#defaultValue}} ?:{{#isInteger}}{{{defaultValue}}}{{/isInteger}}{{#isLong}}{{{defaultValue}}}L{{/isLong}}{{#isShort}}{{{defaultValue}}}.toShort(){{/isShort}}{{#isDouble}}{{{defaultValue}}}.toDouble(){{/isDouble}}{{#isFloat}}{{{defaultValue}}}f{{/isFloat}}{{#isEnum}}{{{dataType}}}.valueOf("{{{defaultValue}}}"){{/isEnum}}{{#isBoolean}}{{{defaultValue}}}{{/isBoolean}}{{#isString}}"{{{defaultValue}}}"{{/isString}}{{#isUuid}}"UUID.fromString({{{defaultValue}}})"{{/isUuid}}{{#isUuid}}"UUID.fromString({{{defaultValue}}})"{{/isUuid}}
+{{/defaultValue}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/pathParams.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/pathParams.mustache
@@ -1,1 +1,1 @@
-{{#isPathParam}}ctx.pathParamAsClass<{{{dataType}}}>("{{baseName}}").get(){{/isPathParam}}
+{{#isPathParam}}ctx.pathParamAsClass<{{{dataType}}}>("{{baseName}}").get(){{>paramDefault}}{{/isPathParam}}

--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/queryParams.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/javalin6/queryParams.mustache
@@ -1,1 +1,1 @@
-{{#isQueryParam}}{{#isArray}}ctx.queryParams("{{baseName}}"){{/isArray}}{{^isArray}}ctx.queryParamAsClass<{{{dataType}}}>("{{baseName}}"){{^required}}.allowNullable(){{/required}}.get(){{/isArray}}{{/isQueryParam}}
+{{#isQueryParam}}{{#isArray}}ctx.queryParams("{{baseName}}"){{/isArray}}{{^isArray}}ctx.queryParamAsClass<{{{dataType}}}>("{{baseName}}"){{^required}}.allowNullable(){{/required}}.get(){{>paramDefault}}{{/isArray}}{{/isQueryParam}}

--- a/samples/server/petstore/kotlin-server-required-and-nullable-properties/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/petstore/kotlin-server-required-and-nullable-properties/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -20,9 +20,17 @@ package org.openapitools.server.models
  * @param notNullableNotRequired 
  */
 data class Pet(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("notNullable_required")
     val notNullableRequired: kotlin.String,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("nullable_required")
     val nullableRequired: kotlin.String?,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("nullable_notRequired")
     val nullableNotRequired: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("notNullable_notRequired")
     val notNullableNotRequired: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Category.kt
+++ b/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Category.kt
@@ -18,7 +18,11 @@ package org.openapitools.server.models
  * @param name 
  */
 data class Category(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
     val name: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/ModelApiResponse.kt
@@ -19,8 +19,14 @@ package org.openapitools.server.models
  * @param message 
  */
 data class ModelApiResponse(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("code")
     val code: kotlin.Int? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("type")
     val type: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("message")
     val message: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Order.kt
+++ b/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Order.kt
@@ -22,12 +22,24 @@ package org.openapitools.server.models
  * @param complete 
  */
 data class Order(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("petId")
     val petId: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("status")
     val status: Order.Status? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 )
 {

--- a/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -24,12 +24,24 @@ import org.openapitools.server.models.Tag
  * @param status pet status in the store
  */
 data class Pet(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
     val name: kotlin.String,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("category")
     val category: Category? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
     /* pet status in the store */
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("status")
     val status: Pet.Status? = null
 )
 {

--- a/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Tag.kt
+++ b/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/Tag.kt
@@ -18,7 +18,11 @@ package org.openapitools.server.models
  * @param name 
  */
 data class Tag(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
     val name: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/User.kt
+++ b/samples/server/petstore/kotlin-server/javalin-6/src/main/kotlin/org/openapitools/server/models/User.kt
@@ -24,14 +24,30 @@ package org.openapitools.server.models
  * @param userStatus User Status
  */
 data class User(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("username")
     val username: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("firstName")
     val firstName: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("lastName")
     val lastName: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("email")
     val email: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("password")
     val password: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("phone")
     val phone: kotlin.String? = null,
     /* User Status */
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Category.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Category.kt
@@ -18,7 +18,11 @@ package org.openapitools.server.models
  * @param name 
  */
 data class Category(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
     val name: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/ModelApiResponse.kt
@@ -19,8 +19,14 @@ package org.openapitools.server.models
  * @param message 
  */
 data class ModelApiResponse(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("code")
     val code: kotlin.Int? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("type")
     val type: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("message")
     val message: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Order.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Order.kt
@@ -22,12 +22,24 @@ package org.openapitools.server.models
  * @param complete 
  */
 data class Order(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("petId")
     val petId: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("quantity")
     val quantity: kotlin.Int? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("shipDate")
     val shipDate: java.time.OffsetDateTime? = null,
     /* Order Status */
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("status")
     val status: Order.Status? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("complete")
     val complete: kotlin.Boolean? = false
 )
 {

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Pet.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Pet.kt
@@ -24,12 +24,24 @@ import org.openapitools.server.models.Tag
  * @param status pet status in the store
  */
 data class Pet(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
     val name: kotlin.String,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("photoUrls")
     val photoUrls: kotlin.collections.List<kotlin.String>,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("category")
     val category: Category? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("tags")
     val tags: kotlin.collections.List<Tag>? = null,
     /* pet status in the store */
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("status")
     val status: Pet.Status? = null
 )
 {

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Tag.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/Tag.kt
@@ -18,7 +18,11 @@ package org.openapitools.server.models
  * @param name 
  */
 data class Tag(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("name")
     val name: kotlin.String? = null
 )
 

--- a/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/User.kt
+++ b/samples/server/petstore/kotlin-server/javalin/src/main/kotlin/org/openapitools/server/models/User.kt
@@ -24,14 +24,30 @@ package org.openapitools.server.models
  * @param userStatus User Status
  */
 data class User(
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("id")
     val id: kotlin.Long? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("username")
     val username: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("firstName")
     val firstName: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("lastName")
     val lastName: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("email")
     val email: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("password")
     val password: kotlin.String? = null,
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("phone")
     val phone: kotlin.String? = null,
     /* User Status */
+    
+    @field:com.fasterxml.jackson.annotation.JsonProperty("userStatus")
     val userStatus: kotlin.Int? = null
 )
 


### PR DESCRIPTION
Several smaller fixes and additions to the javalin5 and javalin6 generators

- Bugfix for having a nullable property with a default value. It is assumed the interface can have a non-nullable field as an implementation for this. However, it is required to then set the default value.

- Adding validations to the beans (largely copied from the jaxrs implementation)

- Adding explicit basenames in the ObjectMapper Property annotations so that we do not have to rely on ObjectMappers' property name translations

@dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier, @e5l