### PR TITLE
Add optional erasable syntax configuration to Typescript generator.

### DIFF
--- a/docs/generators/typescript.md
+++ b/docs/generators/typescript.md
@@ -42,6 +42,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |supportsES6|Generate code that conforms to ES6.| |false|
+|useErasableSyntax|Use erasable syntax for the generated code. This is a temporary feature and will be removed in the future.| |false|
 |useInversify|Enable this to generate decorators and service identifiers for the InversifyJS inversion of control container. If you set 'deno' as 'platform', the generator will process this value as 'disable'.| |false|
 |useObjectParameters|Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.| |false|
 |useRxJS|Enable this to internally use rxjs observables. If disabled, a stub is used instead. This is required for the 'angular' framework.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptClientCodegen.java
@@ -78,6 +78,9 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
     private static final String USE_OBJECT_PARAMS_SWITCH = "useObjectParameters";
     private static final String USE_OBJECT_PARAMS_DESC = "Use aggregate parameter objects as function arguments for api operations instead of passing each parameter as a separate function argument.";
 
+    public static final String USE_ERASABLE_SYNTAX = "useErasableSyntax";
+    public static final String USE_ERASABLE_SYNTAX_DESC = "Use erasable syntax for the generated code. This is a temporary feature and will be removed in the future.";
+
     private final Map<String, String> frameworkToHttpLibMap;
 
     // NPM Options
@@ -122,6 +125,7 @@ public class TypeScriptClientCodegen extends AbstractTypeScriptClientCodegen imp
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_OBJECT_PARAMS_SWITCH, TypeScriptClientCodegen.USE_OBJECT_PARAMS_DESC).defaultValue("false"));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_INVERSIFY_SWITCH, TypeScriptClientCodegen.USE_INVERSIFY_SWITCH_DESC).defaultValue("false"));
         cliOptions.add(new CliOption(TypeScriptClientCodegen.IMPORT_FILE_EXTENSION_SWITCH, TypeScriptClientCodegen.IMPORT_FILE_EXTENSION_SWITCH_DESC));
+        cliOptions.add(new CliOption(TypeScriptClientCodegen.USE_ERASABLE_SYNTAX, TypeScriptClientCodegen.USE_ERASABLE_SYNTAX_DESC).defaultValue("false"));
 
         CliOption frameworkOption = new CliOption(TypeScriptClientCodegen.FRAMEWORK_SWITCH, TypeScriptClientCodegen.FRAMEWORK_SWITCH_DESC);
         for (String option : TypeScriptClientCodegen.FRAMEWORKS) {

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/servers.mustache
@@ -5,7 +5,20 @@
  *
  */
 export class ServerConfiguration<T extends { [key: string]: string }> {
+    {{^useErasableSyntax}}
     public constructor(private url: string, private variableConfiguration: T, private description: string) {}
+    {{/useErasableSyntax}}
+    {{#useErasableSyntax}}
+    private url: string;
+    private variableConfiguration: T;
+    private description: string;
+
+    public constructor(url: string, variableConfiguration: T, description: string) {
+        this.url = url;
+        this.variableConfiguration = variableConfiguration;
+        this.description = description;
+    }
+    {{/useErasableSyntax}}
 
     /**
      * Sets the value of the variables of this server.
@@ -25,15 +38,15 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     /**
-     * Constructions the URL this server using the url with variables
-     * replaced with their respective values
+     * Constructs the URL for this server using the url with variables
+     * replaced with their respective values.
      */
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-                 const re = new RegExp("{" + key + "}","g");
-                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+                const re = new RegExp("{" + key + "}", "g");
+                replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
             }
         }
         return replacedUrl;

--- a/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/baseapi.mustache
@@ -26,8 +26,16 @@ export const COLLECTION_FORMATS = {
 {{/useInversify}}
 export class BaseAPIRequestFactory {
 
+    {{^useErasableSyntax}}
     constructor({{#useInversify}}@inject(AbstractConfiguration) {{/useInversify}}protected configuration: Configuration) {
     }
+    {{/useErasableSyntax}}
+    {{#useErasableSyntax}}
+    protected configuration: Configuration;
+    constructor({{#useInversify}}@inject(AbstractConfiguration) {{/useInversify}} config: Configuration) {
+        this.configuration = config;
+    }
+    {{/useErasableSyntax}}
 };
 
 /**
@@ -38,7 +46,20 @@ export class BaseAPIRequestFactory {
  */
 export class RequiredError extends Error {
     override name: "RequiredError" = "RequiredError";
+    {{#useErasableSyntax}}
+    public api: string;
+    public method: string;
+    public field: string;
+    constructor(api: string, method: string, field: string) {
+        super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
+        this.api = api;
+        this.method = method;
+        this.field = field;
+    }
+    {{/useErasableSyntax}}
+    {{^useErasableSyntax}}
     constructor(public api: string, public method: string, public field: string) {
         super("Required parameter " + field + " was null or undefined when calling " + api + "." + method + ".");
     }
+    {{/useErasableSyntax}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript/api/exception.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/exception.mustache
@@ -8,8 +8,22 @@
  *
  */
 export class ApiException<T> extends Error {
+    {{#useErasableSyntax}}
+    public code: number;
+    public body: T;
+    public headers: { [key: string]: string; };
+    public constructor(code: number, message: string, body: T, headers: { [key: string]: string; }) {
+        super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
+        JSON.stringify(headers));
+        this.code = code;
+        this.body = body;
+        this.headers = headers;
+    }
+    {{/useErasableSyntax}}
+    {{^useErasableSyntax}}
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
+    {{/useErasableSyntax}}
 }

--- a/modules/openapi-generator/src/main/resources/typescript/api/middleware.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/middleware.mustache
@@ -26,10 +26,15 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
+    {{#useErasableSyntax}}
+    private middleware: PromiseMiddleware;
+    public constructor(middleware: PromiseMiddleware) {
+        this.middleware = middleware;
     }
+    {{/useErasableSyntax}}
+    {{^useErasableSyntax}}
+    public constructor(private middleware: PromiseMiddleware) {}
+    {{/useErasableSyntax}}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +43,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/auth/auth.mustache
@@ -40,14 +40,28 @@ export interface TokenProvider {
 {{/useInversify}}
 export class {{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication implements SecurityAuthentication {
     {{#isApiKey}}
+    {{^useErasableSyntax}}
     /**
      * Configures this api key authentication with the necessary properties
      *
      * @param apiKey: The api key to be used for every request
      */
     public constructor({{#useInversify}}@inject(AuthApiKey) @named("{{name}}") {{/useInversify}}private apiKey: string) {}
+    {{/useErasableSyntax}}
+    {{#useErasableSyntax}}
+    private apiKey: string;
+    /**
+     * Configures this api key authentication with the necessary properties
+     *
+     * @param apiKey: The api key to be used for every request
+     */
+    public constructor({{#useInversify}}@inject(AuthApiKey) @named("{{name}}") {{/useInversify}}apiKey: string) {
+        this.apiKey = apiKey;
+    }
+    {{/useErasableSyntax}}
     {{/isApiKey}}
     {{#isBasicBasic}}
+    {{^useErasableSyntax}}
     /**
      * Configures the http authentication with the required details.
      *
@@ -58,22 +72,66 @@ export class {{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication 
         {{#useInversify}}@inject(AuthUsername) @named("{{name}}") {{/useInversify}}private username: string,
         {{#useInversify}}@inject(AuthPassword) @named("{{name}}") {{/useInversify}}private password: string
     ) {}
+    {{/useErasableSyntax}}
+    {{#useErasableSyntax}}
+    private username: string;
+    private password: string;
+    /**
+     * Configures the http authentication with the required details.
+     *
+     * @param username username for http basic authentication
+     * @param password password for http basic authentication
+     */
+    public constructor(
+        {{#useInversify}}@inject(AuthUsername) @named("{{name}}") {{/useInversify}}username: string,
+        {{#useInversify}}@inject(AuthPassword) @named("{{name}}") {{/useInversify}}password: string
+    ) {
+        this.username = username;
+        this.password = password;
+    }
+    {{/useErasableSyntax}}
     {{/isBasicBasic}}
     {{#isBasicBearer}}
+    {{^useErasableSyntax}}
     /**
      * Configures the http authentication with the required details.
      *
      * @param tokenProvider service that can provide the up-to-date token when needed
      */
     public constructor({{#useInversify}}@inject(AbstractTokenProvider) @named("{{name}}") {{/useInversify}}private tokenProvider: TokenProvider) {}
+    {{/useErasableSyntax}}
+    {{#useErasableSyntax}}
+    private tokenProvider: TokenProvider;
+    /**
+     * Configures the http authentication with the required details.
+     *
+     * @param tokenProvider service that can provide the up-to-date token when needed
+     */
+    public constructor({{#useInversify}}@inject(AbstractTokenProvider) @named("{{name}}") {{/useInversify}}tokenProvider: TokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+    {{/useErasableSyntax}}
     {{/isBasicBearer}}
     {{#isOAuth}}
+    {{^useErasableSyntax}}
     /**
      * Configures OAuth2 with the necessary properties
      *
      * @param accessToken: The access token to be used for every request
      */
     public constructor(private accessToken: string) {}
+    {{/useErasableSyntax}}
+    {{#useErasableSyntax}}
+    private accessToken: string;
+    /**
+     * Configures OAuth2 with the necessary properties
+     *
+     * @param accessToken: The access token to be used for every request
+     */
+    public constructor(accessToken: string) {
+        this.accessToken = accessToken;
+    }
+    {{/useErasableSyntax}}
     {{/isOAuth}}
 
     public getName(): string {
@@ -98,7 +156,6 @@ export class {{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication 
 }
 
 {{/authMethods}}
-
 export type AuthMethods = {
     {{^useInversify}}
     "default"?: SecurityAuthentication,

--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -25,6 +25,22 @@ export * from './jquery{{importFileExtension}}';
 /**
  * Represents an HTTP method.
  */
+{{#useErasableSyntax}}
+export const HttpMethod = {
+    GET: "GET",
+    HEAD: "HEAD",
+    POST: "POST",
+    PUT: "PUT",
+    DELETE: "DELETE",
+    CONNECT: "CONNECT",
+    OPTIONS: "OPTIONS",
+    TRACE: "TRACE",
+    PATCH: "PATCH"
+} as const;
+
+export type HttpMethod = typeof HttpMethod[keyof typeof HttpMethod];
+{{/useErasableSyntax}}
+{{^useErasableSyntax}}
 export enum HttpMethod {
     GET = "GET",
     HEAD = "HEAD",
@@ -36,6 +52,7 @@ export enum HttpMethod {
     TRACE = "TRACE",
     PATCH = "PATCH"
 }
+{{/useErasableSyntax}}
 
 /**
  * Represents an HTTP file which will be transferred from or to a server.

--- a/modules/openapi-generator/src/main/resources/typescript/rxjsStub.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/rxjsStub.mustache
@@ -1,5 +1,13 @@
 export class Observable<T> {
+  {{#useErasableSyntax}}
+  private promise: Promise<T>;
+  constructor(promise: Promise<T>) {
+    this.promise = promise;
+  }
+  {{/useErasableSyntax}}
+  {{^useErasableSyntax}}
   constructor(private promise: Promise<T>) {}
+  {{/useErasableSyntax}}
 
   toPromise() {
     return this.promise;

--- a/samples/client/echo_api/typescript/build/apis/exception.ts
+++ b/samples/client/echo_api/typescript/build/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/client/echo_api/typescript/build/auth/auth.ts
+++ b/samples/client/echo_api/typescript/build/auth/auth.ts
@@ -66,7 +66,6 @@ export class HttpBearerAuthAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "http_auth"?: SecurityAuthentication,

--- a/samples/client/echo_api/typescript/build/middleware.ts
+++ b/samples/client/echo_api/typescript/build/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/client/others/typescript-rxjs/allOf-composition/servers.ts
+++ b/samples/client/others/typescript-rxjs/allOf-composition/servers.ts
@@ -25,15 +25,15 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     /**
-     * Constructions the URL this server using the url with variables
-     * replaced with their respective values
+     * Constructs the URL for this server using the url with variables
+     * replaced with their respective values.
      */
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-                 const re = new RegExp("{" + key + "}","g");
-                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+                const re = new RegExp("{" + key + "}", "g");
+                replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
             }
         }
         return replacedUrl;

--- a/samples/client/others/typescript/builds/array-of-lists/apis/exception.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/client/others/typescript/builds/array-of-lists/auth/auth.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/client/others/typescript/builds/array-of-lists/middleware.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/client/others/typescript/builds/enum-single-value/apis/exception.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/client/others/typescript/builds/enum-single-value/auth/auth.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/client/others/typescript/builds/enum-single-value/middleware.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/client/others/typescript/builds/null-types-simple/apis/exception.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/client/others/typescript/builds/null-types-simple/auth/auth.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/client/others/typescript/builds/null-types-simple/middleware.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/client/others/typescript/builds/with-unique-items/apis/exception.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/client/others/typescript/builds/with-unique-items/auth/auth.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/client/others/typescript/builds/with-unique-items/middleware.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/client/others/typescript/encode-decode/build/apis/exception.ts
+++ b/samples/client/others/typescript/encode-decode/build/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/client/others/typescript/encode-decode/build/auth/auth.ts
+++ b/samples/client/others/typescript/encode-decode/build/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/client/others/typescript/encode-decode/build/middleware.ts
+++ b/samples/client/others/typescript/encode-decode/build/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/client/petstore/typescript-rxjs/builds/default/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/default/servers.ts
@@ -25,15 +25,15 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     /**
-     * Constructions the URL this server using the url with variables
-     * replaced with their respective values
+     * Constructs the URL for this server using the url with variables
+     * replaced with their respective values.
      */
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-                 const re = new RegExp("{" + key + "}","g");
-                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+                const re = new RegExp("{" + key + "}", "g");
+                replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
             }
         }
         return replacedUrl;

--- a/samples/client/petstore/typescript-rxjs/builds/es6-target/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/es6-target/servers.ts
@@ -25,15 +25,15 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     /**
-     * Constructions the URL this server using the url with variables
-     * replaced with their respective values
+     * Constructs the URL for this server using the url with variables
+     * replaced with their respective values.
      */
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-                 const re = new RegExp("{" + key + "}","g");
-                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+                const re = new RegExp("{" + key + "}", "g");
+                replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
             }
         }
         return replacedUrl;

--- a/samples/client/petstore/typescript-rxjs/builds/with-npm-version/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-npm-version/servers.ts
@@ -25,15 +25,15 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     /**
-     * Constructions the URL this server using the url with variables
-     * replaced with their respective values
+     * Constructs the URL for this server using the url with variables
+     * replaced with their respective values.
      */
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-                 const re = new RegExp("{" + key + "}","g");
-                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+                const re = new RegExp("{" + key + "}", "g");
+                replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
             }
         }
         return replacedUrl;

--- a/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/servers.ts
+++ b/samples/client/petstore/typescript-rxjs/builds/with-progress-subscriber/servers.ts
@@ -25,15 +25,15 @@ export class ServerConfiguration<T extends { [key: string]: string }> {
     }
 
     /**
-     * Constructions the URL this server using the url with variables
-     * replaced with their respective values
+     * Constructs the URL for this server using the url with variables
+     * replaced with their respective values.
      */
     public getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
             if (this.variableConfiguration.hasOwnProperty(key)) {
-                 const re = new RegExp("{" + key + "}","g");
-                 replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
+                const re = new RegExp("{" + key + "}", "g");
+                replacedUrl = replacedUrl.replace(re, this.variableConfiguration[key]);
             }
         }
         return replacedUrl;

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/auth/auth.ts
@@ -61,7 +61,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/browser/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/auth/auth.ts
@@ -61,7 +61,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/default/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/auth/auth.ts
@@ -61,7 +61,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/deno/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/auth/auth.ts
@@ -61,7 +61,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/auth/auth.ts
@@ -139,7 +139,6 @@ export class HttpSignatureTestAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/auth/auth.ts
@@ -69,7 +69,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "petstore_auth"?: SecurityAuthentication,
     "api_key"?: SecurityAuthentication

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/auth/auth.ts
@@ -61,7 +61,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/auth/auth.ts
@@ -21,7 +21,6 @@ export interface TokenProvider {
   getToken(): Promise<string> | string;
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
 }

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/exception.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/exception.ts
@@ -10,6 +10,6 @@
 export class ApiException<T> extends Error {
     public constructor(public code: number, message: string, public body: T, public headers: { [key: string]: string; }) {
         super("HTTP-Code: " + code + "\nMessage: " + message + "\nBody: " + JSON.stringify(body) + "\nHeaders: " +
-        JSON.stringify(headers))
+        JSON.stringify(headers));
     }
 }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/auth/auth.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/auth/auth.ts
@@ -61,7 +61,6 @@ export class ApiKeyAuthentication implements SecurityAuthentication {
     }
 }
 
-
 export type AuthMethods = {
     "default"?: SecurityAuthentication,
     "petstore_auth"?: SecurityAuthentication,

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/middleware.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/middleware.ts
@@ -26,10 +26,7 @@ export interface Middleware {
 }
 
 export class PromiseMiddlewareWrapper implements Middleware {
-
-    public constructor(private middleware: PromiseMiddleware) {
-
-    }
+    public constructor(private middleware: PromiseMiddleware) {}
 
     pre(context: RequestContext): Observable<RequestContext> {
         return from(this.middleware.pre(context));
@@ -38,7 +35,6 @@ export class PromiseMiddlewareWrapper implements Middleware {
     post(context: ResponseContext): Observable<ResponseContext> {
         return from(this.middleware.post(context));
     }
-
 }
 
 /**


### PR DESCRIPTION
Typescript 5.8 added a new flag that optionally removes support for non-erasable syntax. This facilitates running Typescript directly in node 22 without transpiling. This PR adds a new configuration option to the Typescript generator to generate code that complies with erasable syntax only. It is off by default.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)