### PR TITLE
fix: support backwards compatible changes in discriminators

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -126,7 +126,7 @@ export function {{classname}}ToJSONTyped(value?: {{#hasReadOnly}}Omit<{{classnam
                 return {{modelName}}ToJSONTyped(value as {{modelName}}, ignoreDiscriminator);
         {{/discriminator.mappedModels}}
             default:
-                throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${value['{{discriminator.propertyName}}']}'`);
+                return value;
         }
     }
     {{/discriminator}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -27,7 +27,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
             return Object.assign({}, {{modelName}}FromJSONTyped(json, true), { {{discriminator.propertyName}}: '{{mappingName}}' } as const);
 {{/discriminator.mappedModels}}
         default:
-            throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${json['{{discriminator.propertyName}}']}'`);
+            return json;
     }
 {{/discriminator}}
 {{^discriminator}}
@@ -56,7 +56,7 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
             return Object.assign({}, {{modelName}}ToJSON(value), { {{discriminator.propertyName}}: '{{mappingName}}' } as const);
 {{/discriminator.mappedModels}}
         default:
-            throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${value['{{discriminator.propertyName}}']}'`);
+            return json;
     }
 {{/discriminator}}
 

--- a/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
+++ b/samples/client/others/typescript-fetch/self-import-issue/models/AbstractUserDto.ts
@@ -96,7 +96,7 @@ export function AbstractUserDtoToJSONTyped(value?: AbstractUserDto | null, ignor
             case 'remote-authenticated':
                 return RemoteAuthenticatedUserDtoToJSONTyped(value as RemoteAuthenticatedUserDto, ignoreDiscriminator);
             default:
-                throw new Error(`No variant of AbstractUserDto exists with 'type=${value['type']}'`);
+                return value;
         }
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -82,7 +82,7 @@ export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: bo
             case 'DOG':
                 return DogToJSONTyped(value as Dog, ignoreDiscriminator);
             default:
-                throw new Error(`No variant of Animal exists with 'className=${value['className']}'`);
+                return value;
         }
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -85,7 +85,7 @@ export function ParentWithNullableToJSONTyped(value?: ParentWithNullable | null,
             case 'ChildWithNullable':
                 return ChildWithNullableToJSONTyped(value as ChildWithNullable, ignoreDiscriminator);
             default:
-                throw new Error(`No variant of ParentWithNullable exists with 'type=${value['type']}'`);
+                return value;
         }
     }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -82,7 +82,7 @@ export function AnimalToJSONTyped(value?: Animal | null, ignoreDiscriminator: bo
             case 'DOG':
                 return DogToJSONTyped(value as Dog, ignoreDiscriminator);
             default:
-                throw new Error(`No variant of Animal exists with 'className=${value['className']}'`);
+                return value;
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/OpenAPITools/openapi-generator/issues/20982

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
