### PR TITLE
Fix NULL pointer dereference vulnerability in cJSON_InsertItemInArray (CVE-2023-50471)

### DIFF
--- a/samples/client/others/c/bearerAuth/external/cJSON.c
+++ b/samples/client/others/c/bearerAuth/external/cJSON.c
@@ -2138,20 +2138,24 @@ CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const 
 }
 
 /* Replace array/object items with new ones. */
-CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
 {
     cJSON *after_inserted = NULL;
 
+    if ((array == NULL) || (newitem == NULL))
+    {
+        return false;
+    }
+
     if (which < 0)
     {
-        return;
+        return false;
     }
 
     after_inserted = get_array_item(array, (size_t)which);
     if (after_inserted == NULL)
     {
-        add_item_to_array(array, newitem);
-        return;
+        return add_item_to_array(array, newitem);
     }
 
     newitem->next = after_inserted;
@@ -2165,6 +2169,7 @@ CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newit
     {
         newitem->prev->next = newitem;
     }
+    return true;
 }
 
 CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)


### PR DESCRIPTION
**Description:**
This PR adds NULL checks for the array and newitem parameters in the cJSON_InsertItemInArray function to prevent NULL pointer dereferences. This addresses the same vulnerability as CVE-2023-50471 which was fixed in the original cJSON repository.

**References:**
Original fix: https://github.com/DaveGamble/cJSON/commit/60ff122ef5862d04b39b150541459e7f5e35add8
CVE-2023-50471: https://nvd.nist.gov/vuln/detail/CVE-2023-50471