### PR TITLE
[JAVA][FEIGN] Removing hardcoded HTTP Client which is causing performance issues

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -9,12 +9,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 {{#jackson}}
-{{#feign-okhttp}}
-import feign.okhttp.OkHttpClient;
-{{/feign-okhttp}}
-{{#feign-hc5}}
-import feign.hc5.ApacheHttp5Client;
-{{/feign-hc5}}
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -76,12 +70,6 @@ public class ApiClient {
     {{#jackson}}
     objectMapper = createObjectMapper();
     feignBuilder = Feign.builder()
-                {{#feign-okhttp}}
-                .client(new OkHttpClient())
-                {{/feign-okhttp}}
-                {{#feign-hc5}}
-                .client(new ApacheHttp5Client())
-                {{/feign-hc5}}
                 .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
                 .decoder(new ApiResponseDecoder(objectMapper))
                 {{#hasOAuthMethods}}

--- a/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/ApiClient.java
@@ -19,7 +19,6 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import feign.hc5.ApacheHttp5Client;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -60,7 +59,6 @@ public class ApiClient {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
     objectMapper = createObjectMapper();
     feignBuilder = Feign.builder()
-                .client(new ApacheHttp5Client())
                 .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
                 .decoder(new ApiResponseDecoder(objectMapper))
                 .errorDecoder(new ApiErrorDecoder())

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
@@ -19,7 +19,6 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import feign.okhttp.OkHttpClient;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -59,7 +58,6 @@ public class ApiClient {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
     objectMapper = createObjectMapper();
     feignBuilder = Feign.builder()
-                .client(new OkHttpClient())
                 .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
                 .decoder(new ApiResponseDecoder(objectMapper))
                 .errorDecoder(new ApiErrorDecoder())

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
@@ -19,7 +19,6 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import feign.okhttp.OkHttpClient;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -60,7 +59,6 @@ public class ApiClient {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
     objectMapper = createObjectMapper();
     feignBuilder = Feign.builder()
-                .client(new OkHttpClient())
                 .encoder(new FormEncoder(new JacksonEncoder(objectMapper)))
                 .decoder(new ApiResponseDecoder(objectMapper))
                 .errorDecoder(new ApiErrorDecoder())


### PR DESCRIPTION
Fixing performance issues due to Hardcoded HTTP client

1. Breaking change was introduced [here](https://github.com/OpenAPITools/openapi-generator/commit/a7a59378137cb1ce70d785f422251928df009846#diff-86e0b144aa0784ea6cccf92ec027a7b82407ee0cd823044b82396f7ffe08db92R55). (Somehow, the PR got merged despite a review comment suggested to revert the same in 2023 for a different reason)
2. This is causing performance issues as new tcp connection is created for each new request which is caught in performance tests.
3. Lot of TCP connections are created which in turn results in exceeded CPU utilisation and eventually timeout errors as all the resources are exhausted. For example, below image shows the number of TCP connections opened by my application which is using feign client to be 64. For 64 requests, it should have been able to reuse the 1 connection with connection pooling instead of creating 64 connections.
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/cd1210d8-9e90-4e41-89c8-cfcc6da1714d" />


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
