### PR TITLE
[cpp-rest-sdk] fix enum values being used instead of names

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -185,8 +185,11 @@ public:
     {{#isEnum}}
     enum class {{#isContainer}}{{{enumName}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}
     {
-        {{#allowableValues}}{{#enumVars}}{{value}},
-        {{/enumVars}}{{/allowableValues}}
+        {{#allowableValues}}
+        {{#enumVars}}
+        {{{name}}}{{^last}},{{/last}}
+        {{/enumVars}}
+        {{/allowableValues}}
     };
     {{#description}}
     /// <summary>

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -136,14 +136,14 @@ public:
         std::map<e{{classname}},utility::string_t> enumToStrMap = {
         {{#allowableValues}}
         {{#enumVars}}
-        { e{{classname}}::{{{name}}}, "{{{name}}}" }{{^-last}},{{/-last}}
+        { e{{classname}}::{{{name}}}, _XPLATSTR("{{{name}}}") }{{^-last}},{{/-last}}
         {{/enumVars}}
         {{/allowableValues}}
 };
         std::map<utility::string_t,e{{classname}}> strToEnumMap = {
         {{#allowableValues}}
         {{#enumVars}}
-        { "{{{name}}}", e{{classname}}::{{{name}}} }{{^-last}},{{/-last}}
+        { _XPLATSTR("{{{name}}}"), e{{classname}}::{{{name}}} }{{^-last}},{{/-last}}
         {{/enumVars}}
         {{/allowableValues}}
 };

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -123,7 +123,7 @@ public:
         /// {{.}}
         /// </summary>
         {{/enumDescription}}
-        {{classname}}_{{{name}}}{{^last}},{{/last}}
+        {{{name}}}{{^last}},{{/last}}
         {{/enumVars}}
         {{/allowableValues}}
     };
@@ -136,14 +136,14 @@ public:
         std::map<e{{classname}},utility::string_t> enumToStrMap = {
         {{#allowableValues}}
         {{#enumVars}}
-        { e{{classname}}::{{classname}}_{{{name}}}, "{{{name}}}" }{{^-last}},{{/-last}}
+        { e{{classname}}::{{{name}}}, "{{{name}}}" }{{^-last}},{{/-last}}
         {{/enumVars}}
         {{/allowableValues}}
 };
         std::map<utility::string_t,e{{classname}}> strToEnumMap = {
         {{#allowableValues}}
         {{#enumVars}}
-        { "{{{name}}}", e{{classname}}::{{classname}}_{{{name}}} }{{^-last}},{{/-last}}
+        { "{{{name}}}", e{{classname}}::{{{name}}} }{{^-last}},{{/-last}}
         {{/enumVars}}
         {{/allowableValues}}
 };

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -72,7 +72,7 @@ using EnumUnderlyingType = {{#isNumeric}}int64_t{{/isNumeric}}{{^isNumeric}}util
     {
     {{#enumVars}}
     case {{value}}:
-        return {{classname}}::e{{classname}}::{{classname}}_{{name}};
+        return {{classname}}::e{{classname}}::{{name}};
     {{#-last}}
     default:
         break;
@@ -83,7 +83,7 @@ using EnumUnderlyingType = {{#isNumeric}}int64_t{{/isNumeric}}{{^isNumeric}}util
 {{^isNumeric}}
     {{#enumVars}}
     if (val == utility::conversions::to_string_t(_XPLATSTR("{{{value}}}")))
-        return {{classname}}::e{{classname}}::{{classname}}_{{name}};
+        return {{classname}}::e{{classname}}::{{name}};
     {{/enumVars}}
 {{/isNumeric}}
 {{/allowableValues}}
@@ -96,7 +96,7 @@ EnumUnderlyingType fromEnum({{classname}}::e{{classname}} e)
     switch (e)
     {
 {{#enumVars}}
-    case {{classname}}::e{{classname}}::{{classname}}_{{name}}:
+    case {{classname}}::e{{classname}}::{{name}}:
         return {{#isNumeric}}{{value}}{{/isNumeric}}{{^isNumeric}}_XPLATSTR("{{value}}"){{/isNumeric}};
 {{#-last}}
     default:

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -354,7 +354,7 @@ bool {{classname}}::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, 
 {
     {{#allowableValues}}{{#enumVars}}
     if (value == utility::conversions::to_string_t("{{value}}")) {
-        return {{#isContainer}}{{{enumName}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}::{{value}};
+        return {{#isContainer}}{{{enumName}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}::{{name}};
     }
     {{/enumVars}}{{/allowableValues}}
     throw std::invalid_argument("Invalid value for conversion to {{{datatypeWithEnum}}}");
@@ -369,7 +369,7 @@ const {{dataType}} {{classname}}::from{{{datatypeWithEnum}}}(const {{{datatypeWi
     switch(value)
     {
         {{#allowableValues}}{{#enumVars}}
-        case {{#isContainer}}{{{enumName}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}::{{value}}: return utility::conversions::to_string_t("{{value}}");
+        case {{#isContainer}}{{{enumName}}}{{/isContainer}}{{^isContainer}}{{{datatypeWithEnum}}}{{/isContainer}}::{{name}}: return utility::conversions::to_string_t("{{value}}");
         {{/enumVars}}{{/allowableValues}}
     }
 }

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Color.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Color.h
@@ -54,11 +54,11 @@ public:
 
     enum class eColor
     {
-        Color_BLACK,
-        Color_WHITE,
-        Color_BROWN,
-        Color_GOLDEN,
-        Color_MIXED,
+        BLACK,
+        WHITE,
+        BROWN,
+        GOLDEN,
+        MIXED,
     };
 
     eColor getValue() const;
@@ -67,18 +67,18 @@ public:
     protected:
         eColor m_value;
         std::map<eColor,utility::string_t> enumToStrMap = {
-        { eColor::Color_BLACK, "BLACK" },
-        { eColor::Color_WHITE, "WHITE" },
-        { eColor::Color_BROWN, "BROWN" },
-        { eColor::Color_GOLDEN, "GOLDEN" },
-        { eColor::Color_MIXED, "MIXED" }
+        { eColor::BLACK, "BLACK" },
+        { eColor::WHITE, "WHITE" },
+        { eColor::BROWN, "BROWN" },
+        { eColor::GOLDEN, "GOLDEN" },
+        { eColor::MIXED, "MIXED" }
 };
         std::map<utility::string_t,eColor> strToEnumMap = {
-        { "BLACK", eColor::Color_BLACK },
-        { "WHITE", eColor::Color_WHITE },
-        { "BROWN", eColor::Color_BROWN },
-        { "GOLDEN", eColor::Color_GOLDEN },
-        { "MIXED", eColor::Color_MIXED }
+        { "BLACK", eColor::BLACK },
+        { "WHITE", eColor::WHITE },
+        { "BROWN", eColor::BROWN },
+        { "GOLDEN", eColor::GOLDEN },
+        { "MIXED", eColor::MIXED }
 };
 
 };

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Color.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Color.h
@@ -67,18 +67,18 @@ public:
     protected:
         eColor m_value;
         std::map<eColor,utility::string_t> enumToStrMap = {
-        { eColor::BLACK, "BLACK" },
-        { eColor::WHITE, "WHITE" },
-        { eColor::BROWN, "BROWN" },
-        { eColor::GOLDEN, "GOLDEN" },
-        { eColor::MIXED, "MIXED" }
+        { eColor::BLACK, _XPLATSTR("BLACK") },
+        { eColor::WHITE, _XPLATSTR("WHITE") },
+        { eColor::BROWN, _XPLATSTR("BROWN") },
+        { eColor::GOLDEN, _XPLATSTR("GOLDEN") },
+        { eColor::MIXED, _XPLATSTR("MIXED") }
 };
         std::map<utility::string_t,eColor> strToEnumMap = {
-        { "BLACK", eColor::BLACK },
-        { "WHITE", eColor::WHITE },
-        { "BROWN", eColor::BROWN },
-        { "GOLDEN", eColor::GOLDEN },
-        { "MIXED", eColor::MIXED }
+        { _XPLATSTR("BLACK"), eColor::BLACK },
+        { _XPLATSTR("WHITE"), eColor::WHITE },
+        { _XPLATSTR("BROWN"), eColor::BROWN },
+        { _XPLATSTR("GOLDEN"), eColor::GOLDEN },
+        { _XPLATSTR("MIXED"), eColor::MIXED }
 };
 
 };

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Order.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Order.h
@@ -58,10 +58,9 @@ public:
 
     enum class StatusEnum
     {
-        placed,
-        approved,
-        delivered,
-        
+        PLACED,
+        APPROVED,
+        DELIVERED,
     };
     /// <summary>
     /// Order Status

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
@@ -63,10 +63,9 @@ public:
 
     enum class StatusEnum
     {
-        available,
-        pending,
-        sold,
-        
+        AVAILABLE,
+        PENDING,
+        SOLD,
     };
     /// <summary>
     /// pet status in the store

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Color.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Color.cpp
@@ -25,15 +25,15 @@ using EnumUnderlyingType = utility::string_t;
 Color::eColor toEnum(const EnumUnderlyingType& val)
 {
     if (val == utility::conversions::to_string_t(_XPLATSTR("black")))
-        return Color::eColor::Color_BLACK;
+        return Color::eColor::BLACK;
     if (val == utility::conversions::to_string_t(_XPLATSTR("white")))
-        return Color::eColor::Color_WHITE;
+        return Color::eColor::WHITE;
     if (val == utility::conversions::to_string_t(_XPLATSTR("brown")))
-        return Color::eColor::Color_BROWN;
+        return Color::eColor::BROWN;
     if (val == utility::conversions::to_string_t(_XPLATSTR("golden")))
-        return Color::eColor::Color_GOLDEN;
+        return Color::eColor::GOLDEN;
     if (val == utility::conversions::to_string_t(_XPLATSTR("mixed")))
-        return Color::eColor::Color_MIXED;
+        return Color::eColor::MIXED;
     return {};
 }
 
@@ -41,15 +41,15 @@ EnumUnderlyingType fromEnum(Color::eColor e)
 {
     switch (e)
     {
-    case Color::eColor::Color_BLACK:
+    case Color::eColor::BLACK:
         return _XPLATSTR("black");
-    case Color::eColor::Color_WHITE:
+    case Color::eColor::WHITE:
         return _XPLATSTR("white");
-    case Color::eColor::Color_BROWN:
+    case Color::eColor::BROWN:
         return _XPLATSTR("brown");
-    case Color::eColor::Color_GOLDEN:
+    case Color::eColor::GOLDEN:
         return _XPLATSTR("golden");
-    case Color::eColor::Color_MIXED:
+    case Color::eColor::MIXED:
         return _XPLATSTR("mixed");
     default:
         break;

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Order.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Order.cpp
@@ -239,15 +239,15 @@ Order::StatusEnum Order::toStatusEnum(const utility::string_t& value) const
 {
     
     if (value == utility::conversions::to_string_t("placed")) {
-        return StatusEnum::placed;
+        return StatusEnum::PLACED;
     }
     
     if (value == utility::conversions::to_string_t("approved")) {
-        return StatusEnum::approved;
+        return StatusEnum::APPROVED;
     }
     
     if (value == utility::conversions::to_string_t("delivered")) {
-        return StatusEnum::delivered;
+        return StatusEnum::DELIVERED;
     }
     
     throw std::invalid_argument("Invalid value for conversion to StatusEnum");
@@ -259,11 +259,11 @@ const utility::string_t Order::fromStatusEnum(const StatusEnum value) const
     switch(value)
     {
         
-        case StatusEnum::placed: return utility::conversions::to_string_t("placed");
+        case StatusEnum::PLACED: return utility::conversions::to_string_t("placed");
         
-        case StatusEnum::approved: return utility::conversions::to_string_t("approved");
+        case StatusEnum::APPROVED: return utility::conversions::to_string_t("approved");
         
-        case StatusEnum::delivered: return utility::conversions::to_string_t("delivered");
+        case StatusEnum::DELIVERED: return utility::conversions::to_string_t("delivered");
         
     }
 }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Pet.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Pet.cpp
@@ -236,15 +236,15 @@ Pet::StatusEnum Pet::toStatusEnum(const utility::string_t& value) const
 {
     
     if (value == utility::conversions::to_string_t("available")) {
-        return StatusEnum::available;
+        return StatusEnum::AVAILABLE;
     }
     
     if (value == utility::conversions::to_string_t("pending")) {
-        return StatusEnum::pending;
+        return StatusEnum::PENDING;
     }
     
     if (value == utility::conversions::to_string_t("sold")) {
-        return StatusEnum::sold;
+        return StatusEnum::SOLD;
     }
     
     throw std::invalid_argument("Invalid value for conversion to StatusEnum");
@@ -256,11 +256,11 @@ const utility::string_t Pet::fromStatusEnum(const StatusEnum value) const
     switch(value)
     {
         
-        case StatusEnum::available: return utility::conversions::to_string_t("available");
+        case StatusEnum::AVAILABLE: return utility::conversions::to_string_t("available");
         
-        case StatusEnum::pending: return utility::conversions::to_string_t("pending");
+        case StatusEnum::PENDING: return utility::conversions::to_string_t("pending");
         
-        case StatusEnum::sold: return utility::conversions::to_string_t("sold");
+        case StatusEnum::SOLD: return utility::conversions::to_string_t("sold");
         
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This fixes the issue with enum values being used instead of enum names. This is problematic when the values contain symbols that can't be a C++ variable. 
This also fixes compilation of enums on Windows for the string literals. 


It also simplifies the enum variables by removing the unnecessary prefix for scoped enum classes.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
