### PR TITLE
Add error reporting when handling exception in PHP Laravel

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-laravel/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/api_controller.mustache
@@ -91,6 +91,7 @@ class {{controllerName}} extends Controller
             $apiResult = $this->api->{{operationId}}({{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/AnotherFakeController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/AnotherFakeController.php
@@ -70,6 +70,7 @@ class AnotherFakeController extends Controller
             $apiResult = $this->api->call123TestSpecialTags($client);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/DefaultController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/DefaultController.php
@@ -68,6 +68,7 @@ class DefaultController extends Controller
             $apiResult = $this->api->fooGet();
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/FakeClassnameTags123Controller.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/FakeClassnameTags123Controller.php
@@ -70,6 +70,7 @@ class FakeClassnameTags123Controller extends Controller
             $apiResult = $this->api->testClassname($client);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/FakeController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/FakeController.php
@@ -68,6 +68,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeBigDecimalMap();
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -106,6 +107,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeHealthGet();
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -150,6 +152,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeHttpSignatureTest($pet, $query1, $header1);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -190,6 +193,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeOuterBooleanSerialize($body);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -230,6 +234,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeOuterCompositeSerialize($outerComposite);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -270,6 +275,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeOuterNumberSerialize($body);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -310,6 +316,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakeOuterStringSerialize($body);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -350,6 +357,7 @@ class FakeController extends Controller
             $apiResult = $this->api->fakePropertyEnumIntegerSerialize($outerObjectWithEnumProperty);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -390,6 +398,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testAdditionalPropertiesReference($requestBody);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -430,6 +439,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testBodyWithBinary($body);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -470,6 +480,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testBodyWithFileSchema($fileSchemaTestClass);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -512,6 +523,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testBodyWithQueryParams($query, $user);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -552,6 +564,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testClientModel($client);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -672,6 +685,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testEndpointParameters($number, $double, $patternWithoutDelimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $dateTime, $password, $callback);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -754,6 +768,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testEnumParameters($enumHeaderStringArray, $enumHeaderString, $enumQueryStringArray, $enumQueryString, $enumQueryInteger, $enumQueryDouble, $enumQueryModelArray, $enumFormStringArray, $enumFormString);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -829,6 +844,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testGroupParameters($requiredStringGroup, $requiredBooleanGroup, $requiredInt64Group, $stringGroup, $booleanGroup, $int64Group);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -869,6 +885,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testInlineAdditionalProperties($requestBody);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -909,6 +926,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testInlineFreeformAdditionalProperties($testInlineFreeformAdditionalPropertiesRequest);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -959,6 +977,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testJsonFormData($param, $param2);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -999,6 +1018,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testNullable($childWithNullable);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -1077,6 +1097,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allowEmpty, $language);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -1117,6 +1138,7 @@ class FakeController extends Controller
             $apiResult = $this->api->testStringMapReference($requestBody);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/PetController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/PetController.php
@@ -70,6 +70,7 @@ class PetController extends Controller
             $apiResult = $this->api->addPet($pet);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -122,6 +123,7 @@ class PetController extends Controller
             $apiResult = $this->api->deletePet($petId, $apiKey);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -170,6 +172,7 @@ class PetController extends Controller
             $apiResult = $this->api->findPetsByStatus($status);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -220,6 +223,7 @@ class PetController extends Controller
             $apiResult = $this->api->findPetsByTags($tags);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -268,6 +272,7 @@ class PetController extends Controller
             $apiResult = $this->api->getPetById($petId);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -316,6 +321,7 @@ class PetController extends Controller
             $apiResult = $this->api->updatePet($pet);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -381,6 +387,7 @@ class PetController extends Controller
             $apiResult = $this->api->updatePetWithForm($petId, $name, $status);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -438,6 +445,7 @@ class PetController extends Controller
             $apiResult = $this->api->uploadFile($petId, $additionalMetadata, $file);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -492,6 +500,7 @@ class PetController extends Controller
             $apiResult = $this->api->uploadFileWithRequiredFile($petId, $requiredFile, $additionalMetadata);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/StoreController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/StoreController.php
@@ -73,6 +73,7 @@ class StoreController extends Controller
             $apiResult = $this->api->deleteOrder($orderId);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -115,6 +116,7 @@ class StoreController extends Controller
             $apiResult = $this->api->getInventory();
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -161,6 +163,7 @@ class StoreController extends Controller
             $apiResult = $this->api->getOrderById($orderId);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -209,6 +212,7 @@ class StoreController extends Controller
             $apiResult = $this->api->placeOrder($order);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 

--- a/samples/server/petstore/php-laravel/Http/Controllers/UserController.php
+++ b/samples/server/petstore/php-laravel/Http/Controllers/UserController.php
@@ -70,6 +70,7 @@ class UserController extends Controller
             $apiResult = $this->api->createUser($user);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -110,6 +111,7 @@ class UserController extends Controller
             $apiResult = $this->api->createUsersWithArrayInput($user);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -150,6 +152,7 @@ class UserController extends Controller
             $apiResult = $this->api->createUsersWithListInput($user);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -193,6 +196,7 @@ class UserController extends Controller
             $apiResult = $this->api->deleteUser($username);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -240,6 +244,7 @@ class UserController extends Controller
             $apiResult = $this->api->getUserByName($username);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -298,6 +303,7 @@ class UserController extends Controller
             $apiResult = $this->api->loginUser($username, $password);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -340,6 +346,7 @@ class UserController extends Controller
             $apiResult = $this->api->logoutUser();
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 
@@ -381,6 +388,7 @@ class UserController extends Controller
             $apiResult = $this->api->updateUser($username, $user);
         } catch (\Exception $exception) {
             // This shouldn't happen
+            report($exception);
             return response()->json(['error' => $exception->getMessage()], 500);
         }
 


### PR DESCRIPTION
When handling exceptions thrown in the concrete instance of the API interface we currently do not report them. This would be problematic in production environments. Adding the `report` fixes this issue by using [Laravel error reporting](https://laravel.com/docs/12.x/errors#reporting-exceptions).

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
