### PR TITLE
feat: [Rust][client] Add option to use rustls for reqwest instead of openssl

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -63,13 +63,13 @@ secrecy = "0.8.0"
 {{/withAWSV4Signature}}
 {{#reqwest}}
 {{^supportAsync}}
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }
 {{#supportMiddleware}}
 reqwest-middleware = { version = "^0.4", features = ["json", "blocking", "multipart"] }
 {{/supportMiddleware}}
 {{/supportAsync}}
 {{#supportAsync}}
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 {{#supportMiddleware}}
 reqwest-middleware = { version = "^0.4", features = ["json", "multipart"] }
 {{/supportMiddleware}}
@@ -82,7 +82,7 @@ google-cloud-token = "^0.1"
 {{/reqwest}}
 {{#reqwestTrait}}
 async-trait = "^0.1"
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 {{#supportMiddleware}}
 reqwest-middleware = { version = "^0.4", features = ["json", "multipart"] }
 {{/supportMiddleware}}
@@ -97,6 +97,9 @@ mockall = { version = "^0.13", optional = true}
 bon = { version = "2.3", optional = true }
 {{/useBonBuilder}}
 [features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
 {{#mockall}}
 mockall = ["dep:mockall"]
 {{/mockall}}

--- a/samples/client/others/rust/reqwest-regression-16119/Cargo.toml
+++ b/samples/client/others/rust/reqwest-regression-16119/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/api-with-ref-param/Cargo.toml
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }

--- a/samples/client/others/rust/reqwest/composed-oneof/Cargo.toml
+++ b/samples/client/others/rust/reqwest/composed-oneof/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/emptyObject/Cargo.toml
+++ b/samples/client/others/rust/reqwest/emptyObject/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/oneOf-array-map/Cargo.toml
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/Cargo.toml
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/others/rust/reqwest/oneOf/Cargo.toml
+++ b/samples/client/others/rust/reqwest/oneOf/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/petstore/rust/reqwest-trait/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/Cargo.toml
@@ -14,7 +14,10 @@ serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 async-trait = "^0.1"
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 mockall = { version = "^0.13", optional = true}
 [features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
 mockall = ["dep:mockall"]

--- a/samples/client/petstore/rust/reqwest/name-mapping/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/name-mapping/Cargo.toml
@@ -11,4 +11,4 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/Cargo.toml
@@ -13,5 +13,5 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 reqwest-middleware = { version = "^0.4", features = ["json", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 async-trait = "^0.1"
 # TODO: propose to Yoshidan to externalize this as non google related crate, so that it can easily be extended for other cloud providers.
 google-cloud-token = "^0.1"

--- a/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
@@ -13,4 +13,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/Cargo.toml
@@ -13,4 +13,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
@@ -16,4 +16,4 @@ uuid = { version = "^1.8", features = ["serde", "v4"] }
 aws-sigv4 = "0.3.0"
 http = "0.2.5"
 secrecy = "0.8.0"
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/Cargo.toml
@@ -13,4 +13,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore/Cargo.toml
@@ -13,4 +13,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "blocking", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "blocking", "multipart"] }


### PR DESCRIPTION
Generated Rust crates will allow configuring reqwest to use rustls via passthrough features.

fix: #19853

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @frol @farcaller @richardwhiuk @paladinzh @jacob-pro