### PR TITLE
[typescript] Use static middleware when calltime options exist but specify no middleware

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
@@ -113,7 +113,7 @@ export function mergeConfiguration(conf: Configuration, options?: Configuration)
 {{/useInversify}}
 {{^useInversify}}
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -138,7 +138,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
@@ -113,26 +113,7 @@ export function mergeConfiguration(conf: Configuration, options?: Configuration)
 {{/useInversify}}
 {{^useInversify}}
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -142,6 +123,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 {{/useInversify}}
 

--- a/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
@@ -12,16 +12,16 @@ import { BaseServerConfiguration, server1 } from "./servers{{importFileExtension
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth{{importFileExtension}}";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
@@ -105,48 +105,36 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  */
 {{#useInversify}}
 export function mergeConfiguration(conf: Configuration, options?: Configuration): Configuration {
-    if (options) {
-        conf = options;
-    }
-    return conf;
+    return options || conf;
 }
 {{/useInversify}}
 {{^useInversify}}
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 {{/useInversify}}
 

--- a/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
@@ -121,12 +121,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/configuration.mustache
@@ -132,8 +132,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 {{/useInversify}}
 

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -72,7 +72,7 @@ export class Observable{{classname}} {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/types/ObservableAPI.mustache
@@ -65,7 +65,7 @@ export class Observable{{classname}} {
     public {{nickname}}WithHttpInfo({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration{{^useInversify}}Options{{/useInversify}}): Observable<HttpInfo<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}{{#useInversify}}_options{{/useInversify}}{{^useInversify}}_config{{/useInversify}});
+        const requestContextPromise = this.requestFactory.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}_config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {

--- a/samples/client/echo_api/typescript/build/configuration.ts
+++ b/samples/client/echo_api/typescript/build/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/client/echo_api/typescript/build/configuration.ts
+++ b/samples/client/echo_api/typescript/build/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/client/echo_api/typescript/build/configuration.ts
+++ b/samples/client/echo_api/typescript/build/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/client/echo_api/typescript/build/configuration.ts
+++ b/samples/client/echo_api/typescript/build/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/echo_api/typescript/build/configuration.ts
+++ b/samples/client/echo_api/typescript/build/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/client/echo_api/typescript/build/configuration.ts
+++ b/samples/client/echo_api/typescript/build/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/echo_api/typescript/build/types/ObservableAPI.ts
+++ b/samples/client/echo_api/typescript/build/types/ObservableAPI.ts
@@ -46,7 +46,7 @@ export class ObservableAuthApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -78,7 +78,7 @@ export class ObservableAuthApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -128,7 +128,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -161,7 +161,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -195,7 +195,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -229,7 +229,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -263,7 +263,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -297,7 +297,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -331,7 +331,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -365,7 +365,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -399,7 +399,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -433,7 +433,7 @@ export class ObservableBodyApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -487,7 +487,7 @@ export class ObservableFormApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -523,7 +523,7 @@ export class ObservableFormApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -562,7 +562,7 @@ export class ObservableFormApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -623,7 +623,7 @@ export class ObservableHeaderApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -682,7 +682,7 @@ export class ObservablePathApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -738,7 +738,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -775,7 +775,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -813,7 +813,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -849,7 +849,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -883,7 +883,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -917,7 +917,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -951,7 +951,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -985,7 +985,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1019,7 +1019,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1053,7 +1053,7 @@ export class ObservableQueryApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/client/others/typescript/builds/array-of-lists/configuration.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/client/others/typescript/builds/array-of-lists/configuration.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/client/others/typescript/builds/array-of-lists/configuration.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/client/others/typescript/builds/array-of-lists/configuration.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/array-of-lists/configuration.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/client/others/typescript/builds/array-of-lists/configuration.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/array-of-lists/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/types/ObservableAPI.ts
@@ -34,7 +34,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/client/others/typescript/builds/enum-single-value/configuration.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/client/others/typescript/builds/enum-single-value/configuration.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/client/others/typescript/builds/enum-single-value/configuration.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/client/others/typescript/builds/enum-single-value/configuration.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/enum-single-value/configuration.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/client/others/typescript/builds/enum-single-value/configuration.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/null-types-simple/configuration.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/client/others/typescript/builds/null-types-simple/configuration.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/client/others/typescript/builds/null-types-simple/configuration.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/client/others/typescript/builds/null-types-simple/configuration.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/null-types-simple/configuration.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/client/others/typescript/builds/null-types-simple/configuration.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/with-unique-items/configuration.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/client/others/typescript/builds/with-unique-items/configuration.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/client/others/typescript/builds/with-unique-items/configuration.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/client/others/typescript/builds/with-unique-items/configuration.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/with-unique-items/configuration.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/client/others/typescript/builds/with-unique-items/configuration.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/builds/with-unique-items/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/types/ObservableAPI.ts
@@ -33,7 +33,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/client/others/typescript/encode-decode/build/configuration.ts
+++ b/samples/client/others/typescript/encode-decode/build/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/client/others/typescript/encode-decode/build/configuration.ts
+++ b/samples/client/others/typescript/encode-decode/build/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/client/others/typescript/encode-decode/build/configuration.ts
+++ b/samples/client/others/typescript/encode-decode/build/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/client/others/typescript/encode-decode/build/configuration.ts
+++ b/samples/client/others/typescript/encode-decode/build/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/encode-decode/build/configuration.ts
+++ b/samples/client/others/typescript/encode-decode/build/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/client/others/typescript/encode-decode/build/configuration.ts
+++ b/samples/client/others/typescript/encode-decode/build/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/client/others/typescript/encode-decode/build/types/ObservableAPI.ts
+++ b/samples/client/others/typescript/encode-decode/build/types/ObservableAPI.ts
@@ -34,7 +34,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -62,7 +62,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -90,7 +90,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -118,7 +118,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -146,7 +146,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -174,7 +174,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -202,7 +202,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -230,7 +230,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -258,7 +258,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -286,7 +286,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -314,7 +314,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -342,7 +342,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -370,7 +370,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -398,7 +398,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -426,7 +426,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -454,7 +454,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -483,7 +483,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -513,7 +513,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -543,7 +543,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -573,7 +573,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -603,7 +603,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -633,7 +633,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -663,7 +663,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -693,7 +693,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -723,7 +723,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -753,7 +753,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -783,7 +783,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -813,7 +813,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -843,7 +843,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -873,7 +873,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -903,7 +903,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -933,7 +933,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/types/ObservableAPI.ts
@@ -41,7 +41,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -76,7 +76,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -111,7 +111,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -145,7 +145,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -179,7 +179,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -213,7 +213,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -249,7 +249,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -287,7 +287,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -341,7 +341,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -374,7 +374,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -407,7 +407,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -441,7 +441,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -493,7 +493,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -527,7 +527,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -561,7 +561,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -595,7 +595,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -629,7 +629,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -664,7 +664,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -698,7 +698,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -732,7 +732,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/types/ObservableAPI.ts
@@ -40,7 +40,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -70,7 +70,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -100,7 +100,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/types/ObservableAPI.ts
@@ -41,7 +41,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -76,7 +76,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -111,7 +111,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -145,7 +145,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -179,7 +179,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -213,7 +213,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -249,7 +249,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -287,7 +287,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -341,7 +341,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -374,7 +374,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -407,7 +407,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -441,7 +441,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -493,7 +493,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -527,7 +527,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -561,7 +561,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -595,7 +595,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -629,7 +629,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -664,7 +664,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -698,7 +698,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -732,7 +732,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers.ts";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth.ts";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/types/ObservableAPI.ts
@@ -41,7 +41,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -76,7 +76,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -111,7 +111,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -145,7 +145,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -179,7 +179,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -213,7 +213,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -249,7 +249,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -287,7 +287,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -341,7 +341,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -374,7 +374,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -407,7 +407,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -441,7 +441,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -493,7 +493,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -527,7 +527,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -561,7 +561,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -595,7 +595,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -629,7 +629,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -664,7 +664,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -698,7 +698,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -732,7 +732,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers.ts";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth.ts";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/types/ObservableAPI.ts
@@ -41,7 +41,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -76,7 +76,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -111,7 +111,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -145,7 +145,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -179,7 +179,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -213,7 +213,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -249,7 +249,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -287,7 +287,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -341,7 +341,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -374,7 +374,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -407,7 +407,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -441,7 +441,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -493,7 +493,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -527,7 +527,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -561,7 +561,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -595,7 +595,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -629,7 +629,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -664,7 +664,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -698,7 +698,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -732,7 +732,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/types/ObservableAPI.ts
@@ -82,7 +82,7 @@ export class ObservableAnotherFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -131,7 +131,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -178,7 +178,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -208,7 +208,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -241,7 +241,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -275,7 +275,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -307,7 +307,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -339,7 +339,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -371,7 +371,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -403,7 +403,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -435,7 +435,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -467,7 +467,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -499,7 +499,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -532,7 +532,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -579,7 +579,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -634,7 +634,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -681,7 +681,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -720,7 +720,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -755,7 +755,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -795,7 +795,7 @@ export class ObservableFakeApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -852,7 +852,7 @@ export class ObservableFakeClassnameTags123Api {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -904,7 +904,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -939,7 +939,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -974,7 +974,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1008,7 +1008,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1042,7 +1042,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1076,7 +1076,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1112,7 +1112,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1150,7 +1150,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1188,7 +1188,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1242,7 +1242,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1275,7 +1275,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1308,7 +1308,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1342,7 +1342,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1394,7 +1394,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1428,7 +1428,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1462,7 +1462,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1496,7 +1496,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1530,7 +1530,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1565,7 +1565,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1599,7 +1599,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -1633,7 +1633,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/configuration.ts
@@ -97,10 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: Configuration): Configuration {
-    if (options) {
-        conf = options;
-    }
-    return conf;
+    return options || conf;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -46,7 +46,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -81,7 +81,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -116,7 +116,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -150,7 +150,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -184,7 +184,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -218,7 +218,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -254,7 +254,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -292,7 +292,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -349,7 +349,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -382,7 +382,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -415,7 +415,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -449,7 +449,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -504,7 +504,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -538,7 +538,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -572,7 +572,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -606,7 +606,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -640,7 +640,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -675,7 +675,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -709,7 +709,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -743,7 +743,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/types/ObservableAPI.ts
@@ -39,7 +39,7 @@ export class ObservablePetApi {
     public addPetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.addPet(pet, _options);
+        const requestContextPromise = this.requestFactory.addPet(pet, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -74,7 +74,7 @@ export class ObservablePetApi {
     public deletePetWithHttpInfo(petId: number, apiKey?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _options);
+        const requestContextPromise = this.requestFactory.deletePet(petId, apiKey, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -109,7 +109,7 @@ export class ObservablePetApi {
     public findPetsByStatusWithHttpInfo(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _options);
+        const requestContextPromise = this.requestFactory.findPetsByStatus(status, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -143,7 +143,7 @@ export class ObservablePetApi {
     public findPetsByTagsWithHttpInfo(tags: Array<string>, _options?: Configuration): Observable<HttpInfo<Array<Pet>>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _options);
+        const requestContextPromise = this.requestFactory.findPetsByTags(tags, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -177,7 +177,7 @@ export class ObservablePetApi {
     public getPetByIdWithHttpInfo(petId: number, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.getPetById(petId, _options);
+        const requestContextPromise = this.requestFactory.getPetById(petId, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -211,7 +211,7 @@ export class ObservablePetApi {
     public updatePetWithHttpInfo(pet: Pet, _options?: Configuration): Observable<HttpInfo<Pet>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.updatePet(pet, _options);
+        const requestContextPromise = this.requestFactory.updatePet(pet, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -247,7 +247,7 @@ export class ObservablePetApi {
     public updatePetWithFormWithHttpInfo(petId: number, name?: string, status?: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _options);
+        const requestContextPromise = this.requestFactory.updatePetWithForm(petId, name, status, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -285,7 +285,7 @@ export class ObservablePetApi {
     public uploadFileWithHttpInfo(petId: number, additionalMetadata?: string, file?: HttpFile, _options?: Configuration): Observable<HttpInfo<ApiResponse>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _options);
+        const requestContextPromise = this.requestFactory.uploadFile(petId, additionalMetadata, file, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -342,7 +342,7 @@ export class ObservableStoreApi {
     public deleteOrderWithHttpInfo(orderId: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _options);
+        const requestContextPromise = this.requestFactory.deleteOrder(orderId, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -375,7 +375,7 @@ export class ObservableStoreApi {
     public getInventoryWithHttpInfo(_options?: Configuration): Observable<HttpInfo<{ [key: string]: number; }>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.getInventory(_options);
+        const requestContextPromise = this.requestFactory.getInventory(_config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -408,7 +408,7 @@ export class ObservableStoreApi {
     public getOrderByIdWithHttpInfo(orderId: number, _options?: Configuration): Observable<HttpInfo<Order>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.getOrderById(orderId, _options);
+        const requestContextPromise = this.requestFactory.getOrderById(orderId, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -442,7 +442,7 @@ export class ObservableStoreApi {
     public placeOrderWithHttpInfo(order: Order, _options?: Configuration): Observable<HttpInfo<Order>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.placeOrder(order, _options);
+        const requestContextPromise = this.requestFactory.placeOrder(order, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -497,7 +497,7 @@ export class ObservableUserApi {
     public createUserWithHttpInfo(user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.createUser(user, _options);
+        const requestContextPromise = this.requestFactory.createUser(user, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -531,7 +531,7 @@ export class ObservableUserApi {
     public createUsersWithArrayInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _options);
+        const requestContextPromise = this.requestFactory.createUsersWithArrayInput(user, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -565,7 +565,7 @@ export class ObservableUserApi {
     public createUsersWithListInputWithHttpInfo(user: Array<User>, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _options);
+        const requestContextPromise = this.requestFactory.createUsersWithListInput(user, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -599,7 +599,7 @@ export class ObservableUserApi {
     public deleteUserWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.deleteUser(username, _options);
+        const requestContextPromise = this.requestFactory.deleteUser(username, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -633,7 +633,7 @@ export class ObservableUserApi {
     public getUserByNameWithHttpInfo(username: string, _options?: Configuration): Observable<HttpInfo<User>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.getUserByName(username, _options);
+        const requestContextPromise = this.requestFactory.getUserByName(username, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -668,7 +668,7 @@ export class ObservableUserApi {
     public loginUserWithHttpInfo(username: string, password: string, _options?: Configuration): Observable<HttpInfo<string>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.loginUser(username, password, _options);
+        const requestContextPromise = this.requestFactory.loginUser(username, password, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -702,7 +702,7 @@ export class ObservableUserApi {
     public logoutUserWithHttpInfo(_options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.logoutUser(_options);
+        const requestContextPromise = this.requestFactory.logoutUser(_config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -736,7 +736,7 @@ export class ObservableUserApi {
     public updateUserWithHttpInfo(username: string, user: User, _options?: Configuration): Observable<HttpInfo<void>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.updateUser(username, user, _options);
+        const requestContextPromise = this.requestFactory.updateUser(username, user, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/types/ObservableAPI.ts
@@ -41,7 +41,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -76,7 +76,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -111,7 +111,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -145,7 +145,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -179,7 +179,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -213,7 +213,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -249,7 +249,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -287,7 +287,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -341,7 +341,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -374,7 +374,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -407,7 +407,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -441,7 +441,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -493,7 +493,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -527,7 +527,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -561,7 +561,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -595,7 +595,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -629,7 +629,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -664,7 +664,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -698,7 +698,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -732,7 +732,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/types/ObservableAPI.ts
@@ -33,7 +33,7 @@ export class ObservableDefaultApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
@@ -108,12 +108,11 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
     };
 }
 
-function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy: "append" | "prepend" | "replace" = "replace") {
     if (!calltimeMiddleware) {
         return staticMiddleware;
     }
-    // default to replace behavior
-    switch(strategy ?? "replace") {
+    switch(strategy) {
         case "append":
             return staticMiddleware.concat(calltimeMiddleware);
         case "prepend":

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
@@ -97,7 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = [];
+    let allMiddleware: Middleware[] = conf.middleware;
     if (options && options.middleware) {
         const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
         // call-time middleware provided
@@ -122,7 +122,7 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
           baseServer: options.baseServer || conf.baseServer,
           httpApi: options.httpApi || conf.httpApi,
           authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware || conf.middleware
+          middleware: allMiddleware,
         };
     }
     return conf;

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
@@ -97,26 +97,7 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = conf.middleware;
-    if (options && options.middleware) {
-        const middlewareMergeStrategy = options.middlewareMergeStrategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = options.middleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = conf.middleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(conf.middleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
-    }
+    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
     if (options) {
         conf = {
           baseServer: options.baseServer || conf.baseServer,
@@ -126,6 +107,30 @@ export function mergeConfiguration(conf: Configuration, options?: ConfigurationO
         };
     }
     return conf;
+}
+
+function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
+    let allMiddleware: Middleware[] = staticMiddleware;
+    if (calltimeMiddleware) {
+        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
+        // call-time middleware provided
+        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
+
+        switch(middlewareMergeStrategy) {
+        case "append":
+            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
+            break;
+        case "prepend":
+            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
+            break;
+        case "replace":
+            allMiddleware = calltimeMiddleware
+            break;
+        default:
+            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
+        }
+    }
+    return allMiddleware;
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
@@ -119,8 +119,9 @@ function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Mi
             return calltimeMiddleware.concat(staticMiddleware)
         case "replace":
             return calltimeMiddleware
+        default:
+            throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
     }
-    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
@@ -5,16 +5,16 @@ import { BaseServerConfiguration, server1 } from "./servers";
 import { configureAuthMethods, AuthMethods, AuthMethodsConfiguration } from "./auth/auth";
 
 export interface Configuration<M = Middleware> {
-  readonly baseServer: BaseServerConfiguration;
-  readonly httpApi: HttpLibrary;
-  readonly middleware: M[];
-  readonly authMethods: AuthMethods;
+    readonly baseServer: BaseServerConfiguration;
+    readonly httpApi: HttpLibrary;
+    readonly middleware: M[];
+    readonly authMethods: AuthMethods;
 }
 
 // Additional option specific to middleware merge strategy
 export interface MiddlewareMergeOptions {
-  // default is `'replace'` for backwards compatibility
-  middlewareMergeStrategy?: 'replace' | 'append' | 'prepend';
+    // default is `"replace"` for backwards compatibility
+    middlewareMergeStrategy?: "replace" | "append" | "prepend";
 }
 
 // Unify configuration options using Partial plus extra merge strategy

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/configuration.ts
@@ -97,40 +97,31 @@ export function createConfiguration(conf: ConfigurationParameters = {}): Configu
  * Merge configuration options into a configuration.
  */
 export function mergeConfiguration(conf: Configuration, options?: ConfigurationOptions): Configuration {
-    let allMiddleware: Middleware[] = mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy);
-    if (options) {
-        conf = {
-          baseServer: options.baseServer || conf.baseServer,
-          httpApi: options.httpApi || conf.httpApi,
-          authMethods: options.authMethods || conf.authMethods,
-          middleware: allMiddleware,
-        };
+    if (!options) {
+        return conf;
     }
-    return conf;
+    return {
+        baseServer: options.baseServer || conf.baseServer,
+        httpApi: options.httpApi || conf.httpApi,
+        authMethods: options.authMethods || conf.authMethods,
+        middleware: mergeMiddleware(conf.middleware, options?.middleware, options?.middlewareMergeStrategy),
+    };
 }
 
 function mergeMiddleware(staticMiddleware: Middleware[], calltimeMiddleware?: Middleware[], strategy?: "append" | "prepend" | "replace") {
-    let allMiddleware: Middleware[] = staticMiddleware;
-    if (calltimeMiddleware) {
-        const middlewareMergeStrategy = strategy || "replace" // default to replace behavior
-        // call-time middleware provided
-        const calltimeMiddleware: Middleware[] = calltimeMiddleware;
-
-        switch(middlewareMergeStrategy) {
-        case "append":
-            allMiddleware = staticMiddleware.concat(calltimeMiddleware);
-            break;
-        case "prepend":
-            allMiddleware = calltimeMiddleware.concat(staticMiddleware)
-            break;
-        case "replace":
-            allMiddleware = calltimeMiddleware
-            break;
-        default:
-            throw new Error(`unrecognized middleware merge strategy '${middlewareMergeStrategy}'`);
-        }
+    if (!calltimeMiddleware) {
+        return staticMiddleware;
     }
-    return allMiddleware;
+    // default to replace behavior
+    switch(strategy ?? "replace") {
+        case "append":
+            return staticMiddleware.concat(calltimeMiddleware);
+        case "prepend":
+            return calltimeMiddleware.concat(staticMiddleware)
+        case "replace":
+            return calltimeMiddleware
+    }
+    throw new Error(`Unrecognized middleware merge strategy '${strategy}'`)
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/types/ObservableAPI.ts
@@ -41,7 +41,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -76,7 +76,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -111,7 +111,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -145,7 +145,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -179,7 +179,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -213,7 +213,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -249,7 +249,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -287,7 +287,7 @@ export class ObservablePetApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -341,7 +341,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -374,7 +374,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -407,7 +407,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -441,7 +441,7 @@ export class ObservableStoreApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -493,7 +493,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -527,7 +527,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -561,7 +561,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -595,7 +595,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -629,7 +629,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -664,7 +664,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -698,7 +698,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {
@@ -732,7 +732,7 @@ export class ObservableUserApi {
             middlewarePreObservable = middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => middleware.pre(ctx)));
         }
 
-        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => this.configuration.httpApi.send(ctx))).
+        return middlewarePreObservable.pipe(mergeMap((ctx: RequestContext) => _config.httpApi.send(ctx))).
             pipe(mergeMap((response: ResponseContext) => {
                 let middlewarePostObservable = of(response);
                 for (const middleware of _config.middleware.reverse()) {

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/api/PetApi.test.ts
@@ -103,6 +103,24 @@ describe("PetApi", () => {
     expect(CallOrder).deep.equal(['base-pre', 'base-post'])
   })
 
+  it("should keep middleware when options are given without middleware", async () => {
+    let { CallOrder, BaseMiddleware, CalltimeMiddleware } = MiddlewareCallTracker()
+    const configuration = petstore.createConfiguration({ promiseMiddleware: [BaseMiddleware] });
+    const petApi = new petstore.PetApi(configuration);
+    const callTimeAppendedRightPet = await petApi.getPetById(pet.id, {});
+    expect(callTimeAppendedRightPet).to.deep.equal(pet);
+    expect(CallOrder).deep.equal(['base-pre', 'base-post'])
+  })
+
+  it("should replace middleware when options contain an empty array of middlewares", async () => {
+    let { CallOrder, BaseMiddleware, CalltimeMiddleware } = MiddlewareCallTracker()
+    const configuration = petstore.createConfiguration({ promiseMiddleware: [BaseMiddleware] });
+    const petApi = new petstore.PetApi(configuration);
+    const callTimeAppendedRightPet = await petApi.getPetById(pet.id, { middleware: [] });
+    expect(callTimeAppendedRightPet).to.deep.equal(pet);
+    expect(CallOrder).deep.equal([])
+  })
+
   it("replace Middleware call order", async () => {
     let { CallOrder, BaseMiddleware, CalltimeMiddleware } = MiddlewareCallTracker()
     const configuration = petstore.createConfiguration({ promiseMiddleware: [BaseMiddleware] })


### PR DESCRIPTION
This PR is a continuation of https://github.com/OpenAPITools/openapi-generator/pull/20978 with more improvements following https://github.com/OpenAPITools/openapi-generator/pull/20430.
I'll rebase once the other PR is merged. Currently this branch contains all changes from both PRs.

- **Keep static middleware when options contain no middleware field**
  This is the main change in behaviour as discussed before in the other PR.
  When the user calls a method with options that do not set a middleware, the existing static middleware should be used, to follow the spirit of merging the top-level fields of the options.
  On the other hand the user can give an empty array to skip any middlewares for the call.
  I added tests for both cases.
- **Extract middleware merge logic into function**
  I included more refactoring in this PR.
- **Simplify extracted functions**
- **Fix: Pass static config when no options are given for inversify**
  I also noticed an error in the inversify variant. When no options are given, the static config should be used. Previously even empty options where used here.
  Unfortunately it seems the inversify tests are broken and I guess inversify 6 is not compatible with typescript 4. Anyway I could not get them to work again and so I did not add a test here.
- **Fix: Allow overriding http api with options**
  Another bug, that I found, is that `httpApi` was always taken from the static configuration and could not be overridden using options. I fixed that and added a test.
- **Regenerate samples**
  I regenerated the samples after almost every change, to make them clearer.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)