### PR TITLE
[doc][elixir] remove hard-coded refs to openapipetstore

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -96,7 +96,7 @@ defmodule {{moduleName}}.Connection do
     of the function call, will be set as a bearer token in the
     `authorization` header.
   {{/hasOAuthMethods}}
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 
@@ -133,7 +133,7 @@ defmodule {{moduleName}}.Connection do
     that returns a bearer token.
   - `scopes_or_password`: a list of Strings represenging OAuth2 scopes, or
     a single string that is the password for the username provided.
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 
@@ -155,7 +155,7 @@ defmodule {{moduleName}}.Connection do
     of the function call, will be set as a bearer token in the
     `authorization` header.
   - `scopes`: a list of Strings represenging OAuth2 scopes.
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
@@ -84,7 +84,7 @@ defmodule OpenapiPetstore.Connection do
   - `token`: a String or a function of arity one. This value, or the result
     of the function call, will be set as a bearer token in the
     `authorization` header.
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of OpenapiPetstore.Connection.options.
 
   ### Returns
 
@@ -112,7 +112,7 @@ defmodule OpenapiPetstore.Connection do
     that returns a bearer token.
   - `scopes_or_password`: a list of Strings represenging OAuth2 scopes, or
     a single string that is the password for the username provided.
-  - `options`: a keyword list of OpenAPIPetstore.Connection.options.
+  - `options`: a keyword list of OpenapiPetstore.Connection.options.
 
   ### Returns
 


### PR DESCRIPTION
### Description

Generated documentation in the `Connection` module includes hard-coded references to the sample `OpenAPIPetstore` application.

This `PR` includes a fix to replace these hard-coded references by dynamic references to the generated module.

@mrmstn, @wing328 - This should be an easy one. As usual, curious to hear your thoughts 😊

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
