### PR TITLE
Fix single quote escaping for python code generator (and its test)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -214,7 +214,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 String defaultValue = String.valueOf(p.getDefault());
                 if (defaultValue != null) {
                     defaultValue = defaultValue.replace("\\", "\\\\")
-                            .replace("'", "\'");
+                            .replace("'", "\\'");
                     if (Pattern.compile("\r\n|\r|\n").matcher(defaultValue).find()) {
                         return "'''" + defaultValue + "'''";
                     } else {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -139,7 +139,7 @@ public class PythonClientCodegenTest {
         StringSchema schema = new StringSchema();
         schema.setDefault("Text containing 'single' quote");
         String defaultValue = codegen.toDefaultValue(schema);
-        Assert.assertEquals("'Text containing \'single\' quote'", defaultValue);
+        Assert.assertEquals("'Text containing \\'single\\' quote'", defaultValue);
     }
 
     @Test(description = "test backslash default")


### PR DESCRIPTION
Currently, the implementation of the code generator for Python can generate invalid Python code if single quotes are used within an OpenAPI specification, e.g. for default values. Please see also this [issue](https://github.com/OpenAPITools/openapi-generator/issues/21022) that I have created.

This stems from invalid single quote escaping within the generator. It's kind of hard to spot, but in Java the strings "'" and "\'" are identical, so the implementation and its test were broken identically. 

This seems to have happened already quite a few years ago during refactoring, since the test seems might have been created as a result of this [issue](https://github.com/OpenAPITools/openapi-generator/issues/5981).

The minimal example from there is still valid:

##### OpenAPI declaration file content or url

```yaml
openapi: 3.0.0
info:
  title: Single quote example
  version: 1.0.0
paths:
  /singleQuoteExample:
    post:
      summary: Test single quote in default and example values.
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              properties:
                singleQuoteInDefault1:
                  type: string
                  default: Text containing 'single' quote
                singleQuoteInDefault2:
                  type: string
                  default: "8'998'999'998'000'000"
                singleQuoteInExample1:
                  type: string
                  example: "Text containing 'single' quote"
                singleQuoteInExample2:
                  type: string
                  example: 8'998'999'998'000'000
      responses:
        '201':
          description: OK
```
##### Command line used for generation
`docker run --rm -v $(pwd)/bla:/bla -v $(pwd):/local openapitools/openapi-generator-cli:latest generate -i /local/bla.yaml  -g python -o /bla`

##### Steps to reproduce

Run the above command.

##### Expected output

`bla/openapi_client/models/single_quote_example_post_request.py`

```python
class SingleQuoteExamplePostRequest(BaseModel):
    """
    SingleQuoteExamplePostRequest
    """ # noqa: E501
    single_quote_in_default1: Optional[StrictStr] = Field(default='Text containing \'single\' quote', alias="singleQuoteInDefault1")
    single_quote_in_default2: Optional[StrictStr] = Field(default='8\'998\'999\'998\'000\'000', alias="singleQuoteInDefault2")
    single_quote_in_example1: Optional[StrictStr] = Field(default=None, alias="singleQuoteInExample1")
    single_quote_in_example2: Optional[StrictStr] = Field(default=None, alias="singleQuoteInExample2")
    __properties: ClassVar[List[str]] = ["singleQuoteInDefault1", "singleQuoteInDefault2", "singleQuoteInExample1", "singleQuoteInExample2"]
```

##### Actual output

`bla/openapi_client/models/single_quote_example_post_request.py`
```python
class SingleQuoteExamplePostRequest(BaseModel):
    """
    SingleQuoteExamplePostRequest
    """ # noqa: E501
    single_quote_in_default1: Optional[StrictStr] = Field(default='Text containing 'single' quote', alias="singleQuoteInDefault1")
    single_quote_in_default2: Optional[StrictStr] = Field(default='8'998'999'998'000'000', alias="singleQuoteInDefault2")
    single_quote_in_example1: Optional[StrictStr] = Field(default=None, alias="singleQuoteInExample1")
    single_quote_in_example2: Optional[StrictStr] = Field(default=None, alias="singleQuoteInExample2")
    __properties: ClassVar[List[str]] = ["singleQuoteInDefault1", "singleQuoteInDefault2", "singleQuoteInExample1", "singleQuoteInExample2"]

```

@cbornet @tomplus @krjakbrjak @fa0311 @multani

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
