### PR TITLE
[fix][elixir] missing type mapping for AnyType

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -226,6 +226,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
         typeMapping.put("date", "Date.t");
         typeMapping.put("date-time", "DateTime.t");
         // other
+        typeMapping.put("AnyType", "any()");
         typeMapping.put("ByteArray", "binary()");
         typeMapping.put("DateTime", "DateTime.t");
         typeMapping.put("UUID", "String.t");


### PR DESCRIPTION
### Description

Add missing mapping for `AnyType`.

The lack of this mapping would result in `AnyType` being encoded as `<invokerPackage>.Model.AnyType` in certain scenarios.

[Here](https://github.com/efcasado/elixir-cloudflare/blob/1cd390d9baae2105d8db13b87f7212ca1e112692/lib/cloudflare/model/overrides.ex#L19) is an example of a generated model exhibiting this issue. [Here](https://github.com/efcasado/elixir-cloudflare/blob/fix-anytype/lib/cloudflare/model/overrides.ex) is the same model generated after applying this fix.

The issue was caught by dialyzer.

```elixir
lib/cloudflare/model/overrides.ex:23:41:unknown_type
Unknown type: Cloudflare.Model.AnyType.t/0.
```

I am having difficulties generating a smaller example to reproduce the issue and add it as a new test to the project. So far, I've only been able to reproduce the issue when using `--skip-validate-spec` with the Cloudflare OAS file.

As usual, curious to hear your thoughts @mrmstn and @wing328 😊

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
