### PR TITLE
[julia] fix regex escape on server codegen

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
@@ -531,6 +531,9 @@ public abstract class AbstractJuliaCodegen extends DefaultCodegen {
         }
     }
 
+    // The DefaultCodegen.toRegularExpression method returns regex in a format
+    // that is unsuitable for use in Julia. This method changes the regex to
+    // a suitable format.
     private void changeRegexEscape(List<CodegenParameter> paramsList) {
         for (CodegenParameter param : paramsList) {
             if (param.pattern != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJuliaCodegen.java
@@ -531,6 +531,14 @@ public abstract class AbstractJuliaCodegen extends DefaultCodegen {
         }
     }
 
+    private void changeRegexEscape(List<CodegenParameter> paramsList) {
+        for (CodegenParameter param : paramsList) {
+            if (param.pattern != null) {
+                param.pattern = escapeRegex(param.pattern);
+            }
+        }
+    }
+
     /**
      * Convert OAS Operation object to Codegen Operation object
      *
@@ -561,6 +569,13 @@ public abstract class AbstractJuliaCodegen extends DefaultCodegen {
         changeParamNames(op.pathParams, reservedNames);
         changeParamNames(op.queryParams, reservedNames);
         changeParamNames(op.formParams, reservedNames);
+
+        changeRegexEscape(op.allParams);
+        changeRegexEscape(op.bodyParams);
+        changeRegexEscape(op.headerParams);
+        changeRegexEscape(op.pathParams);
+        changeRegexEscape(op.queryParams);
+        changeRegexEscape(op.formParams);
 
         return op;
     }


### PR DESCRIPTION
Fixed escaping of regex patterns on julialang server codegen.

cc: @wing328 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
