### PR TITLE
[Bug] [Java] Fix java compilation warnings in RFC3339JavaTimeModule and RFC3339InstantDeserializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/RFC3339InstantDeserializer.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/RFC3339InstantDeserializer.mustache
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 {{>generatedAnnotation}}
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/modules/openapi-generator/src/main/resources/Java/RFC3339JavaTimeModule.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/RFC3339JavaTimeModule.mustache
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 {{>generatedAnnotation}}
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/others/java/jersey2-oneOf-Mixed/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/others/java/jersey2-oneOf-Mixed/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/others/java/jersey2-oneOf-duplicates/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/others/java/jersey2-oneOf-duplicates/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/microprofile-rest-client-3.0-jackson-with-xml/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0-jackson-with-xml/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/microprofile-rest-client-3.0-jackson-with-xml/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0-jackson-with-xml/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/microprofile-rest-client-3.0-jackson/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0-jackson/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/microprofile-rest-client-3.0-jackson/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/microprofile-rest-client-3.0-jackson/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/vertx-supportVertxFuture/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/vertx-supportVertxFuture/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");

--- a/samples/server/petstore/java-microprofile/src/main/java/org/openapitools/server/RFC3339InstantDeserializer.java
+++ b/samples/server/petstore/java-microprofile/src/main/java/org/openapitools/server/RFC3339InstantDeserializer.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaMicroprofileServerCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339InstantDeserializer<T extends Temporal> extends InstantDeserializer<T> {
-
+    private static final long serialVersionUID = 1L;
     private final static boolean DEFAULT_NORMALIZE_ZONE_ID = JavaTimeFeature.NORMALIZE_DESERIALIZED_ZONE_ID.enabledByDefault();
     private final static boolean DEFAULT_ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS
     = JavaTimeFeature.ALWAYS_ALLOW_STRINGIFIED_DATE_TIMESTAMPS.enabledByDefault();

--- a/samples/server/petstore/java-microprofile/src/main/java/org/openapitools/server/RFC3339JavaTimeModule.java
+++ b/samples/server/petstore/java-microprofile/src/main/java/org/openapitools/server/RFC3339JavaTimeModule.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaMicroprofileServerCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class RFC3339JavaTimeModule extends SimpleModule {
+    private static final long serialVersionUID = 1L;
 
     public RFC3339JavaTimeModule() {
         super("RFC3339JavaTimeModule");


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #21242
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Mentions: @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg
