### PR TITLE
[fix][elixir] simplify connection module

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/connection.ex.mustache
@@ -77,136 +77,22 @@ defmodule {{moduleName}}.Connection do
   defdelegate request(client, options), to: Tesla
 
   @doc """
-  Configure a client with no authentication.
-
-  ### Returns
-
-  Tesla.Env.client
-  """
-  @spec new() :: Tesla.Env.client()
-  def new do
-    Tesla.client(middleware(), adapter())
-  end
-
-  @doc """
-  Configure a client that may have authentication.
+  Configure a {{moduleName}} client.
 
   ### Parameters
 
-  {{#hasOAuthMethods}}
-  The first parameter *may* be a `token` (a string, a token fetcher class,
-  or a module/function tuple) or a keyword list of `options`. They are
-  documented separately, but only *one* of them will be passed.
-
-  - `token`: a String or a function of arity one. This value, or the result
-    of the function call, will be set as a bearer token in the
-    `authorization` header.
-  {{/hasOAuthMethods}}
-  - `options`: a keyword list of {{moduleName}}.Connection.options.
+  - `options`: an optional keyword list of {{moduleName}}.Connection.options.
 
   ### Returns
 
   Tesla.Env.client
   """
-  {{#hasOAuthMethods}}
-  @spec new(String.t() | token_fetcher | options) :: Tesla.Env.client()
-  {{/hasOAuthMethods}}
-  {{^hasOAuthMethods}}
   @spec new(options) :: Tesla.Env.client()
-  {{/hasOAuthMethods}}
-  {{#hasOAuthMethods}}
-  def new(token) when is_binary(token) or is_function(token, 1) or is_tuple(token) do
-    new(token: token)
-  end
-  {{/hasOAuthMethods}}
-
-  def new(options) when is_list(options) do
+  def new(options \\ []) do
     options
     |> middleware()
     |> Tesla.client(adapter())
   end
-
-  {{#hasOAuthMethods}}
-  {{#hasHttpBasicMethods}}
-  @doc """
-  Configure a client using bearer authentication with scopes, or with
-  username and password for basic authentication.
-
-  ### Parameters
-
-  - `token_or_username`: a String representing a bearer token or a username,
-    depending on the type of the next parameter, or a function arity one
-    that returns a bearer token.
-  - `scopes_or_password`: a list of Strings represenging OAuth2 scopes, or
-    a single string that is the password for the username provided.
-  - `options`: a keyword list of {{moduleName}}.Connection.options.
-
-  ### Returns
-
-  Tesla.Env.client
-  """
-  @spec new(
-          token_or_username :: String.t() | token_fetcher,
-          scopes_or_password :: list(String.t()) | String.t(),
-          options
-        ) :: Tesla.Env.client()
-  {{/hasHttpBasicMethods}}
-  {{^hasHttpBasicMethods}}
-  @doc """
-  Configure a client using bearer authentication with scopes.
-
-  ### Parameters
-
-  - `token`: a String or a function of arity one. This value, or the result
-    of the function call, will be set as a bearer token in the
-    `authorization` header.
-  - `scopes`: a list of Strings represenging OAuth2 scopes.
-  - `options`: a keyword list of {{moduleName}}.Connection.options.
-
-  ### Returns
-
-  Tesla.Env.client
-  """
-  @spec new(String.t() | token_fetcher, list(String.t()), options) :: Tesla.Env.client()
-  {{/hasHttpBasicMethods}}
-  {{/hasOAuthMethods}}
-  {{^hasOAuthMethods}}
-  {{#hasHttpBasicMethods}}
-  @doc """
-  Configure a client using username and password for basic authentication.
-
-  ### Parameters
-
-  - `username`: a String representing a username.
-  - `password`: a String representing a password.
-  - `options`: a keyword list of {{moduleName}}.Connection.options.
-
-  ### Returns
-
-  Tesla.Env.client
-  """
-  @spec new(String.t(), String.t()), options) :: Tesla.Env.client()
-  {{/hasHttpBasicMethods}}
-  {{/hasOAuthMethods}}
-
-  {{#hasOAuthMethods}}
-  def new(token_or_username, scopes_or_password, options \\ [])
-
-  def new(token, scopes, options)
-      when (is_binary(token) or is_function(token, 1) or is_tuple(token)) and is_list(scopes) do
-    options
-    |> Keyword.merge(token: token, token_scopes: scopes)
-    |> new()
-  end
-  {{/hasOAuthMethods}}
-
-  {{#hasHttpBasicMethods}}
-  def new(username, password, options) when is_binary(username) and is_binary(password) do
-    options
-    |> Keyword.merge(username: username, password: password)
-    |> new()
-  end
-  {{/hasHttpBasicMethods}}
 
   @doc """
   Returns fully configured middleware for passing to Tesla.client/2.

--- a/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/connection.ex
@@ -63,82 +63,21 @@ defmodule OpenapiPetstore.Connection do
   defdelegate request(client, options), to: Tesla
 
   @doc """
-  Configure a client with no authentication.
-
-  ### Returns
-
-  Tesla.Env.client
-  """
-  @spec new() :: Tesla.Env.client()
-  def new do
-    Tesla.client(middleware(), adapter())
-  end
-
-  @doc """
-  Configure a client that may have authentication.
+  Configure a OpenapiPetstore client.
 
   ### Parameters
 
-  The first parameter *may* be a `token` (a string, a token fetcher class,
-  or a module/function tuple) or a keyword list of `options`. They are
-  documented separately, but only *one* of them will be passed.
-
-  - `token`: a String or a function of arity one. This value, or the result
-    of the function call, will be set as a bearer token in the
-    `authorization` header.
-  - `options`: a keyword list of OpenapiPetstore.Connection.options.
+  - `options`: an optional keyword list of OpenapiPetstore.Connection.options.
 
   ### Returns
 
   Tesla.Env.client
   """
-  @spec new(String.t() | token_fetcher | options) :: Tesla.Env.client()
-  def new(token) when is_binary(token) or is_function(token, 1) or is_tuple(token) do
-    new(token: token)
-  end
-
-  def new(options) when is_list(options) do
+  @spec new(options) :: Tesla.Env.client()
+  def new(options \\ []) do
     options
     |> middleware()
     |> Tesla.client(adapter())
-  end
-
-  @doc """
-  Configure a client using bearer authentication with scopes, or with
-  username and password for basic authentication.
-
-  ### Parameters
-
-  - `token_or_username`: a String representing a bearer token or a username,
-    depending on the type of the next parameter, or a function arity one
-    that returns a bearer token.
-  - `scopes_or_password`: a list of Strings represenging OAuth2 scopes, or
-    a single string that is the password for the username provided.
-  - `options`: a keyword list of OpenapiPetstore.Connection.options.
-
-  ### Returns
-
-  Tesla.Env.client
-  """
-  @spec new(
-          token_or_username :: String.t() | token_fetcher,
-          scopes_or_password :: list(String.t()) | String.t(),
-          options
-        ) :: Tesla.Env.client()
-
-  def new(token_or_username, scopes_or_password, options \\ [])
-
-  def new(token, scopes, options)
-      when (is_binary(token) or is_function(token, 1) or is_tuple(token)) and is_list(scopes) do
-    options
-    |> Keyword.merge(token: token, token_scopes: scopes)
-    |> new()
-  end
-
-  def new(username, password, options) when is_binary(username) and is_binary(password) do
-    options
-    |> Keyword.merge(username: username, password: password)
-    |> new()
   end
 
   @doc """


### PR DESCRIPTION
### Description

This PR simplifies the generated `Connection` module according to the discussion [here](https://github.com/OpenAPITools/openapi-generator/pull/21110#issuecomment-2816781119). The new approach is more idiomatic and improves the maintainability of the generator.

Additionally, it resolves the issue reported in #20562 by removing the problematic function specification from the generated code. The issue can be reproduced using Stripe's OpenAPI specification, available [here](https://raw.githubusercontent.com/stripe/openapi/refs/tags/v1719/openapi/spec3.json).

```
== Compilation error in file lib/connection.ex ==
** (MismatchedDelimiterError) mismatched delimiter found on lib/connection.ex:92:45:
    error: unexpected token: )
    │
  4 │ defmodule Stripe.Connection do
    │                             └ unclosed delimiter
 ...
 92 │   @spec new(String.t(), String.t()), options) :: Tesla.Env.client()
    │                                             └ mismatched closing delimiter (expected "end")
    │
    └─ lib/connection.ex:92:45
    (elixir 1.18.3) lib/kernel/parallel_compiler.ex:428: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/8
```

With these changes, #15075 becomes unnecessary.

I considered targeting the `8.0.x` branch, but since the Elixir generator is still in alpha and this change also fixes a known issue, I believe it makes more sense to target `master` directly. What do you think?

As usual, curious to hear your thoughts @mrmstn and @wing328 😊

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
