### PR TITLE
feat: Add type+format mappings for go

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -117,9 +117,27 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         instantiationTypes.put("map", "GoMap");*/
 
         typeMapping.clear();
+        typeMapping.put("integer+int8", "int8");
+        typeMapping.put("integer+uint8", "uint8");
+        typeMapping.put("integer+int16", "int16");
+        typeMapping.put("integer+uint16", "uint16");
         typeMapping.put("integer", "int32");
+        typeMapping.put("integer+int32", "int32");
+        typeMapping.put("integer+int64", "int64");
+        typeMapping.put("integer+uint32", "uint32");
+        typeMapping.put("integer+uint64", "uint64");
         typeMapping.put("long", "int64");
+        typeMapping.put("number+int8", "int8");
+        typeMapping.put("number+uint8", "uint8");
+        typeMapping.put("number+int16", "int16");
+        typeMapping.put("number+uint16", "uint16");
+        typeMapping.put("number+int32", "int32");
+        typeMapping.put("number+int64", "int64");
+        typeMapping.put("number+uint32", "uint32");
+        typeMapping.put("number+uint64", "uint64");
         typeMapping.put("number", "float32");
+        typeMapping.put("number+float32", "float32");
+        typeMapping.put("number+float64", "float64");
         typeMapping.put("float", "float32");
         typeMapping.put("double", "float64");
         typeMapping.put("decimal", "float64");


### PR DESCRIPTION
# Add type+format mappings for Go generator

## Description
Adds support for explicit type+format mappings in the Go generator, allowing precise control over numeric types through both integer and number formats. This enhancement enables users to specify exact Go numeric types using OpenAPI's type and format fields.

## New Type Mappings

### Integer Format Mappings
| OpenAPI Type+Format | Go Type  |
|-------------------|-----------|
| integer+int8     | int8      |
| integer+uint8    | uint8     |
| integer+int16    | int16     |
| integer+uint16   | uint16    |
| integer+int32    | int32     |
| integer+int64    | int64     |
| integer+uint32   | uint32    |
| integer+uint64   | uint64    |

### Number Format Mappings
| OpenAPI Type+Format | Go Type  |
|-------------------|-----------|
| number+int8      | int8      |
| number+uint8     | uint8     |
| number+int16     | int16     |
| number+uint16    | uint16    |
| number+int32     | int32     |
| number+int64     | int64     |
| number+uint32    | uint32    |
| number+uint64    | uint64    |
| number+float32   | float32   |
| number+float64   | float64   |

Default mappings remain unchanged:
- `integer` → `int32`
- `number` → `float32`
- `long` → `int64`
- `float` → `float32`
- `double` → `float64`
- `decimal` → `float64`

## Usage Example
```yaml
components:
  schemas:
    MyModel:
      type: object
      properties:
        byteValue:
          type: integer
          format: uint8
        preciseFloat:
          type: number
          format: float64
        standardInt:
          type: integer  # defaults to int32
```

Closes: #21031

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
