### PR TITLE
fix: [csharp] JsonConverter anyOf creates uncompilable code

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/JsonConverter.mustache
@@ -284,6 +284,7 @@
             {{^vendorExtensions.x-duplicated-data-type}}
             {{#model.discriminator}}
             {{#model.hasDiscriminatorWithNonEmptyMapping}}
+            {{^model.composedSchemas.anyOf}}
             {{#mappedModels}}
             if ({{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}} != null)
                 return new {{classname}}({{#lambda.joinWithComma}}{{#lambda.camelcase_sanitize_param}}{{model.classname}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{#model.composedSchemas.anyOf}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#vendorExtensions.x-is-value-type}}{{^isNullable}}.Value{{/isNullable}}{{/vendorExtensions.x-is-value-type}}  {{/model.composedSchemas.anyOf}}{{#allVars}}{{^isDiscriminator}}{{#lambda.camelcase_sanitize_param}}{{name}}{{/lambda.camelcase_sanitize_param}}{{#required}}.Value{{nrt!}}{{^isNullable}}{{#vendorExtensions.x-is-value-type}}.Value{{/vendorExtensions.x-is-value-type}}{{/isNullable}}{{/required}}  {{/isDiscriminator}}{{/allVars}}{{/lambda.joinWithComma}});
@@ -292,6 +293,7 @@
             throw new JsonException();
             {{/-last}}
             {{/mappedModels}}
+            {{/model.composedSchemas.anyOf}}
             {{/model.hasDiscriminatorWithNonEmptyMapping}}
             {{/model.discriminator}}
             {{^composedSchemas.oneOf}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.TestUtils.assertFileNotContains;
 
 public class CSharpClientCodegenTest {
 
@@ -180,5 +181,34 @@ public class CSharpClientCodegenTest {
             assertNotNull(file, "Could not find file for model: " + modelName);
             assertFileContains(file.toPath(), expectedContent);
         }
+    }
+
+    @Test
+    public void testAnyOfDiscriminatorCreatesCompilableCode() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec(
+            "src/test/resources/3_0/anyOfDiscriminatorSimple.yaml");
+        final DefaultGenerator defaultGenerator = new DefaultGenerator();
+        final ClientOptInput clientOptInput = new ClientOptInput();
+        clientOptInput.openAPI(openAPI);
+        CSharpClientCodegen cSharpClientCodegen = new CSharpClientCodegen();
+        cSharpClientCodegen.setLibrary("generichost");
+        cSharpClientCodegen.setOutputDir(output.getAbsolutePath());
+        cSharpClientCodegen.setAutosetConstants(true);
+        clientOptInput.config(cSharpClientCodegen);
+        defaultGenerator.opts(clientOptInput);
+
+        Map<String, File> files = defaultGenerator.generate().stream()
+            .collect(Collectors.toMap(File::getPath, Function.identity()));
+
+        String modelName = "FruitAnyOfDisc";
+        File file = files.get(Paths
+            .get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Model", modelName + ".cs")
+            .toString()
+        );
+        assertNotNull(file, "Could not find file for model: " + modelName);
+        // Should not contain this as the constructor will have two parameters instead of one
+        assertFileNotContains(file.toPath(), "return new FruitAnyOfDisc(appleAnyOfDisc);");
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/anyOfDiscriminatorSimple.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/anyOfDiscriminatorSimple.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+   title: fruity
+   version: 0.0.1
+paths:
+   /:
+      get:
+         responses:
+            '200':
+               description: desc
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/FruitAnyOfDisc'
+components:
+   schemas:
+    FruitAnyOfDisc:
+      anyOf:
+        - $ref: '#/components/schemas/AppleAnyOfDisc'
+        - $ref: '#/components/schemas/BananaAnyOfDisc'
+      discriminator:
+        propertyName: fruitType
+    AppleAnyOfDisc:
+      type: object
+      required:
+        - fruitType
+      properties:
+        fruitType:
+          type: string
+    BananaAnyOfDisc:
+      type: object
+      required:
+        - fruitType
+      properties:
+        fruitType:
+          type: string


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Using an anyOf with a discriminator creates uncompilable code with cshapr generichost. The issue is that the generated code tries to call a constructor with only one parameter, but the constructor will have multiple parameters.

Steps to reproduce:
```sh
# create openapi spec
cat << 'EOF' > modules/openapi-generator/src/test/resources/3_0/anyOfDiscriminatorSimple.yaml
openapi: 3.0.1
info:
   title: fruity
   version: 0.0.1
paths:
   /:
      get:
         responses:
            '200':
               description: desc
               content:
                  application/json:
                     schema:
                        $ref: '#/components/schemas/FruitAnyOfDisc'
components:
   schemas:
    FruitAnyOfDisc:
      anyOf:
        - $ref: '#/components/schemas/AppleAnyOfDisc'
        - $ref: '#/components/schemas/BananaAnyOfDisc'
      discriminator:
        propertyName: fruitType
    AppleAnyOfDisc:
      type: object
      required:
        - fruitType
      properties:
        fruitType:
          type: string
    BananaAnyOfDisc:
      type: object
      required:
        - fruitType
      properties:
        fruitType:
          type: string
EOF
# Generate csharp code
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g csharp -i modules/openapi-generator/src/test/resources/3_0/anyOfDiscriminatorSimple.yaml -o test
# Build csharp code
dotnet build test
```
Output:
```
❯ dotnet build test
Restore complete (0.4s)
  Org.OpenAPITools failed with 2 error(s) and 1 warning(s) (0.3s)
    /home/david/git/openapi-generator/test/src/Org.OpenAPITools/Model/FruitAnyOfDisc.cs(192,28): error CS7036: There is no argument given that corresponds to the required parameter 'bananaAnyOfDisc' of 'FruitAnyOfDisc.FruitAnyOfDisc(Option<AppleAnyOfDisc?>, Option<BananaAnyOfDisc?>)'
    /home/david/git/openapi-generator/test/src/Org.OpenAPITools/Model/FruitAnyOfDisc.cs(195,28): error CS7036: There is no argument given that corresponds to the required parameter 'bananaAnyOfDisc' of 'FruitAnyOfDisc.FruitAnyOfDisc(Option<AppleAnyOfDisc?>, Option<BananaAnyOfDisc?>)'
    /home/david/git/openapi-generator/test/src/Org.OpenAPITools/Model/FruitAnyOfDisc.cs(198,13): warning CS0162: Unreachable code detected

Build failed with 2 error(s) and 1 warning(s) in 0.8s
```

@mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
