### PR TITLE
Jaxrs cxf client support swagger v3

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaCXFClientCodegen.java
@@ -47,6 +47,8 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
 
     public static final String USE_ABSTRACTION_FOR_FILES = "useAbstractionForFiles";
 
+	public static final String OAS3 = "oas3";
+	
     @Getter protected boolean useGenericResponse = false;
 
     @Getter protected boolean useGzipFeatureForTests = false;
@@ -54,6 +56,8 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
     @Getter protected boolean useLoggingFeatureForTests = false;
 
     @Setter protected boolean useAbstractionForFiles = false;
+    
+    @Setter protected boolean oas3 = false;
 
     public JavaCXFClientCodegen() {
         super();
@@ -93,6 +97,7 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_LOGGING_FEATURE_FOR_TESTS, "Use Logging Feature for tests"));
         cliOptions.add(CliOption.newBoolean(USE_GENERIC_RESPONSE, "Use generic response"));
         cliOptions.add(CliOption.newBoolean(USE_ABSTRACTION_FOR_FILES, "Use alternative types instead of java.io.File to allow passing bytes without a file on disk."));
+        cliOptions.add(CliOption.newBoolean(OAS3, "Generate Swagger annotations in version 3 instead of version 2."));
     }
 
     @Override
@@ -103,6 +108,7 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         convertPropertyToBooleanAndWriteBack(USE_LOGGING_FEATURE_FOR_TESTS, this::setUseLoggingFeatureForTests);
         convertPropertyToBooleanAndWriteBack(JACKSON, this::setJackson);
         convertPropertyToBooleanAndWriteBack(USE_ABSTRACTION_FOR_FILES, this::setUseAbstractionForFiles);
+        convertPropertyToBooleanAndWriteBack(OAS3, this::setOas3);
 
         supportingFiles.clear(); // Don't need extra files provided by AbstractJAX-RS & Java Codegen
 
@@ -132,6 +138,13 @@ public class JavaCXFClientCodegen extends AbstractJavaCodegen
         super.postProcessModelProperty(model, property);
         model.imports.remove("ApiModelProperty");
         model.imports.remove("ApiModel");
+        
+        if (oas3) {
+            apiTemplateFiles.remove("api.mustache");
+            importMapping.remove("ApiModelProperty");
+            importMapping.remove("ApiModel");
+            apiTemplateFiles.put("api_oas3.mustache", ".java");
+        }
 
         if (jackson) {
             //Add jackson imports when model has inner enum

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_oas3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_oas3.mustache
@@ -1,0 +1,76 @@
+package {{package}};
+
+{{#imports}}import {{import}};
+{{/imports}}
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import {{javaxPackage}}.ws.rs.*;
+import {{javaxPackage}}.ws.rs.core.Response;
+import {{javaxPackage}}.ws.rs.core.MediaType;
+import org.apache.cxf.jaxrs.ext.multipart.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+{{/useBeanValidation}}
+
+{{#appName}}
+/**
+ * {{{appName}}}
+ *
+ {{#appDescription}}
+ * <p>{{{.}}}
+ *
+ {{/appDescription}}
+ */
+{{/appName}}
+@Path("{{#useAnnotatedBasePath}}{{contextPath}}{{/useAnnotatedBasePath}}{{commonPath}}")
+{{#addConsumesProducesJson}}
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+{{/addConsumesProducesJson}}
+public interface {{classname}}  {
+{{#operations}}
+{{#operation}}
+
+    {{#summary}}
+    /**
+     * {{summary}}
+     *
+     {{#notes}}
+     * {{.}}
+     *
+     {{/notes}}
+     */
+    {{/summary}}
+    @{{httpMethod}}
+    {{#subresourceOperation}}@Path("{{{path}}}"){{/subresourceOperation}}
+{{#hasConsumes}}
+    @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} })
+{{/hasConsumes}}
+{{#hasProduces}}
+    @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} })
+{{/hasProduces}}
+    @Operation(summary = "{{{summary}}}", tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-tags}} })
+    {{#implicitHeadersParams.0}}
+    @io.swagger.annotations.ApiImplicitParams({
+        {{#implicitHeadersParams}}
+        @io.swagger.annotations.ApiImplicitParam(name = "{{{baseName}}}", value = "{{{description}}}", {{#required}}required = true,{{/required}} dataType = "{{{dataType}}}", paramType = "header"){{^-last}},{{/-last}}
+        {{/implicitHeadersParams}}
+    })
+    {{/implicitHeadersParams.0}}
+    @ApiResponses(value = { {{#responses}}
+        @ApiResponse(responseCode = "{{{code}}}", description = "{{{message}}}", content = @Content(mediaType = {{#content}}{{#entrySet}}"{{{key}}}"{{/entrySet}}{{/content}}{{^content}}"*/*"{{/content}}, {{#containerType}}array = @ArraySchema({{/containerType}}schema = @Schema(implementation = {{#isFile}}{{#useAbstractionForFiles}}InputStream{{/useAbstractionForFiles}}{{^useAbstractionForFiles}}{{{baseType}}}{{/useAbstractionForFiles}}{{/isFile}}{{^isFile}}{{{baseType}}}{{/isFile}}.class){{#containerType}}){{/containerType}})){{^-last}},{{/-last}}{{/responses}} })
+    public {{>returnTypes}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}});
+{{/operation}}
+}
+{{/operations}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_oas3.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/api_oas3.mustache
@@ -13,6 +13,9 @@ import {{javaxPackage}}.ws.rs.core.MediaType;
 import org.apache.cxf.jaxrs.ext.multipart.*;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -62,9 +65,9 @@ public interface {{classname}}  {
 {{/hasProduces}}
     @Operation(summary = "{{{summary}}}", tags={ {{#vendorExtensions.x-tags}}"{{tag}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-tags}} })
     {{#implicitHeadersParams.0}}
-    @io.swagger.annotations.ApiImplicitParams({
+    @Parameters({
         {{#implicitHeadersParams}}
-        @io.swagger.annotations.ApiImplicitParam(name = "{{{baseName}}}", value = "{{{description}}}", {{#required}}required = true,{{/required}} dataType = "{{{dataType}}}", paramType = "header"){{^-last}},{{/-last}}
+        @Parameter(name = "{{{baseName}}}", description = "{{{description}}}", {{#required}}required = true,{{/required}} in = ParameterIn.HEADER, content = @Content(schema = @Schema(type = "{{{dataType}}}"))){{^-last}},{{/-last}}
         {{/implicitHeadersParams}}
     })
     {{/implicitHeadersParams.0}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pojo.mustache
@@ -1,4 +1,9 @@
+{{#oas3}}
+import io.swagger.v3.oas.annotations.media.Schema;
+{{/oas3}}
+{{^oas3}}
 import io.swagger.annotations.ApiModelProperty;
+{{/oas3}}
 import java.util.Objects;
 {{#withXml}}
 import {{javaxPackage}}.xml.bind.annotation.XmlElement;
@@ -13,9 +18,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 {{#description}}
 /**
-  * {{{description}}}
+  * {{{.}}}
  **/
-@ApiModel(description="{{{description}}}")
+ {{^oas3}}@ApiModel(description="{{{.}}}"){{/oas3}}
 {{/description}}
 {{>additionalModelTypeAnnotations}}{{>xmlPojoAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 {{#vendorExtensions.x-class-extra-annotation}}
@@ -28,8 +33,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
 {{#withXml}}
   @XmlElement(name="{{baseName}}"{{#required}}, required = {{required}}{{/required}})
 {{/withXml}}
-  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{^isPrimitiveType}}{{^isDate}}{{^isDateTime}}{{^isString}}{{^isFile}}{{#useBeanValidation}}
-  @Valid{{/useBeanValidation}}{{/isFile}}{{/isString}}{{/isDateTime}}{{/isDate}}{{/isPrimitiveType}}
+{{#oas3}}
+  @Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}description = "{{{description}}}")
+{{/oas3}}
+{{^oas3}}
+  @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{/oas3}}
+  {{^isPrimitiveType}}{{^isDate}}{{^isDateTime}}{{^isString}}{{^isFile}}{{#useBeanValidation}}@Valid{{/useBeanValidation}}{{/isFile}}{{/isString}}{{/isDateTime}}{{/isDate}}{{/isPrimitiveType}}
 {{#description}}
  /**
    * {{{.}}}

--- a/modules/openapi-generator/src/test/resources/3_1/java/issue_19907.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/java/issue_19907.yaml
@@ -1,0 +1,112 @@
+openapi: 3.1.0
+servers:
+  - url: 'http://petstore.swagger.io/v2'
+info:
+  description: >-
+    This is a sample server Petstore server. For this sample, you can use the api key
+    `special-key` to test the authorization filters.
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+components:
+  schemas:
+    Tag:
+      title: Pet Tag
+      description: A tag for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/Tag'
+        tagsDefaultList:
+          type: array
+          default: []
+          items:
+            $ref: '#/components/schemas/Tag'
+        tagsUnique:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        tagsDefaultSet:
+          type: array
+          default: [ ]
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        stringList:
+          type: array
+          items:
+            type: string
+        stringDefaultList:
+          type: array
+          default:
+            - A
+            - B
+          items:
+            type: string
+        stringEmptyDefaultList:
+          type: array
+          default: []
+          items:
+            type: string
+        stringSet:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        stringDefaultSet:
+          type: array
+          uniqueItems: true
+          default:
+            - A
+            - B
+          items:
+            type: string
+        stringEmptyDefaultSet:
+          type: array
+          uniqueItems: true
+          default: []
+          items:
+            type: string
+


### PR DESCRIPTION
When generating Java 17 / jakarta compatible Code with the jaxrs-cxf-client generator the swagger2 annotations are a not compatible, because they contain `javax` imports. I added an optional flag to generate those oas3 Annotations. To maintain the mustache api files better, i created a new one and switch to it, when the flag is set.

fix #19907 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
