### PR TITLE
[Spring]Added support for composed annotations (@GetMapping,@PostMapping,@PutMapping,@DeleteMapping).

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -419,6 +419,7 @@ public class DefaultCodegen implements CodegenConfig {
                 .put("forwardslash", new ForwardSlashLambda())
                 .put("backslash", new BackSlashLambda())
                 .put("doublequote", new DoubleQuoteLambda())
+                .put("composedannotationlambda", new ComposedRequestMappingAnnotationLambda())
                 .put("indented", new IndentedLambda())
                 .put("indented_8", new IndentedLambda(8, " ", false, false))
                 .put("indented_12", new IndentedLambda(12, " ", false, false))

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java
@@ -98,6 +98,8 @@ public class SpringCodegen extends AbstractJavaCodegen
     public static final String USE_SEALED = "useSealed";
     public static final String OPTIONAL_ACCEPT_NULLABLE = "optionalAcceptNullable";
     public static final String USE_SPRING_BUILT_IN_VALIDATION = "useSpringBuiltInValidation";
+    public static final String USE_API_COMPOSED_ANNOTATION = "useApiComposedAnnotation";
+    public static final String API_COMPOSED_ANNOTATION_LAMBDA = "apiComposedAnnotationLambda";
 
     @Getter
     public enum RequestMappingMode {
@@ -157,6 +159,8 @@ public class SpringCodegen extends AbstractJavaCodegen
     protected boolean optionalAcceptNullable = true;
     @Getter @Setter
     protected boolean useSpringBuiltInValidation = false;
+    @Getter @Setter
+    protected boolean useApiComposedAnnotation = false;
 
     public SpringCodegen() {
         super();
@@ -224,6 +228,9 @@ public class SpringCodegen extends AbstractJavaCodegen
         cliOptions.add(CliOption.newBoolean(USE_SPRING_BUILT_IN_VALIDATION,
                 "Disable `@Validated` at the class level when using built-in validation.",
                 useSpringBuiltInValidation));
+        cliOptions.add(CliOption.newBoolean(USE_API_COMPOSED_ANNOTATION,
+                "Use @<method>Mapping instead of @RequestMapping(method = RequestMethod.<method>) when generating the API interfaces.",
+                useApiComposedAnnotation));
         cliOptions.add(CliOption.newBoolean(PERFORM_BEANVALIDATION,
                 "Use Bean Validation Impl. to perform BeanValidation", performBeanValidation));
         cliOptions.add(CliOption.newBoolean(USE_SEALED,
@@ -435,6 +442,7 @@ public class SpringCodegen extends AbstractJavaCodegen
         convertPropertyToBooleanAndWriteBack(USE_RESPONSE_ENTITY, this::setUseResponseEntity);
         convertPropertyToBooleanAndWriteBack(OPTIONAL_ACCEPT_NULLABLE, this::setOptionalAcceptNullable);
         convertPropertyToBooleanAndWriteBack(USE_SPRING_BUILT_IN_VALIDATION, this::setUseSpringBuiltInValidation);
+        convertPropertyToBooleanAndWriteBack(USE_API_COMPOSED_ANNOTATION, this::setUseApiComposedAnnotation);
 
         additionalProperties.put("springHttpStatus", new SpringHttpStatusLambda());
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/ComposedRequestMappingAnnotationLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/ComposedRequestMappingAnnotationLambda.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Replaces @RequestMapping annotation with the appropriate composed annotation when using <strong>Spring generator</strong>. e.g:
+ * <p><code>@RequestMapping(method = RequestMethod.GET</code>
+ * will be replaced with:<code>@GetMapping(</code> as it is defined on the file JavaSpring/api.mustache under
+ * the {{#useApiComposedAnnotation}} section</p>
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("composedannotationlambda", new ComposedRequestMappingAnnotationLambda());
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#lambda.composedannotationlambda}}{{httpMethod}}{{/lambda.composedannotationlambda}}
+ * </pre>
+ */
+public class ComposedRequestMappingAnnotationLambda implements Mustache.Lambda {
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+            String text = fragment.execute();
+            writer.write(String.format("@%sMapping(",text.substring(0,1).toUpperCase()+text.substring(1).toLowerCase()));
+    }
+}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -226,8 +226,15 @@ public interface {{classname}} {
     })
     {{/swagger1AnnotationLibrary}}
     {{/implicitHeadersParams.0}}
+    {{#useApiComposedAnnotation}}
+    {{#lambda.composedannotationlambda}}{{httpMethod}}{{/lambda.composedannotationlambda}}
+    {{/useApiComposedAnnotation}}
+    {{^useApiComposedAnnotation}}
     @RequestMapping(
+    {{/useApiComposedAnnotation}}
+        {{^useApiComposedAnnotation}}
         method = RequestMethod.{{httpMethod}},
+        {{/useApiComposedAnnotation}}
         value = "{{{path}}}"{{#singleContentTypes}}{{#hasProduces}},
         produces = { {{#vendorExtensions.x-accepts}}"{{{.}}}"{{^-last}}, {{/-last}}{{/vendorExtensions.x-accepts}} }{{/hasProduces}}{{#hasConsumes}},
         consumes = "{{{vendorExtensions.x-content-type}}}"{{/hasConsumes}}{{/singleContentTypes}}{{^singleContentTypes}}{{#hasProduces}},

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5434,6 +5434,104 @@ public class SpringCodegenTest {
     }
 
     @Test
+    public void shouldUseApiComposedAnnotationWhenSetToTrue() throws IOException {
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.additionalProperties().put(USE_API_COMPOSED_ANNOTATION, true);
+
+        Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/petstore.yaml");
+        var file = files.get("UserApi.java");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("getUserByName")
+                .assertMethodAnnotations()
+                .containsWithName("GetMapping")
+                .doesNotContainWithName("RequestMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("createUser")
+                .assertMethodAnnotations()
+                .containsWithName("PostMapping")
+                .doesNotContainWithName("RequestMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("updateUser")
+                .assertMethodAnnotations()
+                .containsWithName("PutMapping")
+                .doesNotContainWithName("RequestMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("deleteUser")
+                .assertMethodAnnotations()
+                .containsWithName("DeleteMapping")
+                .doesNotContainWithName("RequestMapping");
+    }
+
+    @Test
+    public void shouldNotUseApiComposedAnnotationWhenSetToFalse() throws IOException {
+        final SpringCodegen codegen = new SpringCodegen();
+        codegen.additionalProperties().put(USE_API_COMPOSED_ANNOTATION, false);
+
+        Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/petstore.yaml");
+        var file = files.get("UserApi.java");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("getUserByName")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("GetMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("createUser")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("PostMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("updateUser")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("PutMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("deleteUser")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("DeleteMapping");
+    }
+
+    @Test
+    public void shouldNotUseApiComposedAnnotationByDefault() throws IOException {
+        final SpringCodegen codegen = new SpringCodegen();
+
+        Map<String, File> files = generateFiles(codegen, "src/test/resources/3_0/petstore.yaml");
+        var file = files.get("UserApi.java");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("getUserByName")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("GetMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("createUser")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("PostMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("updateUser")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("PutMapping");
+
+        JavaFileAssert.assertThat(file)
+                .assertMethod("deleteUser")
+                .assertMethodAnnotations()
+                .containsWithName("RequestMapping")
+                .doesNotContainWithName("DeleteMapping");
+    }
+
+    @Test
     public void testEnumFieldShouldBeFinal_issue21018() throws IOException {
         SpringCodegen codegen = new SpringCodegen();
         codegen.setLibrary(SPRING_BOOT);


### PR DESCRIPTION
I have noticed that when using the Spring generator, the API interface file would contain @RequestMapping(method = RequestMethod.<METHOD>) annotation. This would isn't exactly an issue but would be a code smell under sonar coding rule java:s4488 https://sonarsource.github.io/rspec/#/rspec/S4488. I tried to search for an existing way to change it but could not find it. So I went ahead and added the support myself.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
