### PR TITLE
fix: Support PathParams not of primitive types for Go in generated tests

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_test.mustache
@@ -36,7 +36,12 @@ func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 		t.Skip("skip test")  // remove to run test
 
 		{{/-first}}
+        {{#isPrimitiveType}}
 		var {{paramName}} {{{dataType}}}
+		{{/isPrimitiveType}}
+		{{^isPrimitiveType}}
+		var {{paramName}} {{goImportAlias}}.{{{dataType}}}
+		{{/isPrimitiveType}}
 		{{/pathParams}}
 
 		{{#returnType}}resp, {{/returnType}}httpRes, err := apiClient.{{classname}}.{{operationId}}(context.Background(){{#pathParams}}, {{paramName}}{{/pathParams}}).Execute()

--- a/modules/openapi-generator/src/main/resources/go/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api_test.mustache
@@ -36,7 +36,7 @@ func Test_{{packageName}}_{{classname}}Service(t *testing.T) {
 		t.Skip("skip test")  // remove to run test
 
 		{{/-first}}
-        {{#isPrimitiveType}}
+		{{#isPrimitiveType}}
 		var {{paramName}} {{{dataType}}}
 		{{/isPrimitiveType}}
 		{{^isPrimitiveType}}


### PR DESCRIPTION
This is a PR to address #21106.

FYI @antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
