### PR TITLE
[kotlin-client][jvm-spring-webclient] Fix metrics URI templating for WebClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/infrastructure/ApiClient.kt.mustache
@@ -10,8 +10,6 @@ import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
-private val URI_TEMPLATE_ATTRIBUTE = WebClient::class.java.name + ".uriTemplate";
-
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class ApiClient(protected val client: WebClient) {
 
     protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): Mono<ResponseEntity<T>> {
@@ -40,10 +38,8 @@ private val URI_TEMPLATE_ATTRIBUTE = WebClient::class.java.name + ".uriTemplate"
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
-        uri { builder ->
-            attribute(URI_TEMPLATE_ATTRIBUTE, requestConfig.path)
+        uri(requestConfig.path) { builder ->
             builder
-                .path(requestConfig.path)
                 .queryParams(LinkedMultiValueMap(requestConfig.query))
                 .build(requestConfig.params)
         }
@@ -55,6 +51,7 @@ private val URI_TEMPLATE_ATTRIBUTE = WebClient::class.java.name + ".uriTemplate"
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val builder = MultipartBodyBuilder()
+                @Suppress("UNCHECKED_CAST")
                 (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
                     if (part.body != null) {
                         val partBuilder = builder.part(name, part.body)

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,8 +10,6 @@ import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
-private val URI_TEMPLATE_ATTRIBUTE = WebClient::class.java.name + ".uriTemplate";
-
 open class ApiClient(protected val client: WebClient) {
 
     protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): Mono<ResponseEntity<T>> {
@@ -40,10 +38,8 @@ open class ApiClient(protected val client: WebClient) {
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
-        uri { builder ->
-            attribute(URI_TEMPLATE_ATTRIBUTE, requestConfig.path)
+        uri(requestConfig.path) { builder ->
             builder
-                .path(requestConfig.path)
                 .queryParams(LinkedMultiValueMap(requestConfig.query))
                 .build(requestConfig.params)
         }
@@ -55,6 +51,7 @@ open class ApiClient(protected val client: WebClient) {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val builder = MultipartBodyBuilder()
+                @Suppress("UNCHECKED_CAST")
                 (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
                     if (part.body != null) {
                         val partBuilder = builder.part(name, part.body)

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,8 +10,6 @@ import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
-private val URI_TEMPLATE_ATTRIBUTE = WebClient::class.java.name + ".uriTemplate";
-
 open class ApiClient(protected val client: WebClient) {
 
     protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): Mono<ResponseEntity<T>> {
@@ -40,10 +38,8 @@ open class ApiClient(protected val client: WebClient) {
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
-        uri { builder ->
-            attribute(URI_TEMPLATE_ATTRIBUTE, requestConfig.path)
+        uri(requestConfig.path) { builder ->
             builder
-                .path(requestConfig.path)
                 .queryParams(LinkedMultiValueMap(requestConfig.query))
                 .build(requestConfig.params)
         }
@@ -55,6 +51,7 @@ open class ApiClient(protected val client: WebClient) {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val builder = MultipartBodyBuilder()
+                @Suppress("UNCHECKED_CAST")
                 (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
                     if (part.body != null) {
                         val partBuilder = builder.part(name, part.body)

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -10,8 +10,6 @@ import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
-private val URI_TEMPLATE_ATTRIBUTE = WebClient::class.java.name + ".uriTemplate";
-
 open class ApiClient(protected val client: WebClient) {
 
     protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): Mono<ResponseEntity<T>> {
@@ -40,10 +38,8 @@ open class ApiClient(protected val client: WebClient) {
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
-        uri { builder ->
-            attribute(URI_TEMPLATE_ATTRIBUTE, requestConfig.path)
+        uri(requestConfig.path) { builder ->
             builder
-                .path(requestConfig.path)
                 .queryParams(LinkedMultiValueMap(requestConfig.query))
                 .build(requestConfig.params)
         }
@@ -55,6 +51,7 @@ open class ApiClient(protected val client: WebClient) {
         when {
             requestConfig.headers[HttpHeaders.CONTENT_TYPE] == MediaType.MULTIPART_FORM_DATA_VALUE -> {
                 val builder = MultipartBodyBuilder()
+                @Suppress("UNCHECKED_CAST")
                 (requestConfig.body as Map<String, PartConfig<*>>).forEach { (name, part) ->
                     if (part.body != null) {
                         val partBuilder = builder.part(name, part.body)


### PR DESCRIPTION
Fixes #16923

Spring configures the uriTemplate attribute and not generated openapi code. It also leverages Spring's uriBuilderFactory to correctly set the template.

Also, the commit removes a compile warning.

Kotlin technical committee:
@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
