### PR TITLE
[kotlin-client] Add support for integer enums in serialization step

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -43,20 +43,45 @@ import kotlinx.serialization.*
 {{#allowableValues}}{{#enumVars}}
     {{^multiplatform}}
     {{#moshi}}
+    {{#isString}}
     @Json(name = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
+    {{/isString}}
+    {{^isString}}
+    @Json(name = {{{value}}})
+    {{/isString}}
     {{/moshi}}
     {{#gson}}
+    {{#isString}}
     @SerializedName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
+    {{/isString}}
+    {{^isString}}
+    @SerializedName(value = {{{value}}})
+    {{/isString}}
     {{/gson}}
     {{#jackson}}
+    {{#isString}}
     @JsonProperty(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
+    {{/isString}}
+    {{^isString}}
+    @JsonProperty(value = {{{value}}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
+    {{/isString}}
     {{/jackson}}
     {{#kotlinx_serialization}}
+    {{#isString}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
+    {{/isString}}
+    {{^isString}}
+    @SerialName(value = {{{value}}})
+    {{/isString}}
     {{/kotlinx_serialization}}
     {{/multiplatform}}
     {{#multiplatform}}
+    {{#isString}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
+    {{/isString}}
+    {{^isString}}
+    @SerialName(value = {{{value}}})
+    {{/isString}}
     {{/multiplatform}}
     {{#isArray}}
     {{#isList}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Following [this issue](https://github.com/OpenAPITools/openapi-generator/issues/21204), when using integer enums with the kotlin-client generator, the generated enum will look like this:
```kotlin
@Serializable
enum class SomeCode(val value: kotlin.Int) {
    @SerialName(value = "0")
    _0(0)
}
```
You can see the values of the enum members are not integers, they are strings (`value = "0"`).  
Using integer enums, it's should look like this:
```kotlin
@Serializable
enum class SomeCode(val value: kotlin.Int) {
    @SerialName(value = 0)
    _0(0),
}
```

## How to test

1. Create a `test.yml` file with the following content:
```yml
openapi: 3.0.3
info:
  title: Demo
  version: v1

components:
  schemas:
    Code:
      type: integer
      enum:
        - 0
        - 1
    StringCode:
      type: string
      enum:
        - hello
        - world

paths:
  /do:
    get:
      summary: Do something
      responses:
        200:
          description: Successful response
          content:
            application/json:
              schema:
                type: object
                required:
                  - code
                properties:
                  code:
                    $ref: '#/components/schemas/Code'
```
2. Create a `config.json` file to generate only relevant content with the following:
```json
{
  "modelPackage": "com.test",
  "generatorName": "kotlin",
  "enumPropertyNaming": "UPPERCASE",
  "additionalProperties": {
    "serializableModel": true,
    "omitGradleWrapper": true,
    "omitGradlePluginVersions": true
  },
  "globalProperties": {
    "apis": false,
    "models": "",
    "apiDocs": false,
    "modelDocs": false,
    "apiTests": false,
    "modelTests": false
  }
}
```
3. Build openapi on the head branch of this PR: `./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true`
4. Run the builded version against the files you've previously created: `java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -i test.yml -g kotlin -o out/ -c config.json`
5. See the generated code handling string enums (`StringCode.kt`) and integer enums (`Code.kt`)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


Hello all @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @e5l, could you take a look please? 😁