### PR TITLE
fix: fix dev container failing to build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,10 +11,9 @@
     },
     "ghcr.io/devcontainers/features/rust:1": {},
     "ghcr.io/snebjorn/devcontainer-feature/chromium:latest": {},
-    "docker-in-docker": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
-      "moby": true,
-      "dockerDashComposeVersion": "v1"
+      "moby": true
     }
   },
   // Configure tool-specific properties.

--- a/modules/openapi-generator/src/main/resources/python-fastapi/README.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/README.mustache
@@ -29,7 +29,7 @@ and open your browser at `http://localhost:{{serverPort}}/docs/` to see the docs
 To run the server on a Docker container, please execute the following from the root directory:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 ## Tests

--- a/samples/server/petstore/python-fastapi/README.md
+++ b/samples/server/petstore/python-fastapi/README.md
@@ -26,7 +26,7 @@ and open your browser at `http://localhost:8080/docs/` to see the docs.
 To run the server on a Docker container, please execute the following from the root directory:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 ## Tests


### PR DESCRIPTION
The dev container fails to build because of the outdated docker-in-docker feature. This updates the docker-in-docker and fixes the build. I also updated the docker compose references in the docs.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
