### PR TITLE
[fix][Java] Added missing cli option to enable Jackson annotation

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/it/jaxrs-cxf-client-issue5077/invoker.properties
+++ b/modules/openapi-generator-maven-plugin/src/it/jaxrs-cxf-client-issue5077/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals = -nsu clean generate-sources
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/modules/openapi-generator-maven-plugin/src/it/jaxrs-cxf-client-issue5077/pom.xml
+++ b/modules/openapi-generator-maven-plugin/src/it/jaxrs-cxf-client-issue5077/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openapitools.maven.its</groupId>
+    <artifactId>jaxrs-cxf-client-issue5077</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <inputSpec>https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml</inputSpec>
+                    <generatorName>jaxrs-cxf-client</generatorName>
+                    <dateLibrary>java8</dateLibrary>
+                    <output>${basedir}/out</output>
+                    <configOptions>
+                        <jackson>true</jackson>
+                    </configOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>remote</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/modules/openapi-generator-maven-plugin/src/it/jaxrs-cxf-client-issue5077/verify.groovy
+++ b/modules/openapi-generator-maven-plugin/src/it/jaxrs-cxf-client-issue5077/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+File mavenPomXml = new File(basedir, "out/pom.xml")
+assert mavenPomXml.isFile()
+
+File petModel = new File(basedir, "out/src/gen/java/org/openapitools/model/Pet.java")
+assert petModel.isFile()
+assert petModel.text.contains("import com.fasterxml.jackson.annotation.JsonCreator;")
+assert petModel.text.contains("import com.fasterxml.jackson.annotation.JsonValue;")
+assert petModel.text.contains("@JsonCreator")
+assert petModel.text.contains("@JsonValue")

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -317,6 +317,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         cliOptions.add(CliOption.newBoolean(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC, this.isHideGenerationTimestamp()));
         cliOptions.add(CliOption.newBoolean(WITH_XML, "whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)"));
         cliOptions.add(CliOption.newBoolean(USE_ONE_OF_INTERFACES, "whether to use a java interface to describe a set of oneOf options, where each option is a class that implements the interface"));
+        cliOptions.add(CliOption.newBoolean(JACKSON, "Enable Jackson annotation as serialization library."));
 
         CliOption dateLibrary = new CliOption(DATE_LIBRARY, "Option. Date library to use").defaultValue(this.getDateLibrary());
         Map<String, String> dateOptions = new HashMap<>();


### PR DESCRIPTION
The option "jackson" is used in most java generators and it seems to be "true" per default except in the jaxrs-cxf-client generator. This option could not be set in the config-options of a maven-plugin, because it was not be added to the cli-options. 
This was not be covered by junit tests, as they set this option in the generator. I added an integration test for that purpose.

fix #5077 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
