### PR TITLE
[Java][WebClient|RestClient][20808] add Autowired annotations guard to skip generation when not generating Spring bean

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
@@ -18,7 +18,9 @@ import {{javaxPackage}}.validation.constraints.*;
 import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
+{{#generateClientAsBean}}
 import org.springframework.beans.factory.annotation.Autowired;
+{{/generateClientAsBean}}
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -46,7 +48,9 @@ public class {{classname}} {
         this(new ApiClient());
     }
 
+{{#generateClientAsBean}}
     @Autowired
+{{/generateClientAsBean}}
     public {{classname}}(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
@@ -18,7 +18,9 @@ import {{javaxPackage}}.validation.constraints.*;
 import {{javaxPackage}}.validation.Valid;
 
 {{/useBeanValidation}}
+{{#generateClientAsBean}}
 import org.springframework.beans.factory.annotation.Autowired;
+{{/generateClientAsBean}}
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -48,7 +50,9 @@ public class {{classname}} {
         this(new ApiClient());
     }
 
+{{#generateClientAsBean}}
     @Autowired
+{{/generateClientAsBean}}
     public {{classname}}(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/AuthApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/AuthApi.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -32,7 +31,6 @@ public class AuthApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AuthApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class BodyApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public BodyApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/FormApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class FormApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FormApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class HeaderApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public HeaderApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/PathApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class PathApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PathApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -39,7 +38,6 @@ public class QueryApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public QueryApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/api/ResourceApi.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/api/ResourceApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class ResourceApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public ResourceApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/api/ResourceApi.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/api/ResourceApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class ResourceApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public ResourceApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -47,7 +46,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +33,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -47,7 +46,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +33,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -47,7 +46,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +33,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -47,7 +46,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +32,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +33,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -49,7 +48,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -38,7 +37,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -49,7 +48,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -38,7 +37,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -49,7 +48,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -38,7 +37,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/AnotherFakeApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class AnotherFakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public AnotherFakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/DefaultApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/DefaultApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class DefaultApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public DefaultApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -49,7 +48,6 @@ public class FakeApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeClassnameTags123Api.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class FakeClassnameTags123Api {
         this(new ApiClient());
     }
 
-    @Autowired
     public FakeClassnameTags123Api(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -38,7 +37,6 @@ public class PetApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public PetApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -35,7 +34,6 @@ public class StoreApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public StoreApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,6 @@ public class UserApi {
         this(new ApiClient());
     }
 
-    @Autowired
     public UserApi(ApiClient apiClient) {
         this.apiClient = apiClient;
     }


### PR DESCRIPTION
annotation import and usage is not generated when API is not a Spring Bean

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes https://github.com/OpenAPITools/openapi-generator/issues/20808

Although not problematic from runtime point of view, generation of Autowired annotation is unnecessary when RestClient or WebClient class is not a Spring Bean - because Autowired annotation will not be picked up at all.

Another negative side effect, IntelliJ correctly displays no ApiClient candidate is available for autowiring, because ApiClient instance itself is correctly guarded by generation flag.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg 
