### PR TITLE
[feat][elixir] support bearer authentication

### DIFF
--- a/docs/generators/elixir.md
+++ b/docs/generators/elixir.md
@@ -189,7 +189,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |BasicAuth|✓|OAS2,OAS3
 |ApiKey|✗|OAS2,OAS3
 |OpenIDConnect|✗|OAS3
-|BearerToken|✗|OAS3
+|BearerToken|✓|OAS3
 |OAuth2_Implicit|✓|OAS2,OAS3
 |OAuth2_Password|✗|OAS2,OAS3
 |OAuth2_ClientCredentials|✗|OAS2,OAS3

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -71,7 +71,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
                 .includeDocumentationFeatures(DocumentationFeature.Readme)
                 .securityFeatures(EnumSet.of(
                         SecurityFeature.OAuth2_Implicit,
-                        SecurityFeature.BasicAuth))
+                        SecurityFeature.BasicAuth,
+                        SecurityFeature.BearerToken))
                 .excludeGlobalFeatures(
                         GlobalFeature.XMLStructureDefinitions,
                         GlobalFeature.Callbacks,

--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -52,6 +52,9 @@ defmodule {{moduleName}}.Connection do
   - `username`: A username for basic authentication.
   - `password`: A password for basic authentication.
   {{/hasHttpBasicMethods}}
+  {{#hasHttpBearerMethods}}
+  - `bearer_token`: A bearer token for bearer authentication.
+  {{/hasHttpBearerMethods}}
   """
   @type options :: [
           {:base_url, String.t()},
@@ -64,6 +67,9 @@ defmodule {{moduleName}}.Connection do
           {:username, String.t() | nil},
           {:password, String.t() | nil},
   {{/hasHttpBasicMethods}}
+  {{#hasHttpBearerMethods}}
+          {:bearer_token, String.t() | nil},
+  {{/hasHttpBearerMethods}}
         ]
 
   @doc "Forward requests to Tesla."
@@ -239,6 +245,11 @@ defmodule {{moduleName}}.Connection do
         middleware
       end
     {{/hasHttpBasicMethods}}
+
+    {{#hasHttpBearerMethods}}
+    bearer_token = Keyword.get(options, :bearer_token)
+    middleware = [{Tesla.Middleware.BearerAuth, token: bearer_token} | middleware]
+    {{/hasHttpBearerMethods}}
 
     {{#hasOAuthMethods}}
     middleware =

--- a/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
@@ -46,6 +46,7 @@ defmodule OpenapiPetstore.Connection do
     fetcher function.
   - `username`: A username for basic authentication.
   - `password`: A password for basic authentication.
+  - `bearer_token`: A bearer token for bearer authentication.
   """
   @type options :: [
           {:base_url, String.t()},
@@ -54,6 +55,7 @@ defmodule OpenapiPetstore.Connection do
           {:token_scopes, list(String.t())},
           {:username, String.t() | nil},
           {:password, String.t() | nil},
+          {:bearer_token, String.t() | nil},
         ]
 
   @doc "Forward requests to Tesla."
@@ -174,6 +176,9 @@ defmodule OpenapiPetstore.Connection do
       else
         middleware
       end
+
+    bearer_token = Keyword.get(options, :bearer_token)
+    middleware = [{Tesla.Middleware.BearerAuth, token: bearer_token} | middleware]
 
     middleware =
       if token = Keyword.get(options, :token) do


### PR DESCRIPTION
### Description

This `PR` adds support for [Bearer Authentication ](https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/)to the Elixir generator.

Bearer Authentication is implemented using [Tesla's BearerAuth middleware](https://hexdocs.pm/tesla/Tesla.Middleware.BearerAuth.html).

@mrmstn, @wing328 - Curious to hear your thoughts on this one too! 🙂

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
