### PR TITLE
[Protobuf Schema] Map Field Handling in Composed Schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -397,7 +397,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         if (ModelUtils.isMapSchema(schema) && ModelUtils.getAdditionalProperties(schema) != null) {
             Schema mapValueSchema = ModelUtils.getAdditionalProperties(schema);
             mapValueSchema = ModelUtils.getReferencedSchema(openAPI, mapValueSchema);
-            if (ModelUtils.isArraySchema(mapValueSchema) || (!ModelUtils.isMapSchema(mapValueSchema) && !ModelUtils.isModel(mapValueSchema))) {
+            if (ModelUtils.isArraySchema(mapValueSchema) || (ModelUtils.isMapSchema(mapValueSchema) && !ModelUtils.isModel(mapValueSchema))) {
                 Schema innerSchema = generateNestedSchema(mapValueSchema, visitedSchemas);
                 schema.setAdditionalProperties(innerSchema);
 
@@ -1053,6 +1053,21 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         return GeneratorLanguage.PROTOBUF;
     }
 
+
+/**
+ * Handles additionalProperties defined in composed schemas (e.g., allOf) by injecting into the model's properties.
+ * Example:
+ *  components:
+ *    schemas:
+ *      Dog:
+ *        allOf:
+ *          - $ref: '#/components/schemas/DogBase'
+ *          - type: object
+ *            additionalProperties:
+ *              title: pet
+ *              $ref: '#/components/schemas/Pet'
+ * In this case, the second allOf that defines a map with string keys and Pet values will be part of model's property.
+ */
     @Override
     protected void addProperties(Map<String, Schema> properties, List<String> required, Schema schema, Set<Schema> visitedSchemas){
         super.addProperties(properties, required, schema, visitedSchemas);
@@ -1072,5 +1087,4 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
             properties.put(addtionalPropertiesName, schema);
         }
     }
-
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -397,7 +397,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         if (ModelUtils.isMapSchema(schema) && ModelUtils.getAdditionalProperties(schema) != null) {
             Schema mapValueSchema = ModelUtils.getAdditionalProperties(schema);
             mapValueSchema = ModelUtils.getReferencedSchema(openAPI, mapValueSchema);
-            if (ModelUtils.isArraySchema(mapValueSchema) || ModelUtils.isMapSchema(mapValueSchema)) {
+            if (ModelUtils.isArraySchema(mapValueSchema) || (!ModelUtils.isMapSchema(mapValueSchema) && !ModelUtils.isModel(mapValueSchema))) {
                 Schema innerSchema = generateNestedSchema(mapValueSchema, visitedSchemas);
                 schema.setAdditionalProperties(innerSchema);
 
@@ -405,7 +405,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         } else if (ModelUtils.isArraySchema(schema) && ModelUtils.getSchemaItems(schema) != null) {
             Schema arrayItemSchema = ModelUtils.getSchemaItems(schema);
             arrayItemSchema = ModelUtils.getReferencedSchema(openAPI, arrayItemSchema);
-            if (ModelUtils.isMapSchema(arrayItemSchema) || ModelUtils.isArraySchema(arrayItemSchema)) {
+            if ((ModelUtils.isMapSchema(arrayItemSchema) && !ModelUtils.isModel(arrayItemSchema)) || ModelUtils.isArraySchema(arrayItemSchema)) {
                 Schema innerSchema = generateNestedSchema(arrayItemSchema, visitedSchemas);
                 schema.setItems(innerSchema);
             }
@@ -418,7 +418,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
                     Schema innerSchema = generateNestedSchema(oneOfSchema, visitedSchemas);
                     innerSchema.setTitle(oneOf.getTitle());
                     newOneOfs.add(innerSchema);
-                } else if (ModelUtils.isMapSchema(oneOfSchema)) {
+                } else if (ModelUtils.isMapSchema(oneOfSchema) && !ModelUtils.isModel(oneOfSchema)) {
                     Schema innerSchema = generateNestedSchema(oneOfSchema, visitedSchemas);
                     innerSchema.setTitle(oneOf.getTitle());
                     newOneOfs.add(innerSchema);
@@ -1051,6 +1051,26 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
     @Override
     public GeneratorLanguage generatorLanguage() {
         return GeneratorLanguage.PROTOBUF;
+    }
+
+    @Override
+    protected void addProperties(Map<String, Schema> properties, List<String> required, Schema schema, Set<Schema> visitedSchemas){
+        super.addProperties(properties, required, schema, visitedSchemas);
+        if(schema.getAdditionalProperties() != null) {
+            String addtionalPropertiesName = "default_map";
+            if(schema.getTitle() != null) {
+                addtionalPropertiesName = schema.getTitle();
+            } else {
+                Schema additionalProperties = ModelUtils.getAdditionalProperties(schema);
+                if (additionalProperties.getTitle() != null) {
+                    addtionalPropertiesName = additionalProperties.getTitle();
+                } else if (additionalProperties.get$ref() != null) {
+                    String ref = ModelUtils.getSimpleRef(additionalProperties.get$ref());
+                    addtionalPropertiesName = toVarName(toModelName(ref));
+                }
+            }
+            properties.put(addtionalPropertiesName, schema);
+        }
     }
 
 }

--- a/modules/openapi-generator/src/test/resources/3_0/protobuf/petstore-complex.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/protobuf/petstore-complex.yaml
@@ -34,13 +34,22 @@ externalDocs:
 components:
   schemas:
     Dog:
-      type: object
-      properties:
-        bark:
-          type: boolean
-        breed:
-          type: string
-          enum: [ Dingo, Husky, Retriever, Shepherd ]
+      allOf:
+        - type: object
+          properties:
+            bark:
+              type: boolean
+            breed:
+              type: string
+              enum: [Dingo, Husky, Retriever, Shepherd]
+        - type: object
+          propertyNames:
+            title: field
+            type: string
+          additionalProperties:
+            title: pet
+            $ref: '#/components/schemas/Pet'
+          minProperties: 1
     Cat:
       type: object
       properties:
@@ -100,31 +109,26 @@ components:
           format: int64
         category:
           $ref: '#/components/schemas/Category'
-      name:
-        type: string
-      photoUrls:
-        type: array
-        xml:
-          name: photoUrl
-          wrapped: true
-        items:
+        name:
           type: string
-      tags:
-        type: array
-        xml:
-          name: tag
-          wrapped: true
-        items:
+        photoUrls:
           type: array
-          additionalProperties:
-            $ref: '#/components/schemas/Tag'
-      status:
-        type: string
-        description: pet status in the store
-        deprecated: true
-        enum:
-          - available
-          - pending
-          - sold
-      xml:
-        name: Pet
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          deprecated: true
+          enum:
+            - available
+            - pending
+            - sold

--- a/samples/config/petstore/protobuf-schema-config-complex/.openapi-generator/FILES
+++ b/samples/config/petstore/protobuf-schema-config-complex/.openapi-generator/FILES
@@ -6,5 +6,6 @@ models/pet.proto
 models/string_array.proto
 models/string_map.proto
 models/tag.proto
+models/tag_map.proto
 models/tag_name.proto
 services/default_service.proto

--- a/samples/config/petstore/protobuf-schema-config-complex/models/pet.proto
+++ b/samples/config/petstore/protobuf-schema-config-complex/models/pet.proto
@@ -13,12 +13,29 @@ syntax = "proto3";
 package petstore;
 
 import public "models/category.proto";
+import public "models/tag_map.proto";
 
 message Pet {
 
   int64 id = 1;
 
   Category category = 2;
+
+  string name = 3;
+
+  repeated string photo_urls = 4 [json_name="photoUrls"];
+
+  repeated TagMap tags = 5;
+
+  // pet status in the store
+  enum Status {
+    STATUS_UNSPECIFIED = 0;
+    STATUS_AVAILABLE = 1;
+    STATUS_PENDING = 2;
+    STATUS_SOLD = 3;
+  }
+
+  Status status = 6;
 
 }
 

--- a/samples/config/petstore/protobuf-schema-config-complex/models/tag_map.proto
+++ b/samples/config/petstore/protobuf-schema-config-complex/models/tag_map.proto
@@ -12,23 +12,11 @@ syntax = "proto3";
 
 package petstore;
 
-import public "models/pet.proto";
+import public "models/tag.proto";
 
-message Dog {
+message TagMap {
 
-  bool bark = 1;
-
-  enum Breed {
-    BREED_UNSPECIFIED = 0;
-    BREED_DINGO = 1;
-    BREED_HUSKY = 2;
-    BREED_RETRIEVER = 3;
-    BREED_SHEPHERD = 4;
-  }
-
-  Breed breed = 2;
-
-  map<string, Pet> pet = 3;
+  map<string, Tag> tag_map = 1;
 
 }
 


### PR DESCRIPTION
This PR addresses a corner case where a map defined within an composed schema is being ignored during Protobuf generation. 
Previously, the pet map (the field defined via additionalProperties) was not being handled properly, resulting in its omission from the generated proto file. the schema like the following:
```
schemas:
      Dog:
         allOf:
            - $ref: '#/components/schemas/DogBase'
            - type: object
              additionalProperties:
                 title: pet
                 $ref: '#/components/schemas/Pet'
              minProperties: 1
      Pet:
        type: string
      DogBase:
         type: object
         properties:
            bark:
               type: boolean
            breed:
               type: string
               enum: [ Dingo, Husky, Retriever, Shepherd ]
```

With this PR, the generator now correctly detects and processes the pet map, ensuring that it is included in the generated Protobuf message.
<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
