### PR TITLE
[PHP] Add declareStrictTypes option to AbstractPhpCodegen to generate declare(strict_types=1);

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -573,6 +573,14 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     public String toAbstractName(final String name) {
         return camelize(abstractNamePrefix + name + abstractNameSuffix);
     }
+    
+@Override
+public String getHelp() {
+    return "Generates a PHP client library." + "\n" +
+           "Options:\n" +
+           "  - declareStrictTypes: boolean, set to true to add declare(strict_types=1); in generated PHP files.";
+}
+
 
     /**
      * Output the proper trait name (capitalized).

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -286,6 +286,11 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
         // all PHP codegens requires Composer, it means that we need to exclude from SVN at least vendor folder
         supportingFiles.add(new SupportingFile("gitignore", "", ".gitignore"));
+        // Add declareStrictTypes property to the additionalProperties
+    if (additionalProperties.containsKey("declareStrictTypes")) {
+        this.declareStrictTypes = Boolean.parseBoolean(additionalProperties.get("declareStrictTypes").toString());
+    }
+    additionalProperties.put("declareStrictTypes", declareStrictTypes);
     }
 
     public String toSrcPath(final String packageName, final String basePath) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -69,6 +69,7 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
     protected String interfaceNamePrefix = "", interfaceNameSuffix = "Interface";
     protected String abstractNamePrefix = "Abstract", abstractNameSuffix = "";
     protected String traitNamePrefix = "", traitNameSuffix = "Trait";
+    protected boolean declareStrictTypes = false;
 
     private Map<String, String> schemaKeyToModelNameCache = new HashMap<>();
 

--- a/modules/openapi-generator/src/main/resources/php/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ApiException.mustache
@@ -1,4 +1,6 @@
 <?php
+{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}
+
 /**
  * ApiException
  * PHP version 8.1

--- a/modules/openapi-generator/src/main/resources/php/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php/Configuration.mustache
@@ -1,4 +1,5 @@
 <?php
+{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}
 /**
  * Configuration
  * PHP version 8.1

--- a/modules/openapi-generator/src/main/resources/php/FormDataProcessor.mustache
+++ b/modules/openapi-generator/src/main/resources/php/FormDataProcessor.mustache
@@ -1,4 +1,6 @@
 <?php
+{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}
+
 /**
  * FormDataProcessor
  * PHP version 7.4

--- a/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
@@ -1,4 +1,5 @@
 <?php
+{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}
 /**
  * HeaderSelector
  * PHP version 8.1

--- a/modules/openapi-generator/src/main/resources/php/ModelInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ModelInterface.mustache
@@ -1,4 +1,5 @@
 <?php
+{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}
 /**
  * ModelInterface
  *

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -1,4 +1,5 @@
 <?php
+{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}
 /**
  * ObjectSerializer
  *


### PR DESCRIPTION
# **Summary**
This PR introduces support for a new generator option: declareStrictTypes for PHP code generation.

When enabled via `--additional-properties=declareStrictTypes=true`, the generated PHP files will start with:
```
<?php
declare(strict_types=1);
```
This enforces strict typing in the generated PHP client code, promoting best practices for modern PHP development.

## **Affected Files**
### **Codegen Core:**

 - `AbstractPhpCodegen.java`
 
      → Added support for the declareStrictTypes property and updated the help message.


- ### **PHP Template Files:**

Located in `modules/openapi-generator/src/main/resources/php/
`
```
- model.mustache
- api.mustache
- api_test.mustache
- model_test.mustache
 ```
- Other templates starting with <?php

All updated to conditionally include:

`{{#declareStrictTypes}}declare(strict_types=1);{{/declareStrictTypes}}`


## **Usage Example**
To generate PHP code with declare(strict_types=1); included at the top of the files, run:
```

java -jar openapi-generator-cli.jar generate \
  -g php \
  --additional-properties=declareStrictTypes=true \
  -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
  -o /tmp/test-php
```
Then check any generated file (e.g., `ApiClient.php`) for:
```

<?php
declare(strict_types=1);
```

### **Fixes:** #12771

Thank you for reviewing this contribution! 🙏