### PR TITLE
feat(typescript-angular): add util "provideApi" and update docs to standalone applications

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -176,20 +176,6 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     @Override
     public void processOpts() {
         super.processOpts();
-        supportingFiles.add(
-                new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
-        supportingFiles
-                .add(new SupportingFile("apis.mustache", apiPackage().replace('.', File.separatorChar), "api.ts"));
-        supportingFiles.add(new SupportingFile("index.mustache", getIndexDirectory(), "index.ts"));
-        supportingFiles.add(new SupportingFile("api.module.mustache", getIndexDirectory(), "api.module.ts"));
-        supportingFiles.add(new SupportingFile("configuration.mustache", getIndexDirectory(), "configuration.ts"));
-        supportingFiles.add(new SupportingFile("api.base.service.mustache", getIndexDirectory(), "api.base.service.ts"));
-        supportingFiles.add(new SupportingFile("variables.mustache", getIndexDirectory(), "variables.ts"));
-        supportingFiles.add(new SupportingFile("encoder.mustache", getIndexDirectory(), "encoder.ts"));
-        supportingFiles.add(new SupportingFile("param.mustache", getIndexDirectory(), "param.ts"));
-        supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
-        supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
-        supportingFiles.add(new SupportingFile("README.mustache", getIndexDirectory(), "README.md"));
 
         // determine NG version
         SemVer ngVersion;
@@ -200,6 +186,25 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
             LOGGER.info("generating code for Angular {} ...", ngVersion);
             LOGGER.info("  (you can select the angular version by setting the additionalProperties (--additional-properties in CLI) ngVersion)");
         }
+        boolean ngVersionAtLeast_17 = ngVersion.atLeast("17.0.0");
+
+        supportingFiles.add(
+                new SupportingFile("models.mustache", modelPackage().replace('.', File.separatorChar), "models.ts"));
+        supportingFiles
+                .add(new SupportingFile("apis.mustache", apiPackage().replace('.', File.separatorChar), "api.ts"));
+        supportingFiles.add(new SupportingFile("index.mustache", getIndexDirectory(), "index.ts"));
+        supportingFiles.add(new SupportingFile("api.module.mustache", getIndexDirectory(), "api.module.ts"));
+        if (ngVersionAtLeast_17) {
+            supportingFiles.add(new SupportingFile("provide-api.mustache", getIndexDirectory(), "provide-api.ts"));
+        }
+        supportingFiles.add(new SupportingFile("configuration.mustache", getIndexDirectory(), "configuration.ts"));
+        supportingFiles.add(new SupportingFile("api.base.service.mustache", getIndexDirectory(), "api.base.service.ts"));
+        supportingFiles.add(new SupportingFile("variables.mustache", getIndexDirectory(), "variables.ts"));
+        supportingFiles.add(new SupportingFile("encoder.mustache", getIndexDirectory(), "encoder.ts"));
+        supportingFiles.add(new SupportingFile("param.mustache", getIndexDirectory(), "param.ts"));
+        supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
+        supportingFiles.add(new SupportingFile("git_push.sh.mustache", "", "git_push.sh"));
+        supportingFiles.add(new SupportingFile("README.mustache", getIndexDirectory(), "README.md"));
 
         if (!ngVersion.atLeast("9.0.0")) {
             throw new IllegalArgumentException("Invalid ngVersion: " + ngVersion + ". Only Angular v9+ is supported.");
@@ -250,6 +255,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         }
 
         additionalProperties.put(NG_VERSION, ngVersion);
+        additionalProperties.put("ngVersionAtLeast_17", ngVersionAtLeast_17);
 
         if (additionalProperties.containsKey(API_MODULE_PREFIX)) {
             String apiModulePrefix = additionalProperties.get(API_MODULE_PREFIX).toString();

--- a/modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
@@ -61,7 +61,7 @@ In your Angular project:
 
 import { ApplicationConfig } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideApi } from 'sample-angular-19-0-0';
+import { provideApi } from '{{npmName}}';
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -72,12 +72,18 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
+**NOTE**
+If you're still using `AppModule` and haven't [migrated](https://angular.dev/reference/migrations/standalone) yet, you can still import an Angular module:
+```typescript
+import { {{apiModuleClassName}} } from '{{npmName}}';
+```
+
 If different from the generated base path, during app bootstrap, you can provide the base path to your service.
 
 ```typescript
 import { ApplicationConfig } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideApi } from 'sample-angular-19-0-0';
+import { provideApi } from '{{npmName}}';
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -92,7 +98,7 @@ export const appConfig: ApplicationConfig = {
 // with a custom configuration
 import { ApplicationConfig } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideApi } from 'sample-angular-19-0-0';
+import { provideApi } from '{{npmName}}';
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -111,7 +117,7 @@ export const appConfig: ApplicationConfig = {
 // with factory building a custom configuration
 import { ApplicationConfig } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
-import { provideApi, {{configurationClassName}} } from 'sample-angular-19-0-0';
+import { provideApi, {{configurationClassName}} } from '{{npmName}}';
 
 export const appConfig: ApplicationConfig = {
     providers: [

--- a/modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/README.mustache
@@ -58,157 +58,100 @@ Published packages are not effected by this issue.
 In your Angular project:
 
 ```typescript
-// without configuring providers
-import { {{apiModuleClassName}} } from '{{npmName}}';
-import { HttpClientModule } from '@angular/common/http';
 
-@NgModule({
-    imports: [
-        {{apiModuleClassName}},
-        // make sure to import the HttpClientModule in the AppModule only,
-        // see https://github.com/angular/angular/issues/20575
-        HttpClientModule
-    ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0';
 
-```typescript
-// configuring providers
-import { {{apiModuleClassName}}, {{configurationClassName}}, {{configurationParametersInterfaceName}} } from '{{npmName}}';
-
-export function apiConfigFactory (): {{configurationClassName}} {
-  const params: {{configurationParametersInterfaceName}} = {
-    // set configuration parameters here.
-  }
-  return new {{configurationClassName}}(params);
-}
-
-@NgModule({
-    imports: [ {{apiModuleClassName}}.forRoot(apiConfigFactory) ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-```typescript
-// configuring providers with an authentication service that manages your access tokens
-import { {{apiModuleClassName}}, {{configurationClassName}} } from '{{npmName}}';
-
-@NgModule({
-    imports: [ {{apiModuleClassName}} ],
-    declarations: [ AppComponent ],
+export const appConfig: ApplicationConfig = {
     providers: [
-      {
-        provide: {{configurationClassName}},
-        useFactory: (authService: AuthService) => new {{configurationClassName}}(
-          {
-            basePath: environment.apiUrl,
-            accessToken: authService.getAccessToken.bind(authService)
-          }
-        ),
-        deps: [AuthService],
-        multi: false
-      }
+        // ...
+        provideHttpClient(),
+        provideApi()
     ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
+};
+```
+
+If different from the generated base path, during app bootstrap, you can provide the base path to your service.
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi('http://localhost:9999')
+    ],
+};
 ```
 
 ```typescript
-import { DefaultApi } from '{{npmName}}';
+// with a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0';
 
-export class AppComponent {
-    constructor(private apiGateway: DefaultApi) { }
-}
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi({
+            withCredentials: true,
+            username: 'user',
+            password: 'password'
+        })
+    ],
+};
 ```
 
-Note: The {{apiModuleClassName}} is restricted to being instantiated once app wide.
-This is to ensure that all services are treated as singletons.
+```typescript
+// with factory building a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi, {{configurationClassName}} } from 'sample-angular-19-0-0';
 
-### Using multiple OpenAPI files / APIs / {{apiModuleClassName}}s
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        {
+            provide: {{configurationClassName}},
+            useFactory: (authService: AuthService) => new {{configurationClassName}}({
+                    basePath: 'http://localhost:9999',
+                    withCredentials: true,
+                    username: authService.getUsername(),
+                    password: authService.getPassword(),
+            }),
+            deps: [AuthService],
+            multi: false
+        }
+    ],
+};
+```
 
-In order to use multiple `{{apiModuleClassName}}s` generated from different OpenAPI files,
+### Using multiple OpenAPI files / APIs
+
+In order to use multiple APIs generated from different OpenAPI files,
 you can create an alias name when importing the modules
 in order to avoid naming conflicts:
 
 ```typescript
-import { {{apiModuleClassName}} } from 'my-api-path';
-import { {{apiModuleClassName}} as OtherApiModule } from 'my-other-api-path';
+import { provideApi as provideUserApi } from 'my-user-api-path';
+import { provideApi as provideAdminApi } from 'my-admin-api-path';
 import { HttpClientModule } from '@angular/common/http';
-
-@NgModule({
-  imports: [
-    {{apiModuleClassName}},
-    OtherApiModule,
-    // make sure to import the HttpClientModule in the AppModule only,
-    // see https://github.com/angular/angular/issues/20575
-    HttpClientModule
-  ]
-})
-export class AppModule {
-
-}
-```
-
-### Set service base path
-
-If different than the generated base path, during app bootstrap, you can provide the base path to your service.
-
-```typescript
-import { BASE_PATH } from '{{npmName}}';
-
-bootstrap(AppComponent, [
-    { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
-]);
-```
-
-or
-
-```typescript
-import { BASE_PATH } from '{{npmName}}';
-
-@NgModule({
-    imports: [],
-    declarations: [ AppComponent ],
-    providers: [ provide: BASE_PATH, useValue: 'https://your-web-service.com' ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-### Using @angular/cli
-
-First extend your `src/environments/*.ts` files by adding the corresponding base path:
-
-```typescript
-export const environment = {
-  production: false,
-  API_BASE_PATH: 'http://127.0.0.1:8080'
-};
-```
-
-In the src/app/app.module.ts:
-
-```typescript
-import { BASE_PATH } from '{{npmName}}';
 import { environment } from '../environments/environment';
 
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [ ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
-  bootstrap: [ AppComponent ]
-})
-export class AppModule { }
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideUserApi(environment.basePath),
+        provideAdminApi(environment.basePath),
+    ],
+};
 ```
 
 ### Customizing path parameter encoding

--- a/modules/openapi-generator/src/main/resources/typescript-angular/index.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/index.mustache
@@ -5,4 +5,7 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+{{#ngVersionAtLeast_17}}
+export * from './provide-api';
+{{/ngVersionAtLeast_17}}
 export * from './param';

--- a/modules/openapi-generator/src/main/resources/typescript-angular/provide-api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/provide-api.mustache
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { {{configurationClassName}}, {{configurationParametersInterfaceName}} } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | {{configurationParametersInterfaceName}}) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: {{configurationClassName}},
+                useValue: new {{configurationClassName}}({ ...configOrBasePath }),
+            },
+    ]);
+}

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/.openapi-generator/FILES
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/.openapi-generator/FILES
@@ -21,4 +21,5 @@ model/petWithMappedDiscriminator.ts
 model/petWithSimpleDiscriminator.ts
 model/petWithoutDiscriminator.ts
 param.ts
+provide-api.ts
 variables.ts

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/index.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/index.ts
@@ -3,4 +3,5 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+export * from './provide-api';
 export * from './param';

--- a/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/provide-api.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas-tagged-unions/provide-api.ts
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { Configuration, ConfigurationParameters } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | ConfigurationParameters) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: Configuration,
+                useValue: new Configuration({ ...configOrBasePath }),
+            },
+    ]);
+}

--- a/samples/client/others/typescript-angular/builds/composed-schemas/.openapi-generator/FILES
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/.openapi-generator/FILES
@@ -21,4 +21,5 @@ model/petWithMappedDiscriminator.ts
 model/petWithSimpleDiscriminator.ts
 model/petWithoutDiscriminator.ts
 param.ts
+provide-api.ts
 variables.ts

--- a/samples/client/others/typescript-angular/builds/composed-schemas/index.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/index.ts
@@ -3,4 +3,5 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+export * from './provide-api';
 export * from './param';

--- a/samples/client/others/typescript-angular/builds/composed-schemas/provide-api.ts
+++ b/samples/client/others/typescript-angular/builds/composed-schemas/provide-api.ts
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { Configuration, ConfigurationParameters } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | ConfigurationParameters) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: Configuration,
+                useValue: new Configuration({ ...configOrBasePath }),
+            },
+    ]);
+}

--- a/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/README.md
+++ b/samples/client/petstore/typescript-angular-v12-provided-in-root/builds/with-npm/README.md
@@ -58,157 +58,106 @@ Published packages are not effected by this issue.
 In your Angular project:
 
 ```typescript
-// without configuring providers
-import { ApiModule } from '@openapitools/typescript-angular-petstore';
-import { HttpClientModule } from '@angular/common/http';
 
-@NgModule({
-    imports: [
-        ApiModule,
-        // make sure to import the HttpClientModule in the AppModule only,
-        // see https://github.com/angular/angular/issues/20575
-        HttpClientModule
-    ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from '@openapitools/typescript-angular-petstore';
 
-```typescript
-// configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '@openapitools/typescript-angular-petstore';
-
-export function apiConfigFactory (): Configuration {
-  const params: ConfigurationParameters = {
-    // set configuration parameters here.
-  }
-  return new Configuration(params);
-}
-
-@NgModule({
-    imports: [ ApiModule.forRoot(apiConfigFactory) ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-```typescript
-// configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '@openapitools/typescript-angular-petstore';
-
-@NgModule({
-    imports: [ ApiModule ],
-    declarations: [ AppComponent ],
+export const appConfig: ApplicationConfig = {
     providers: [
-      {
-        provide: Configuration,
-        useFactory: (authService: AuthService) => new Configuration(
-          {
-            basePath: environment.apiUrl,
-            accessToken: authService.getAccessToken.bind(authService)
-          }
-        ),
-        deps: [AuthService],
-        multi: false
-      }
+        // ...
+        provideHttpClient(),
+        provideApi()
     ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
+};
+```
+
+**NOTE**
+If you're still using `AppModule` and haven't [migrated](https://angular.dev/reference/migrations/standalone) yet, you can still import an Angular module:
+```typescript
+import { ApiModule } from '@openapitools/typescript-angular-petstore';
+```
+
+If different from the generated base path, during app bootstrap, you can provide the base path to your service.
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from '@openapitools/typescript-angular-petstore';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi('http://localhost:9999')
+    ],
+};
 ```
 
 ```typescript
-import { DefaultApi } from '@openapitools/typescript-angular-petstore';
+// with a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from '@openapitools/typescript-angular-petstore';
 
-export class AppComponent {
-    constructor(private apiGateway: DefaultApi) { }
-}
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi({
+            withCredentials: true,
+            username: 'user',
+            password: 'password'
+        })
+    ],
+};
 ```
 
-Note: The ApiModule is restricted to being instantiated once app wide.
-This is to ensure that all services are treated as singletons.
+```typescript
+// with factory building a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi, Configuration } from '@openapitools/typescript-angular-petstore';
 
-### Using multiple OpenAPI files / APIs / ApiModules
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        {
+            provide: Configuration,
+            useFactory: (authService: AuthService) => new Configuration({
+                    basePath: 'http://localhost:9999',
+                    withCredentials: true,
+                    username: authService.getUsername(),
+                    password: authService.getPassword(),
+            }),
+            deps: [AuthService],
+            multi: false
+        }
+    ],
+};
+```
 
-In order to use multiple `ApiModules` generated from different OpenAPI files,
+### Using multiple OpenAPI files / APIs
+
+In order to use multiple APIs generated from different OpenAPI files,
 you can create an alias name when importing the modules
 in order to avoid naming conflicts:
 
 ```typescript
-import { ApiModule } from 'my-api-path';
-import { ApiModule as OtherApiModule } from 'my-other-api-path';
+import { provideApi as provideUserApi } from 'my-user-api-path';
+import { provideApi as provideAdminApi } from 'my-admin-api-path';
 import { HttpClientModule } from '@angular/common/http';
-
-@NgModule({
-  imports: [
-    ApiModule,
-    OtherApiModule,
-    // make sure to import the HttpClientModule in the AppModule only,
-    // see https://github.com/angular/angular/issues/20575
-    HttpClientModule
-  ]
-})
-export class AppModule {
-
-}
-```
-
-### Set service base path
-
-If different than the generated base path, during app bootstrap, you can provide the base path to your service.
-
-```typescript
-import { BASE_PATH } from '@openapitools/typescript-angular-petstore';
-
-bootstrap(AppComponent, [
-    { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
-]);
-```
-
-or
-
-```typescript
-import { BASE_PATH } from '@openapitools/typescript-angular-petstore';
-
-@NgModule({
-    imports: [],
-    declarations: [ AppComponent ],
-    providers: [ provide: BASE_PATH, useValue: 'https://your-web-service.com' ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-### Using @angular/cli
-
-First extend your `src/environments/*.ts` files by adding the corresponding base path:
-
-```typescript
-export const environment = {
-  production: false,
-  API_BASE_PATH: 'http://127.0.0.1:8080'
-};
-```
-
-In the src/app/app.module.ts:
-
-```typescript
-import { BASE_PATH } from '@openapitools/typescript-angular-petstore';
 import { environment } from '../environments/environment';
 
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [ ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
-  bootstrap: [ AppComponent ]
-})
-export class AppModule { }
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideUserApi(environment.basePath),
+        provideAdminApi(environment.basePath),
+    ],
+};
 ```
 
 ### Customizing path parameter encoding

--- a/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/README.md
+++ b/samples/client/petstore/typescript-angular-v13-provided-in-root/builds/with-npm/README.md
@@ -58,157 +58,106 @@ Published packages are not effected by this issue.
 In your Angular project:
 
 ```typescript
-// without configuring providers
-import { ApiModule } from '@openapitools/typescript-angular-petstore';
-import { HttpClientModule } from '@angular/common/http';
 
-@NgModule({
-    imports: [
-        ApiModule,
-        // make sure to import the HttpClientModule in the AppModule only,
-        // see https://github.com/angular/angular/issues/20575
-        HttpClientModule
-    ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from '@openapitools/typescript-angular-petstore';
 
-```typescript
-// configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from '@openapitools/typescript-angular-petstore';
-
-export function apiConfigFactory (): Configuration {
-  const params: ConfigurationParameters = {
-    // set configuration parameters here.
-  }
-  return new Configuration(params);
-}
-
-@NgModule({
-    imports: [ ApiModule.forRoot(apiConfigFactory) ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-```typescript
-// configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from '@openapitools/typescript-angular-petstore';
-
-@NgModule({
-    imports: [ ApiModule ],
-    declarations: [ AppComponent ],
+export const appConfig: ApplicationConfig = {
     providers: [
-      {
-        provide: Configuration,
-        useFactory: (authService: AuthService) => new Configuration(
-          {
-            basePath: environment.apiUrl,
-            accessToken: authService.getAccessToken.bind(authService)
-          }
-        ),
-        deps: [AuthService],
-        multi: false
-      }
+        // ...
+        provideHttpClient(),
+        provideApi()
     ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
+};
+```
+
+**NOTE**
+If you're still using `AppModule` and haven't [migrated](https://angular.dev/reference/migrations/standalone) yet, you can still import an Angular module:
+```typescript
+import { ApiModule } from '@openapitools/typescript-angular-petstore';
+```
+
+If different from the generated base path, during app bootstrap, you can provide the base path to your service.
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from '@openapitools/typescript-angular-petstore';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi('http://localhost:9999')
+    ],
+};
 ```
 
 ```typescript
-import { DefaultApi } from '@openapitools/typescript-angular-petstore';
+// with a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from '@openapitools/typescript-angular-petstore';
 
-export class AppComponent {
-    constructor(private apiGateway: DefaultApi) { }
-}
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi({
+            withCredentials: true,
+            username: 'user',
+            password: 'password'
+        })
+    ],
+};
 ```
 
-Note: The ApiModule is restricted to being instantiated once app wide.
-This is to ensure that all services are treated as singletons.
+```typescript
+// with factory building a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi, Configuration } from '@openapitools/typescript-angular-petstore';
 
-### Using multiple OpenAPI files / APIs / ApiModules
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        {
+            provide: Configuration,
+            useFactory: (authService: AuthService) => new Configuration({
+                    basePath: 'http://localhost:9999',
+                    withCredentials: true,
+                    username: authService.getUsername(),
+                    password: authService.getPassword(),
+            }),
+            deps: [AuthService],
+            multi: false
+        }
+    ],
+};
+```
 
-In order to use multiple `ApiModules` generated from different OpenAPI files,
+### Using multiple OpenAPI files / APIs
+
+In order to use multiple APIs generated from different OpenAPI files,
 you can create an alias name when importing the modules
 in order to avoid naming conflicts:
 
 ```typescript
-import { ApiModule } from 'my-api-path';
-import { ApiModule as OtherApiModule } from 'my-other-api-path';
+import { provideApi as provideUserApi } from 'my-user-api-path';
+import { provideApi as provideAdminApi } from 'my-admin-api-path';
 import { HttpClientModule } from '@angular/common/http';
-
-@NgModule({
-  imports: [
-    ApiModule,
-    OtherApiModule,
-    // make sure to import the HttpClientModule in the AppModule only,
-    // see https://github.com/angular/angular/issues/20575
-    HttpClientModule
-  ]
-})
-export class AppModule {
-
-}
-```
-
-### Set service base path
-
-If different than the generated base path, during app bootstrap, you can provide the base path to your service.
-
-```typescript
-import { BASE_PATH } from '@openapitools/typescript-angular-petstore';
-
-bootstrap(AppComponent, [
-    { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
-]);
-```
-
-or
-
-```typescript
-import { BASE_PATH } from '@openapitools/typescript-angular-petstore';
-
-@NgModule({
-    imports: [],
-    declarations: [ AppComponent ],
-    providers: [ provide: BASE_PATH, useValue: 'https://your-web-service.com' ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-### Using @angular/cli
-
-First extend your `src/environments/*.ts` files by adding the corresponding base path:
-
-```typescript
-export const environment = {
-  production: false,
-  API_BASE_PATH: 'http://127.0.0.1:8080'
-};
-```
-
-In the src/app/app.module.ts:
-
-```typescript
-import { BASE_PATH } from '@openapitools/typescript-angular-petstore';
 import { environment } from '../environments/environment';
 
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [ ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
-  bootstrap: [ AppComponent ]
-})
-export class AppModule { }
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideUserApi(environment.basePath),
+        provideAdminApi(environment.basePath),
+    ],
+};
 ```
 
 ### Customizing path parameter encoding

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/.openapi-generator/FILES
@@ -18,4 +18,5 @@ model/pet.ts
 model/tag.ts
 model/user.ts
 param.ts
+provide-api.ts
 variables.ts

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/index.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/index.ts
@@ -3,4 +3,5 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+export * from './provide-api';
 export * from './param';

--- a/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/provide-api.ts
+++ b/samples/client/petstore/typescript-angular-v17-provided-in-root/builds/default/provide-api.ts
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { Configuration, ConfigurationParameters } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | ConfigurationParameters) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: Configuration,
+                useValue: new Configuration({ ...configOrBasePath }),
+            },
+    ]);
+}

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/.openapi-generator/FILES
@@ -18,4 +18,5 @@ model/pet.ts
 model/tag.ts
 model/user.ts
 param.ts
+provide-api.ts
 variables.ts

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/index.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/index.ts
@@ -3,4 +3,5 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+export * from './provide-api';
 export * from './param';

--- a/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/provide-api.ts
+++ b/samples/client/petstore/typescript-angular-v18-provided-in-root/builds/default/provide-api.ts
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { Configuration, ConfigurationParameters } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | ConfigurationParameters) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: Configuration,
+                useValue: new Configuration({ ...configOrBasePath }),
+            },
+    ]);
+}

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/.openapi-generator/FILES
@@ -20,5 +20,6 @@ model/user.ts
 ng-package.json
 package.json
 param.ts
+provide-api.ts
 tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/README.md
@@ -58,157 +58,106 @@ Published packages are not effected by this issue.
 In your Angular project:
 
 ```typescript
-// without configuring providers
-import { ApiModule } from 'sample-angular-19-0-0-with-angular-dependency-params';
-import { HttpClientModule } from '@angular/common/http';
 
-@NgModule({
-    imports: [
-        ApiModule,
-        // make sure to import the HttpClientModule in the AppModule only,
-        // see https://github.com/angular/angular/issues/20575
-        HttpClientModule
-    ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0-with-angular-dependency-params';
 
-```typescript
-// configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from 'sample-angular-19-0-0-with-angular-dependency-params';
-
-export function apiConfigFactory (): Configuration {
-  const params: ConfigurationParameters = {
-    // set configuration parameters here.
-  }
-  return new Configuration(params);
-}
-
-@NgModule({
-    imports: [ ApiModule.forRoot(apiConfigFactory) ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-```typescript
-// configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from 'sample-angular-19-0-0-with-angular-dependency-params';
-
-@NgModule({
-    imports: [ ApiModule ],
-    declarations: [ AppComponent ],
+export const appConfig: ApplicationConfig = {
     providers: [
-      {
-        provide: Configuration,
-        useFactory: (authService: AuthService) => new Configuration(
-          {
-            basePath: environment.apiUrl,
-            accessToken: authService.getAccessToken.bind(authService)
-          }
-        ),
-        deps: [AuthService],
-        multi: false
-      }
+        // ...
+        provideHttpClient(),
+        provideApi()
     ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
+};
+```
+
+**NOTE**
+If you're still using `AppModule` and haven't [migrated](https://angular.dev/reference/migrations/standalone) yet, you can still import an Angular module:
+```typescript
+import { ApiModule } from 'sample-angular-19-0-0-with-angular-dependency-params';
+```
+
+If different from the generated base path, during app bootstrap, you can provide the base path to your service.
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0-with-angular-dependency-params';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi('http://localhost:9999')
+    ],
+};
 ```
 
 ```typescript
-import { DefaultApi } from 'sample-angular-19-0-0-with-angular-dependency-params';
+// with a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0-with-angular-dependency-params';
 
-export class AppComponent {
-    constructor(private apiGateway: DefaultApi) { }
-}
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi({
+            withCredentials: true,
+            username: 'user',
+            password: 'password'
+        })
+    ],
+};
 ```
 
-Note: The ApiModule is restricted to being instantiated once app wide.
-This is to ensure that all services are treated as singletons.
+```typescript
+// with factory building a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi, Configuration } from 'sample-angular-19-0-0-with-angular-dependency-params';
 
-### Using multiple OpenAPI files / APIs / ApiModules
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        {
+            provide: Configuration,
+            useFactory: (authService: AuthService) => new Configuration({
+                    basePath: 'http://localhost:9999',
+                    withCredentials: true,
+                    username: authService.getUsername(),
+                    password: authService.getPassword(),
+            }),
+            deps: [AuthService],
+            multi: false
+        }
+    ],
+};
+```
 
-In order to use multiple `ApiModules` generated from different OpenAPI files,
+### Using multiple OpenAPI files / APIs
+
+In order to use multiple APIs generated from different OpenAPI files,
 you can create an alias name when importing the modules
 in order to avoid naming conflicts:
 
 ```typescript
-import { ApiModule } from 'my-api-path';
-import { ApiModule as OtherApiModule } from 'my-other-api-path';
+import { provideApi as provideUserApi } from 'my-user-api-path';
+import { provideApi as provideAdminApi } from 'my-admin-api-path';
 import { HttpClientModule } from '@angular/common/http';
-
-@NgModule({
-  imports: [
-    ApiModule,
-    OtherApiModule,
-    // make sure to import the HttpClientModule in the AppModule only,
-    // see https://github.com/angular/angular/issues/20575
-    HttpClientModule
-  ]
-})
-export class AppModule {
-
-}
-```
-
-### Set service base path
-
-If different than the generated base path, during app bootstrap, you can provide the base path to your service.
-
-```typescript
-import { BASE_PATH } from 'sample-angular-19-0-0-with-angular-dependency-params';
-
-bootstrap(AppComponent, [
-    { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
-]);
-```
-
-or
-
-```typescript
-import { BASE_PATH } from 'sample-angular-19-0-0-with-angular-dependency-params';
-
-@NgModule({
-    imports: [],
-    declarations: [ AppComponent ],
-    providers: [ provide: BASE_PATH, useValue: 'https://your-web-service.com' ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-### Using @angular/cli
-
-First extend your `src/environments/*.ts` files by adding the corresponding base path:
-
-```typescript
-export const environment = {
-  production: false,
-  API_BASE_PATH: 'http://127.0.0.1:8080'
-};
-```
-
-In the src/app/app.module.ts:
-
-```typescript
-import { BASE_PATH } from 'sample-angular-19-0-0-with-angular-dependency-params';
 import { environment } from '../environments/environment';
 
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [ ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
-  bootstrap: [ AppComponent ]
-})
-export class AppModule { }
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideUserApi(environment.basePath),
+        provideAdminApi(environment.basePath),
+    ],
+};
 ```
 
 ### Customizing path parameter encoding

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/index.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/index.ts
@@ -3,4 +3,5 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+export * from './provide-api';
 export * from './param';

--- a/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/provide-api.ts
+++ b/samples/client/petstore/typescript-angular-v19-with-angular-dependency-params/builds/default/provide-api.ts
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { Configuration, ConfigurationParameters } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | ConfigurationParameters) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: Configuration,
+                useValue: new Configuration({ ...configOrBasePath }),
+            },
+    ]);
+}

--- a/samples/client/petstore/typescript-angular-v19/builds/default/.openapi-generator/FILES
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/.openapi-generator/FILES
@@ -20,5 +20,6 @@ model/user.ts
 ng-package.json
 package.json
 param.ts
+provide-api.ts
 tsconfig.json
 variables.ts

--- a/samples/client/petstore/typescript-angular-v19/builds/default/README.md
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/README.md
@@ -58,157 +58,106 @@ Published packages are not effected by this issue.
 In your Angular project:
 
 ```typescript
-// without configuring providers
-import { ApiModule } from 'sample-angular-19-0-0';
-import { HttpClientModule } from '@angular/common/http';
 
-@NgModule({
-    imports: [
-        ApiModule,
-        // make sure to import the HttpClientModule in the AppModule only,
-        // see https://github.com/angular/angular/issues/20575
-        HttpClientModule
-    ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0';
 
-```typescript
-// configuring providers
-import { ApiModule, Configuration, ConfigurationParameters } from 'sample-angular-19-0-0';
-
-export function apiConfigFactory (): Configuration {
-  const params: ConfigurationParameters = {
-    // set configuration parameters here.
-  }
-  return new Configuration(params);
-}
-
-@NgModule({
-    imports: [ ApiModule.forRoot(apiConfigFactory) ],
-    declarations: [ AppComponent ],
-    providers: [],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-```typescript
-// configuring providers with an authentication service that manages your access tokens
-import { ApiModule, Configuration } from 'sample-angular-19-0-0';
-
-@NgModule({
-    imports: [ ApiModule ],
-    declarations: [ AppComponent ],
+export const appConfig: ApplicationConfig = {
     providers: [
-      {
-        provide: Configuration,
-        useFactory: (authService: AuthService) => new Configuration(
-          {
-            basePath: environment.apiUrl,
-            accessToken: authService.getAccessToken.bind(authService)
-          }
-        ),
-        deps: [AuthService],
-        multi: false
-      }
+        // ...
+        provideHttpClient(),
+        provideApi()
     ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
+};
+```
+
+**NOTE**
+If you're still using `AppModule` and haven't [migrated](https://angular.dev/reference/migrations/standalone) yet, you can still import an Angular module:
+```typescript
+import { ApiModule } from 'sample-angular-19-0-0';
+```
+
+If different from the generated base path, during app bootstrap, you can provide the base path to your service.
+
+```typescript
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi('http://localhost:9999')
+    ],
+};
 ```
 
 ```typescript
-import { DefaultApi } from 'sample-angular-19-0-0';
+// with a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi } from 'sample-angular-19-0-0';
 
-export class AppComponent {
-    constructor(private apiGateway: DefaultApi) { }
-}
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideApi({
+            withCredentials: true,
+            username: 'user',
+            password: 'password'
+        })
+    ],
+};
 ```
 
-Note: The ApiModule is restricted to being instantiated once app wide.
-This is to ensure that all services are treated as singletons.
+```typescript
+// with factory building a custom configuration
+import { ApplicationConfig } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideApi, Configuration } from 'sample-angular-19-0-0';
 
-### Using multiple OpenAPI files / APIs / ApiModules
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        {
+            provide: Configuration,
+            useFactory: (authService: AuthService) => new Configuration({
+                    basePath: 'http://localhost:9999',
+                    withCredentials: true,
+                    username: authService.getUsername(),
+                    password: authService.getPassword(),
+            }),
+            deps: [AuthService],
+            multi: false
+        }
+    ],
+};
+```
 
-In order to use multiple `ApiModules` generated from different OpenAPI files,
+### Using multiple OpenAPI files / APIs
+
+In order to use multiple APIs generated from different OpenAPI files,
 you can create an alias name when importing the modules
 in order to avoid naming conflicts:
 
 ```typescript
-import { ApiModule } from 'my-api-path';
-import { ApiModule as OtherApiModule } from 'my-other-api-path';
+import { provideApi as provideUserApi } from 'my-user-api-path';
+import { provideApi as provideAdminApi } from 'my-admin-api-path';
 import { HttpClientModule } from '@angular/common/http';
-
-@NgModule({
-  imports: [
-    ApiModule,
-    OtherApiModule,
-    // make sure to import the HttpClientModule in the AppModule only,
-    // see https://github.com/angular/angular/issues/20575
-    HttpClientModule
-  ]
-})
-export class AppModule {
-
-}
-```
-
-### Set service base path
-
-If different than the generated base path, during app bootstrap, you can provide the base path to your service.
-
-```typescript
-import { BASE_PATH } from 'sample-angular-19-0-0';
-
-bootstrap(AppComponent, [
-    { provide: BASE_PATH, useValue: 'https://your-web-service.com' },
-]);
-```
-
-or
-
-```typescript
-import { BASE_PATH } from 'sample-angular-19-0-0';
-
-@NgModule({
-    imports: [],
-    declarations: [ AppComponent ],
-    providers: [ provide: BASE_PATH, useValue: 'https://your-web-service.com' ],
-    bootstrap: [ AppComponent ]
-})
-export class AppModule {}
-```
-
-### Using @angular/cli
-
-First extend your `src/environments/*.ts` files by adding the corresponding base path:
-
-```typescript
-export const environment = {
-  production: false,
-  API_BASE_PATH: 'http://127.0.0.1:8080'
-};
-```
-
-In the src/app/app.module.ts:
-
-```typescript
-import { BASE_PATH } from 'sample-angular-19-0-0';
 import { environment } from '../environments/environment';
 
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [ ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
-  bootstrap: [ AppComponent ]
-})
-export class AppModule { }
+export const appConfig: ApplicationConfig = {
+    providers: [
+        // ...
+        provideHttpClient(),
+        provideUserApi(environment.basePath),
+        provideAdminApi(environment.basePath),
+    ],
+};
 ```
 
 ### Customizing path parameter encoding

--- a/samples/client/petstore/typescript-angular-v19/builds/default/index.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/index.ts
@@ -3,4 +3,5 @@ export * from './model/models';
 export * from './variables';
 export * from './configuration';
 export * from './api.module';
+export * from './provide-api';
 export * from './param';

--- a/samples/client/petstore/typescript-angular-v19/builds/default/provide-api.ts
+++ b/samples/client/petstore/typescript-angular-v19/builds/default/provide-api.ts
@@ -1,0 +1,14 @@
+import { makeEnvironmentProviders } from "@angular/core";
+import { Configuration, ConfigurationParameters } from './configuration';
+import { BASE_PATH } from './variables';
+
+export function provideApi(configOrBasePath: string | ConfigurationParameters) {
+    return makeEnvironmentProviders([
+        typeof configOrBasePath === "string"
+            ? { provide: BASE_PATH, useValue: configOrBasePath }
+            : {
+                provide: Configuration,
+                useValue: new Configuration({ ...configOrBasePath }),
+            },
+    ]);
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
