### PR TITLE
[Java] Make Java ApiClient extendable

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
@@ -65,9 +65,9 @@ import {{invokerPackage}}.auth.OAuth;
 
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "{{{basePath}}}";
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "{{{basePath}}}";
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}    new ServerConfiguration(
       "{{{url}}}",
@@ -95,18 +95,18 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   ){{/-last}}{{/servers}});
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private Client httpClient;
-  private ObjectMapper objectMapper;
+  protected Client httpClient;
+  protected ObjectMapper objectMapper;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     objectMapper = new ObjectMapper();
@@ -688,7 +688,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param collectionQueryParams The collection query parameters
    * @return The full URL
    */
-  private String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
+  protected String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
     String baseURL;
     if (serverIndex != null) {
       if (serverIndex < 0 || serverIndex >= servers.size()) {
@@ -741,7 +741,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return url.toString();
   }
 
-  private ClientResponse getAPIResponse(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames) throws ApiException {
+  protected ClientResponse getAPIResponse(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames) throws ApiException {
     if (body != null && !formParams.isEmpty()) {
       throw new ApiException(500, "Cannot have body and form params");
     }
@@ -854,7 +854,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param headerParams Header parameters
    * @param cookieParams Cookie parameters
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);
@@ -867,7 +867,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param formParams Form parameters
    * @return HTTP form encoded parameters
    */
-  private String getXWWWFormUrlencodedParams(Map<String, Object> formParams) {
+  protected String getXWWWFormUrlencodedParams(Map<String, Object> formParams) {
     StringBuilder formParamBuilder = new StringBuilder();
 
     for (Entry<String, Object> param : formParams.entrySet()) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -87,9 +87,9 @@ import {{invokerPackage}}.auth.OAuth;
 
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "{{{basePath}}}";
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "{{{basePath}}}";
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}    new ServerConfiguration(
       "{{{url}}}",
@@ -117,22 +117,22 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   ){{/-last}}{{/servers}});
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private CloseableHttpClient httpClient;
-  private ObjectMapper objectMapper;
+  protected CloseableHttpClient httpClient;
+  protected ObjectMapper objectMapper;
   protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
-  private Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
+  protected Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
+  protected Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   // Methods that can have a request body
-  private static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
+  protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
 
   public ApiClient(CloseableHttpClient httpClient) {
     objectMapper = new ObjectMapper();
@@ -757,7 +757,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Parse content type object from header value
    */
-  private ContentType getContentType(String headerValue) throws ApiException {
+  protected ContentType getContentType(String headerValue) throws ApiException {
     try {
       return ContentType.parse(headerValue);
     } catch (UnsupportedCharsetException e) {
@@ -768,7 +768,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Get content type of a response or null if one was not provided
    */
-  private String getResponseMimeType(HttpResponse response) throws ApiException {
+  protected String getResponseMimeType(HttpResponse response) throws ApiException {
     Header contentTypeHeader = response.getFirstHeader("Content-Type");
     if (contentTypeHeader != null) {
       return getContentType(contentTypeHeader.getValue()).getMimeType();
@@ -877,7 +877,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
   }
 
-  private File downloadFileFromResponse(CloseableHttpResponse response) throws IOException {
+  protected File downloadFileFromResponse(CloseableHttpResponse response) throws IOException {
     Header contentDispositionHeader = response.getFirstHeader("Content-Disposition");
     String contentDisposition = contentDispositionHeader == null ? null : contentDispositionHeader.getValue();
     File file = prepareDownloadFile(contentDisposition);
@@ -948,7 +948,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param urlQueryDeepObject URL query string of the deep object parameters
    * @return The full URL
    */
-  private String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams, String urlQueryDeepObject) {
+  protected String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams, String urlQueryDeepObject) {
     String baseURL = getBaseURL();
 
     final StringBuilder url = new StringBuilder();
@@ -1127,7 +1127,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param headerParams Header parameters
    * @param cookieParams Cookie parameters
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/ApiClient.mustache
@@ -54,16 +54,16 @@ import feign.Retryer;
 
 {{>generatedAnnotation}}
 public class ApiClient {
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   public interface Api {}
 
   {{#jackson}}
   protected ObjectMapper objectMapper;
   {{/jackson}}
-  private String basePath = "{{{basePath}}}";
-  private Map<String, RequestInterceptor> apiAuthorizations;
-  private Feign.Builder feignBuilder;
+  protected String basePath = "{{{basePath}}}";
+  protected Map<String, RequestInterceptor> apiAuthorizations;
+  protected Feign.Builder feignBuilder;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
@@ -167,7 +167,7 @@ public class ApiClient {
   }
 
   {{#jackson}}
-  private ObjectMapper createObjectMapper() {
+  protected ObjectMapper createObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
@@ -194,7 +194,7 @@ public class ApiClient {
   {{/jackson}}
 
   {{#hasOAuthMethods}}
-  private RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
+  protected RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
     switch (flow) {
       case PASSWORD:
         return new OauthPasswordGrant(tokenUrl, scopes);
@@ -375,7 +375,7 @@ public class ApiClient {
     feignBuilder.requestInterceptor(authorization);
   }
 
-  private <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
+  protected <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
     return (T) apiAuthorizations.values()
                                 .stream()
                                 .filter(requestInterceptor -> type.isAssignableFrom(requestInterceptor.getClass()))

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/ApiClient.mustache
@@ -25,14 +25,14 @@ import java.io.OutputStream;
 
 {{>generatedAnnotation}}
 public class ApiClient {
-    private final String basePath;
-    private final HttpRequestFactory httpRequestFactory;
-    private final ObjectMapper objectMapper;
+    protected final String basePath;
+    protected final HttpRequestFactory httpRequestFactory;
+    protected final ObjectMapper objectMapper;
 
-    private static final String defaultBasePath = "{{basePath}}";
+    protected static final String defaultBasePath = "{{basePath}}";
 
     // A reasonable default object mapper. Client can pass in a chosen ObjectMapper anyway, this is just for reasonable defaults.
-    private static ObjectMapper createDefaultObjectMapper() {
+    protected static ObjectMapper createDefaultObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper()
             {{#failOnUnknownProperties}}
             .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
@@ -84,7 +84,7 @@ public class ApiClient {
 
     public class JacksonJsonHttpContent extends AbstractHttpContent {
         /* A POJO that can be serialized with a com.fasterxml Jackson ObjectMapper */
-        private final Object data;
+        protected final Object data;
 
         public JacksonJsonHttpContent(Object data) {
             super(Json.MEDIA_TYPE);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -85,13 +85,13 @@ import {{invokerPackage}}.auth.OAuth;
  */
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "{{{basePath}}}";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}          new ServerConfiguration(
@@ -175,7 +175,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -373,14 +373,14 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
   {{#hasOAuthMethods}}
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -1029,7 +1029,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1350,7 +1350,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1412,7 +1412,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/ApiClient.mustache
@@ -85,13 +85,13 @@ import {{invokerPackage}}.auth.OAuth;
  */
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "{{{basePath}}}";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}          new ServerConfiguration(
@@ -175,7 +175,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -373,14 +373,14 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
   {{#hasOAuthMethods}}
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -1029,7 +1029,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1350,7 +1350,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1412,7 +1412,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -45,17 +45,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 {{>generatedAnnotation}}
 public class ApiClient {
 
-  private HttpClient.Builder builder;
-  private ObjectMapper mapper;
-  private String scheme;
-  private String host;
-  private int port;
-  private String basePath;
-  private Consumer<HttpRequest.Builder> interceptor;
-  private Consumer<HttpResponse<InputStream>> responseInterceptor;
-  private Consumer<HttpResponse<String>> asyncResponseInterceptor;
-  private Duration readTimeout;
-  private Duration connectTimeout;
+  protected HttpClient.Builder builder;
+  protected ObjectMapper mapper;
+  protected String scheme;
+  protected String host;
+  protected int port;
+  protected String basePath;
+  protected Consumer<HttpRequest.Builder> interceptor;
+  protected Consumer<HttpResponse<InputStream>> responseInterceptor;
+  protected Consumer<HttpResponse<String>> asyncResponseInterceptor;
+  protected Duration readTimeout;
+  protected Duration connectTimeout;
 
   public static String valueToString(Object value) {
     if (value == null) {
@@ -200,7 +200,7 @@ public class ApiClient {
     return mapper;
   }
 
-  private String getDefaultBaseUri() {
+  protected String getDefaultBaseUri() {
     return "{{{basePath}}}";
   }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -77,7 +77,7 @@ import {{invokerPackage}}.auth.AWS4Auth;
  */
 public class ApiClient {
 
-    private String basePath = "{{{basePath}}}";
+    protected String basePath = "{{{basePath}}}";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}    new ServerConfiguration(
       "{{{url}}}",
@@ -105,29 +105,29 @@ public class ApiClient {
   ){{/-last}}{{/servers}});
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     {{#dynamicOperations}}
-    private Map<String, ApiOperation> operationLookupMap = new HashMap<>();
+    protected Map<String, ApiOperation> operationLookupMap = new HashMap<>();
 
     {{/dynamicOperations}}
     /**
@@ -243,11 +243,11 @@ public class ApiClient {
     {{/-first}}
     {{/oauthMethods}}
     {{/hasOAuthMethods}}
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -261,7 +261,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1715,7 +1715,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1728,7 +1728,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1750,7 +1750,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1771,7 +1771,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1833,7 +1833,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1861,7 +1861,7 @@ public class ApiClient {
         return this;
     }
 
-    private void addOperationLookupEntry(String path, String method, Operation operation) {
+    protected void addOperationLookupEntry(String path, String method, Operation operation) {
         if ( operation != null && operation.getOperationId() != null) {
             operationLookupMap.put(
                     operation.getOperationId(),
@@ -1921,7 +1921,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws {{invokerPackage}}.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/ApiClient.mustache
@@ -19,9 +19,9 @@ public class ApiClient {
     public static final String BASE_URI = "{{.}}";
     {{/basePath}}
 
-    private final Config config;
+    protected final Config config;
 
-    private ApiClient(Config config) {
+    protected ApiClient(Config config) {
         this.config = config;
     }
 
@@ -38,7 +38,7 @@ public class ApiClient {
      {{/apiInfo}}
 
     public static class Config {
-        private Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
+        protected Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
                 {{#basePath}}.setBaseUri(BASE_URI){{/basePath}}
                 .setConfig(config().objectMapperConfig(objectMapperConfig().defaultObjectMapper({{#gson}}gson(){{/gson}}{{#jackson}}jackson(){{/jackson}})));
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -74,26 +74,26 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "{{basePath}}";
+    protected String basePath = "{{basePath}}";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -118,7 +118,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -626,7 +626,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -652,7 +652,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -728,7 +728,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/ApiClient.mustache
@@ -56,21 +56,21 @@ import {{invokerPackage}}.auth.OAuth;
 
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "{{{basePath}}}";
-  private boolean debugging = false;
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "{{{basePath}}}";
+  protected boolean debugging = false;
 
-  private Client httpClient;
-  private JSON json;
-  private String tempFolderPath = null;
+  protected Client httpClient;
+  protected JSON json;
+  protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     json = new JSON();
@@ -707,7 +707,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
   }
 
-  private Response invoke(Invocation.Builder invocationBuilder, String method, Entity<?> entity) throws ApiException {
+  protected Response invoke(Invocation.Builder invocationBuilder, String method, Entity<?> entity) throws ApiException {
     Response response = null;
 
     if ("GET".equals(method)) {
@@ -736,7 +736,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   /**
    * Build the Client used to make HTTP requests.
    */
-  private Client buildHttpClient(boolean debugging) {
+  protected Client buildHttpClient(boolean debugging) {
     final ClientConfiguration clientConfig = new ClientConfiguration(ResteasyProviderFactory.getInstance());
     clientConfig.register(json);
     if(debugging){
@@ -744,7 +744,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
     return ClientBuilder.newClient(clientConfig);
   }
-  private Map<String, List<String>> buildResponseHeaders(Response response) {
+  protected Map<String, List<String>> buildResponseHeaders(Response response) {
     Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
@@ -762,7 +762,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    *
    * @param authNames The authentications to apply
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -93,33 +93,33 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = {{maxAttemptsForRetry}};
+    protected int maxAttemptsForRetry = {{maxAttemptsForRetry}};
 
-    private long waitTimeMillis = {{waitTimeMillis}};
+    protected long waitTimeMillis = {{waitTimeMillis}};
 
-    private String basePath = "{{basePath}}";
+    protected String basePath = "{{basePath}}";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -852,7 +852,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -906,8 +906,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -917,21 +917,21 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -948,7 +948,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -95,7 +95,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/ApiClient.mustache
@@ -55,11 +55,11 @@ import java.util.HashMap;
 
 public class ApiClient {
 
-  private Map<String, Interceptor> apiAuthorizations;
-  private OkHttpClient.Builder okBuilder;
-  private Retrofit.Builder adapterBuilder;
-  private JSON json;
-  private OkHttpClient okHttpClient;
+  protected Map<String, Interceptor> apiAuthorizations;
+  protected OkHttpClient.Builder okBuilder;
+  protected Retrofit.Builder adapterBuilder;
+  protected JSON json;
+  protected OkHttpClient okHttpClient;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, Interceptor>();
@@ -426,8 +426,8 @@ public class ApiClient {
  * expected type is String, then just return the body string.
  */
 class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T> {
-  private final Gson gson;
-  private final Type type;
+  protected final Gson gson;
+  protected final Type type;
 
   GsonResponseBodyConverterToString(Gson gson, Type type) {
     this.gson = gson;
@@ -447,14 +447,14 @@ class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T>
 
 class GsonCustomConverterFactory extends Converter.Factory
 {
-  private final Gson gson;
-  private final GsonConverterFactory gsonConverterFactory;
+  protected final Gson gson;
+  protected final GsonConverterFactory gsonConverterFactory;
 
   public static GsonCustomConverterFactory create(Gson gson) {
     return new GsonCustomConverterFactory(gson);
   }
 
-  private GsonCustomConverterFactory(Gson gson) {
+  protected GsonCustomConverterFactory(Gson gson) {
     if (gson == null)
       throw new NullPointerException("gson == null");
     this.gson = gson;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play24/ApiClient.mustache
@@ -31,13 +31,13 @@ import {{invokerPackage}}.auth.Authentication;
 public class ApiClient {
 
     /** Underlying HTTP-client */
-    private WSClient wsClient;
+    protected WSClient wsClient;
 
     /** Supported auths */
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
     /** API base path */
-    private String basePath = "{{{basePath}}}";
+    protected String basePath = "{{{basePath}}}";
 
     public ApiClient(WSClient wsClient) {
         this();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play25/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play25/ApiClient.mustache
@@ -31,13 +31,13 @@ import {{invokerPackage}}.auth.Authentication;
 public class ApiClient {
 
     /** Underlying HTTP-client */
-    private WSClient wsClient;
+    protected WSClient wsClient;
 
     /** Supported auths */
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
     /** API base path */
-    private String basePath = "{{{basePath}}}";
+    protected String basePath = "{{{basePath}}}";
 
     public ApiClient(WSClient wsClient) {
         this();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/play26/ApiClient.mustache
@@ -37,22 +37,22 @@ import {{invokerPackage}}.auth.Authentication;
 public class ApiClient {
 
     /** Underlying HTTP-client */
-    private WSClient wsClient;
+    protected WSClient wsClient;
 
     /** Creates HTTP call instances */
-    private Play26CallFactory callFactory;
+    protected Play26CallFactory callFactory;
 
     /** Create {@link java.util.concurrent.CompletionStage} instances from HTTP calls */
-    private Play26CallAdapterFactory callAdapterFactory;
+    protected Play26CallAdapterFactory callAdapterFactory;
 
     /** Supported auths */
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
     /** API base path */
-    private String basePath = "{{{basePath}}}";
+    protected String basePath = "{{{basePath}}}";
 
     /** Default ObjectMapper */
-    private ObjectMapper defaultMapper;
+    protected ObjectMapper defaultMapper;
 
     public ApiClient(WSClient wsClient) {
         this();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -49,21 +49,21 @@ import static java.util.stream.Collectors.toMap;
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
-    private static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-    private static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
+    protected static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+    protected static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
 
-    private final Vertx vertx;
-    private final JsonObject config;
-    private final String identifier;
+    protected final Vertx vertx;
+    protected final JsonObject config;
+    protected final String identifier;
 
-    private MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
-    private MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
-    private Map<String, Authentication> authentications;
-    private String basePath = "{{{basePath}}}";
-    private DateFormat dateFormat;
-    private ObjectMapper objectMapper;
-    private String downloadsDir = "";
-    private int timeout = -1;
+    protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
+    protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
+    protected Map<String, Authentication> authentications;
+    protected String basePath = "{{{basePath}}}";
+    protected DateFormat dateFormat;
+    protected ObjectMapper objectMapper;
+    protected String downloadsDir = "";
+    protected int timeout = -1;
 
     public ApiClient(Vertx vertx, JsonObject config) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
@@ -385,7 +385,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param mime MIME
      * @return True if the MIME type is JSON
      */
-    private boolean isJsonMime(String mime) {
+    protected boolean isJsonMime(String mime) {
         String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
         return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
     }
@@ -523,7 +523,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
     }
 
-    private String buildCookieHeader(MultiMap cookies) {
+    protected String buildCookieHeader(MultiMap cookies) {
       final StringBuilder cookieValue = new StringBuilder();
       String delimiter = "";
       for (final Map.Entry<String, String> entry : cookies.entries()) {
@@ -680,7 +680,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
     public static class AuthInfo {
 
-        private final Map<String, Authentication> authentications = new LinkedHashMap<>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        protected final Map<String, Authentication> authentications = new LinkedHashMap<>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
 
         public void add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String username, String password) {
             HttpBasicAuth auth = new HttpBasicAuth();

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -89,28 +89,28 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "{{basePath}}";
+    protected String basePath = "{{basePath}}";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -135,7 +135,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -634,7 +634,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -660,7 +660,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -90,7 +90,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/ApiClient.mustache
@@ -76,9 +76,9 @@ import {{invokerPackage}}.auth.OAuth;
 
 {{>generatedAnnotation}}
 public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "{{{basePath}}}";
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "{{{basePath}}}";
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}    new ServerConfiguration(
       "{{{url}}}",
@@ -106,18 +106,18 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   ){{/-last}}{{/servers}});
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private Client httpClient;
-  private ObjectMapper objectMapper;
+  protected Client httpClient;
+  protected ObjectMapper objectMapper;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     objectMapper = new ObjectMapper();
@@ -706,7 +706,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param collectionQueryParams The collection query parameters
    * @return The full URL
    */
-  private String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
+  protected String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams) {
     String baseURL;
     if (serverIndex != null) {
       if (serverIndex < 0 || serverIndex >= servers.size()) {
@@ -759,7 +759,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return url.toString();
   }
 
-  private ClientResponse getAPIResponse(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames) throws ApiException {
+  protected ClientResponse getAPIResponse(String path, String method, List<Pair> queryParams, List<Pair> collectionQueryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames) throws ApiException {
     if (body != null && !formParams.isEmpty()) {
       throw new ApiException(500, "Cannot have body and form params");
     }
@@ -872,7 +872,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param headerParams Header parameters
    * @param cookieParams Cookie parameters
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);
@@ -885,7 +885,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @param formParams Form parameters
    * @return HTTP form encoded parameters
    */
-  private String getXWWWFormUrlencodedParams(Map<String, Object> formParams) {
+  protected String getXWWWFormUrlencodedParams(Map<String, Object> formParams) {
     StringBuilder formParamBuilder = new StringBuilder();
 
     for (Entry<String, Object> param : formParams.entrySet()) {

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/ApiClient.mustache
@@ -85,7 +85,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
   protected String basePath = "{{{basePath}}}";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>({{#servers}}{{#-first}}Arrays.asList(
 {{/-first}}    new ServerConfiguration(
@@ -158,7 +158,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -311,14 +311,14 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
   {{#hasOAuthMethods}}
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -1200,7 +1200,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -83,9 +83,9 @@ import org.openapitools.client.auth.HttpBearerAuth;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "http://localhost:3000";
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "http://localhost:3000";
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://localhost:3000",
@@ -95,22 +95,22 @@ public class ApiClient extends JavaTimeFormatter {
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private CloseableHttpClient httpClient;
-  private ObjectMapper objectMapper;
+  protected CloseableHttpClient httpClient;
+  protected ObjectMapper objectMapper;
   protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
-  private Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
+  protected Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
+  protected Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   // Methods that can have a request body
-  private static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
+  protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
 
   public ApiClient(CloseableHttpClient httpClient) {
     objectMapper = new ObjectMapper();
@@ -675,7 +675,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Parse content type object from header value
    */
-  private ContentType getContentType(String headerValue) throws ApiException {
+  protected ContentType getContentType(String headerValue) throws ApiException {
     try {
       return ContentType.parse(headerValue);
     } catch (UnsupportedCharsetException e) {
@@ -686,7 +686,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Get content type of a response or null if one was not provided
    */
-  private String getResponseMimeType(HttpResponse response) throws ApiException {
+  protected String getResponseMimeType(HttpResponse response) throws ApiException {
     Header contentTypeHeader = response.getFirstHeader("Content-Type");
     if (contentTypeHeader != null) {
       return getContentType(contentTypeHeader.getValue()).getMimeType();
@@ -795,7 +795,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private File downloadFileFromResponse(CloseableHttpResponse response) throws IOException {
+  protected File downloadFileFromResponse(CloseableHttpResponse response) throws IOException {
     Header contentDispositionHeader = response.getFirstHeader("Content-Disposition");
     String contentDisposition = contentDispositionHeader == null ? null : contentDispositionHeader.getValue();
     File file = prepareDownloadFile(contentDisposition);
@@ -866,7 +866,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param urlQueryDeepObject URL query string of the deep object parameters
    * @return The full URL
    */
-  private String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams, String urlQueryDeepObject) {
+  protected String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams, String urlQueryDeepObject) {
     String baseURL = getBaseURL();
 
     final StringBuilder url = new StringBuilder();
@@ -1045,7 +1045,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param headerParams Header parameters
    * @param cookieParams Cookie parameters
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -33,13 +33,13 @@ import org.openapitools.client.auth.ApiKeyAuth;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   public interface Api {}
 
-  private String basePath = "http://localhost:3000";
-  private Map<String, RequestInterceptor> apiAuthorizations;
-  private Feign.Builder feignBuilder;
+  protected String basePath = "http://localhost:3000";
+  protected Map<String, RequestInterceptor> apiAuthorizations;
+  protected Feign.Builder feignBuilder;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
@@ -219,7 +219,7 @@ public class ApiClient {
     feignBuilder.requestInterceptor(authorization);
   }
 
-  private <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
+  protected <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
     return (T) apiAuthorizations.values()
                                 .stream()
                                 .filter(requestInterceptor -> type.isAssignableFrom(requestInterceptor.getClass()))

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -54,17 +54,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
 
-  private HttpClient.Builder builder;
-  private ObjectMapper mapper;
-  private String scheme;
-  private String host;
-  private int port;
-  private String basePath;
-  private Consumer<HttpRequest.Builder> interceptor;
-  private Consumer<HttpResponse<InputStream>> responseInterceptor;
-  private Consumer<HttpResponse<String>> asyncResponseInterceptor;
-  private Duration readTimeout;
-  private Duration connectTimeout;
+  protected HttpClient.Builder builder;
+  protected ObjectMapper mapper;
+  protected String scheme;
+  protected String host;
+  protected int port;
+  protected String basePath;
+  protected Consumer<HttpRequest.Builder> interceptor;
+  protected Consumer<HttpResponse<InputStream>> responseInterceptor;
+  protected Consumer<HttpResponse<String>> asyncResponseInterceptor;
+  protected Duration readTimeout;
+  protected Duration connectTimeout;
 
   public static String valueToString(Object value) {
     if (value == null) {
@@ -207,7 +207,7 @@ public class ApiClient {
     return mapper;
   }
 
-  private String getDefaultBaseUri() {
+  protected String getDefaultBaseUri() {
     return "http://localhost:3000";
   }
 

--- a/samples/client/echo_api/java/okhttp-gson-user-defined-templates/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/okhttp-gson-user-defined-templates/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -195,11 +195,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -209,7 +209,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1530,7 +1530,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1543,7 +1543,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1565,7 +1565,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1586,7 +1586,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1648,7 +1648,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1665,7 +1665,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -61,7 +61,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 public class ApiClient {
 
-    private String basePath = "http://localhost:3000";
+    protected String basePath = "http://localhost:3000";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://localhost:3000",
@@ -71,26 +71,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -123,11 +123,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -137,7 +137,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1460,7 +1460,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1473,7 +1473,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1495,7 +1495,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1516,7 +1516,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1578,7 +1578,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1595,7 +1595,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -62,26 +62,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://localhost:3000";
+    protected String basePath = "http://localhost:3000";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -103,7 +103,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -580,7 +580,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -606,7 +606,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -682,7 +682,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
@@ -62,21 +62,21 @@ import org.openapitools.client.auth.ApiKeyAuth;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "http://localhost:3000";
-  private boolean debugging = false;
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "http://localhost:3000";
+  protected boolean debugging = false;
 
-  private Client httpClient;
-  private JSON json;
-  private String tempFolderPath = null;
+  protected Client httpClient;
+  protected JSON json;
+  protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     json = new JSON();
@@ -695,7 +695,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response invoke(Invocation.Builder invocationBuilder, String method, Entity<?> entity) throws ApiException {
+  protected Response invoke(Invocation.Builder invocationBuilder, String method, Entity<?> entity) throws ApiException {
     Response response = null;
 
     if ("GET".equals(method)) {
@@ -724,7 +724,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Build the Client used to make HTTP requests.
    */
-  private Client buildHttpClient(boolean debugging) {
+  protected Client buildHttpClient(boolean debugging) {
     final ClientConfiguration clientConfig = new ClientConfiguration(ResteasyProviderFactory.getInstance());
     clientConfig.register(json);
     if(debugging){
@@ -732,7 +732,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
     return ClientBuilder.newClient(clientConfig);
   }
-  private Map<String, List<String>> buildResponseHeaders(Response response) {
+  protected Map<String, List<String>> buildResponseHeaders(Response response) {
     Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
@@ -750,7 +750,7 @@ public class ApiClient extends JavaTimeFormatter {
    *
    * @param authNames The authentications to apply
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -78,33 +78,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://localhost:3000";
+    protected String basePath = "http://localhost:3000";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -770,7 +770,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -814,8 +814,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -825,21 +825,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -856,7 +856,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -80,7 +80,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/others/java/jersey2-oneOf-Mixed/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/jersey2-oneOf-Mixed/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,13 +85,13 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://api.example.xyz/v1";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -108,7 +108,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -262,7 +262,7 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
@@ -808,7 +808,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1106,7 +1106,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1168,7 +1168,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/client/others/java/jersey2-oneOf-duplicates/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/jersey2-oneOf-duplicates/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,13 +85,13 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://api.example.xyz/v1";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -108,7 +108,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -262,7 +262,7 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
@@ -808,7 +808,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1106,7 +1106,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1168,7 +1168,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/client/others/java/okhttp-gson-oneOf-array/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/src/main/java/org/openapitools/client/ApiClient.java
@@ -61,7 +61,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 public class ApiClient {
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "",
@@ -71,26 +71,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -119,11 +119,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -133,7 +133,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1434,7 +1434,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1447,7 +1447,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1469,7 +1469,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1490,7 +1490,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1552,7 +1552,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1569,7 +1569,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/ApiClient.java
@@ -61,7 +61,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 public class ApiClient {
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "",
@@ -71,26 +71,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -119,11 +119,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -133,7 +133,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1434,7 +1434,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1447,7 +1447,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1469,7 +1469,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1490,7 +1490,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1552,7 +1552,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1569,7 +1569,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiClient.java
@@ -61,7 +61,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 public class ApiClient {
 
-    private String basePath = "http://localhost:8082";
+    protected String basePath = "http://localhost:8082";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://localhost:8082",
@@ -71,26 +71,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -119,11 +119,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -133,7 +133,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1457,7 +1457,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1470,7 +1470,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1492,7 +1492,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1513,7 +1513,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1575,7 +1575,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1592,7 +1592,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -62,26 +62,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -103,7 +103,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -578,7 +578,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -604,7 +604,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -680,7 +680,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/ApiClient.java
@@ -76,33 +76,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://api.example.xyz/v1";
+    protected String basePath = "http://api.example.xyz/v1";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -713,7 +713,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -757,8 +757,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -768,21 +768,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -799,7 +799,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-list-schema-validation/src/main/java/org/openapitools/client/ApiClient.java
@@ -78,7 +78,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -76,33 +76,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -713,7 +713,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -757,8 +757,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -768,21 +768,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -799,7 +799,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -78,7 +78,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,7 +85,7 @@ public class ApiClient extends JavaTimeFormatter {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -84,28 +84,28 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -127,7 +127,7 @@ public class ApiClient extends JavaTimeFormatter {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -604,7 +604,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -630,7 +630,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/samples/client/petstore/java-helidon-client/v3/se/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java-helidon-client/v3/se/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class ApiClient {
 
-  protected final WebClient webClient;
+  private final WebClient webClient;
 
   /**
    * @return a {@code Builder} for an {@code ApiClient}
@@ -134,7 +134,7 @@ public class ApiClient {
     return Collections.singletonList(new Pair(urlEncode(name), joiner.toString()));
   }
 
-  protected ApiClient(Builder builder) {
+  private ApiClient(Builder builder) {
     webClient = builder.webClientBuilder().build();
   }
 
@@ -147,7 +147,7 @@ public class ApiClient {
     return webClient;
   }
 
-  protected static String valueToString(Object value) {
+  private static String valueToString(Object value) {
     if (value == null) {
       return "";
     }
@@ -167,9 +167,9 @@ public class ApiClient {
     */
   public static class Builder {
 
-    protected WebClient.Builder webClientBuilder;
-    protected Config clientConfig;
-    protected ObjectMapper objectMapper;
+    private WebClient.Builder webClientBuilder;
+    private Config clientConfig;
+    private ObjectMapper objectMapper;
 
     public ApiClient build() {
       return new ApiClient(this);
@@ -221,7 +221,7 @@ public class ApiClient {
       return this;
     }
 
-    protected WebClient.Builder defaultWebClientBuilder() {
+    private WebClient.Builder defaultWebClientBuilder() {
       WebClient.Builder defaultWebClientBuilder = WebClient.builder()
                   .baseUri("http://petstore.swagger.io:80/v2")
                   .config(clientConfig());
@@ -231,7 +231,7 @@ public class ApiClient {
       return defaultWebClientBuilder;
     }
 
-    protected Config clientConfig() {
+    private Config clientConfig() {
       if (clientConfig == null) {
          clientConfig = Config.create().get("client");
       }

--- a/samples/client/petstore/java-helidon-client/v3/se/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java-helidon-client/v3/se/src/main/java/org/openapitools/client/ApiClient.java
@@ -41,7 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class ApiClient {
 
-  private final WebClient webClient;
+  protected final WebClient webClient;
 
   /**
    * @return a {@code Builder} for an {@code ApiClient}
@@ -134,7 +134,7 @@ public class ApiClient {
     return Collections.singletonList(new Pair(urlEncode(name), joiner.toString()));
   }
 
-  private ApiClient(Builder builder) {
+  protected ApiClient(Builder builder) {
     webClient = builder.webClientBuilder().build();
   }
 
@@ -147,7 +147,7 @@ public class ApiClient {
     return webClient;
   }
 
-  private static String valueToString(Object value) {
+  protected static String valueToString(Object value) {
     if (value == null) {
       return "";
     }
@@ -167,9 +167,9 @@ public class ApiClient {
     */
   public static class Builder {
 
-    private WebClient.Builder webClientBuilder;
-    private Config clientConfig;
-    private ObjectMapper objectMapper;
+    protected WebClient.Builder webClientBuilder;
+    protected Config clientConfig;
+    protected ObjectMapper objectMapper;
 
     public ApiClient build() {
       return new ApiClient(this);
@@ -221,7 +221,7 @@ public class ApiClient {
       return this;
     }
 
-    private WebClient.Builder defaultWebClientBuilder() {
+    protected WebClient.Builder defaultWebClientBuilder() {
       WebClient.Builder defaultWebClientBuilder = WebClient.builder()
                   .baseUri("http://petstore.swagger.io:80/v2")
                   .config(clientConfig());
@@ -231,7 +231,7 @@ public class ApiClient {
       return defaultWebClientBuilder;
     }
 
-    private Config clientConfig() {
+    protected Config clientConfig() {
       if (clientConfig == null) {
          clientConfig = Config.create().get("client");
       }

--- a/samples/client/petstore/java-helidon-client/v4/se/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java-helidon-client/v4/se/src/main/java/org/openapitools/client/ApiClient.java
@@ -42,7 +42,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class ApiClient {
 
-  private final WebClient webClient;
+  protected final WebClient webClient;
 
   /**
    * @return a {@code Builder} for an {@code ApiClient}
@@ -135,7 +135,7 @@ public class ApiClient {
     return Collections.singletonList(new Pair(urlEncode(name), joiner.toString()));
   }
 
-  private ApiClient(Builder builder) {
+  protected ApiClient(Builder builder) {
     webClient = builder.webClientBuilder().build();
   }
 
@@ -148,7 +148,7 @@ public class ApiClient {
     return webClient;
   }
 
-  private static String valueToString(Object value) {
+  protected static String valueToString(Object value) {
     if (value == null) {
       return "";
     }
@@ -168,9 +168,9 @@ public class ApiClient {
     */
   public static class Builder {
 
-    private WebClientConfig.Builder webClientBuilder;
-    private Config clientConfig;
-    private ObjectMapper objectMapper;
+    protected WebClientConfig.Builder webClientBuilder;
+    protected Config clientConfig;
+    protected ObjectMapper objectMapper;
 
     public ApiClient build() {
       return new ApiClient(this);
@@ -222,7 +222,7 @@ public class ApiClient {
       return this;
     }
 
-    private WebClientConfig.Builder defaultWebClientBuilder() {
+    protected WebClientConfig.Builder defaultWebClientBuilder() {
       WebClientConfig.Builder defaultWebClientBuilder = WebClient.builder()
                   .baseUri("http://petstore.swagger.io:80/v2")
                   .config(clientConfig());
@@ -232,7 +232,7 @@ public class ApiClient {
       return defaultWebClientBuilder;
     }
 
-    private Config clientConfig() {
+    protected Config clientConfig() {
       if (clientConfig == null) {
          clientConfig = Config.create().get("client");
       }

--- a/samples/client/petstore/java-helidon-client/v4/se/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java-helidon-client/v4/se/src/main/java/org/openapitools/client/ApiClient.java
@@ -42,7 +42,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class ApiClient {
 
-  protected final WebClient webClient;
+  private final WebClient webClient;
 
   /**
    * @return a {@code Builder} for an {@code ApiClient}
@@ -135,7 +135,7 @@ public class ApiClient {
     return Collections.singletonList(new Pair(urlEncode(name), joiner.toString()));
   }
 
-  protected ApiClient(Builder builder) {
+  private ApiClient(Builder builder) {
     webClient = builder.webClientBuilder().build();
   }
 
@@ -148,7 +148,7 @@ public class ApiClient {
     return webClient;
   }
 
-  protected static String valueToString(Object value) {
+  private static String valueToString(Object value) {
     if (value == null) {
       return "";
     }
@@ -168,9 +168,9 @@ public class ApiClient {
     */
   public static class Builder {
 
-    protected WebClientConfig.Builder webClientBuilder;
-    protected Config clientConfig;
-    protected ObjectMapper objectMapper;
+    private WebClientConfig.Builder webClientBuilder;
+    private Config clientConfig;
+    private ObjectMapper objectMapper;
 
     public ApiClient build() {
       return new ApiClient(this);
@@ -222,7 +222,7 @@ public class ApiClient {
       return this;
     }
 
-    protected WebClientConfig.Builder defaultWebClientBuilder() {
+    private WebClientConfig.Builder defaultWebClientBuilder() {
       WebClientConfig.Builder defaultWebClientBuilder = WebClient.builder()
                   .baseUri("http://petstore.swagger.io:80/v2")
                   .config(clientConfig());
@@ -232,7 +232,7 @@ public class ApiClient {
       return defaultWebClientBuilder;
     }
 
-    protected Config clientConfig() {
+    private Config clientConfig() {
       if (clientConfig == null) {
          clientConfig = Config.create().get("client");
       }

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,9 +85,9 @@ import org.openapitools.client.auth.OAuth;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io:80/v2";
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "http://petstore.swagger.io:80/v2";
   protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://{server}.swagger.io:{port}/v2",
@@ -140,22 +140,22 @@ public class ApiClient extends JavaTimeFormatter {
   ));
   protected Integer serverIndex = 0;
   protected Map<String, String> serverVariables = null;
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private CloseableHttpClient httpClient;
-  private ObjectMapper objectMapper;
+  protected CloseableHttpClient httpClient;
+  protected ObjectMapper objectMapper;
   protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
-  private Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
+  protected Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
+  protected Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   // Methods that can have a request body
-  private static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
+  protected static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
 
   public ApiClient(CloseableHttpClient httpClient) {
     objectMapper = new ObjectMapper();
@@ -768,7 +768,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Parse content type object from header value
    */
-  private ContentType getContentType(String headerValue) throws ApiException {
+  protected ContentType getContentType(String headerValue) throws ApiException {
     try {
       return ContentType.parse(headerValue);
     } catch (UnsupportedCharsetException e) {
@@ -779,7 +779,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Get content type of a response or null if one was not provided
    */
-  private String getResponseMimeType(HttpResponse response) throws ApiException {
+  protected String getResponseMimeType(HttpResponse response) throws ApiException {
     Header contentTypeHeader = response.getFirstHeader("Content-Type");
     if (contentTypeHeader != null) {
       return getContentType(contentTypeHeader.getValue()).getMimeType();
@@ -888,7 +888,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private File downloadFileFromResponse(CloseableHttpResponse response) throws IOException {
+  protected File downloadFileFromResponse(CloseableHttpResponse response) throws IOException {
     Header contentDispositionHeader = response.getFirstHeader("Content-Disposition");
     String contentDisposition = contentDispositionHeader == null ? null : contentDispositionHeader.getValue();
     File file = prepareDownloadFile(contentDisposition);
@@ -959,7 +959,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param urlQueryDeepObject URL query string of the deep object parameters
    * @return The full URL
    */
-  private String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams, String urlQueryDeepObject) {
+  protected String buildUrl(String path, List<Pair> queryParams, List<Pair> collectionQueryParams, String urlQueryDeepObject) {
     String baseURL = getBaseURL();
 
     final StringBuilder url = new StringBuilder();
@@ -1138,7 +1138,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param headerParams Header parameters
    * @param cookieParams Cookie parameters
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign-hc5/src/main/java/org/openapitools/client/ApiClient.java
@@ -46,14 +46,14 @@ import feign.Retryer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   public interface Api {}
 
   protected ObjectMapper objectMapper;
-  private String basePath = "http://petstore.swagger.io:80/v2";
-  private Map<String, RequestInterceptor> apiAuthorizations;
-  private Feign.Builder feignBuilder;
+  protected String basePath = "http://petstore.swagger.io:80/v2";
+  protected Map<String, RequestInterceptor> apiAuthorizations;
+  protected Feign.Builder feignBuilder;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
@@ -135,7 +135,7 @@ public class ApiClient {
     return this;
   }
 
-  private ObjectMapper createObjectMapper() {
+  protected ObjectMapper createObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
@@ -150,7 +150,7 @@ public class ApiClient {
     return objectMapper;
   }
 
-  private RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
+  protected RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
     switch (flow) {
       case PASSWORD:
         return new OauthPasswordGrant(tokenUrl, scopes);
@@ -326,7 +326,7 @@ public class ApiClient {
     feignBuilder.requestInterceptor(authorization);
   }
 
-  private <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
+  protected <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
     return (T) apiAuthorizations.values()
                                 .stream()
                                 .filter(requestInterceptor -> type.isAssignableFrom(requestInterceptor.getClass()))

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
@@ -45,14 +45,14 @@ import feign.Retryer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   public interface Api {}
 
   protected ObjectMapper objectMapper;
-  private String basePath = "http://petstore.swagger.io:80/v2";
-  private Map<String, RequestInterceptor> apiAuthorizations;
-  private Feign.Builder feignBuilder;
+  protected String basePath = "http://petstore.swagger.io:80/v2";
+  protected Map<String, RequestInterceptor> apiAuthorizations;
+  protected Feign.Builder feignBuilder;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
@@ -131,7 +131,7 @@ public class ApiClient {
     return this;
   }
 
-  private ObjectMapper createObjectMapper() {
+  protected ObjectMapper createObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
@@ -144,7 +144,7 @@ public class ApiClient {
     return objectMapper;
   }
 
-  private RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
+  protected RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
     switch (flow) {
       case PASSWORD:
         return new OauthPasswordGrant(tokenUrl, scopes);
@@ -320,7 +320,7 @@ public class ApiClient {
     feignBuilder.requestInterceptor(authorization);
   }
 
-  private <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
+  protected <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
     return (T) apiAuthorizations.values()
                                 .stream()
                                 .filter(requestInterceptor -> type.isAssignableFrom(requestInterceptor.getClass()))

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/ApiClient.java
@@ -46,14 +46,14 @@ import feign.Retryer;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   public interface Api {}
 
   protected ObjectMapper objectMapper;
-  private String basePath = "http://petstore.swagger.io:80/v2";
-  private Map<String, RequestInterceptor> apiAuthorizations;
-  private Feign.Builder feignBuilder;
+  protected String basePath = "http://petstore.swagger.io:80/v2";
+  protected Map<String, RequestInterceptor> apiAuthorizations;
+  protected Feign.Builder feignBuilder;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, RequestInterceptor>();
@@ -135,7 +135,7 @@ public class ApiClient {
     return this;
   }
 
-  private ObjectMapper createObjectMapper() {
+  protected ObjectMapper createObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
     objectMapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
@@ -150,7 +150,7 @@ public class ApiClient {
     return objectMapper;
   }
 
-  private RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
+  protected RequestInterceptor buildOauthRequestInterceptor(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
     switch (flow) {
       case PASSWORD:
         return new OauthPasswordGrant(tokenUrl, scopes);
@@ -326,7 +326,7 @@ public class ApiClient {
     feignBuilder.requestInterceptor(authorization);
   }
 
-  private <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
+  protected <T extends RequestInterceptor> T getAuthorization(Class<T> type) {
     return (T) apiAuthorizations.values()
                                 .stream()
                                 .filter(requestInterceptor -> type.isAssignableFrom(requestInterceptor.getClass()))

--- a/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/google-api-client/src/main/java/org/openapitools/client/ApiClient.java
@@ -31,14 +31,14 @@ import java.io.OutputStream;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
-    private final String basePath;
-    private final HttpRequestFactory httpRequestFactory;
-    private final ObjectMapper objectMapper;
+    protected final String basePath;
+    protected final HttpRequestFactory httpRequestFactory;
+    protected final ObjectMapper objectMapper;
 
-    private static final String defaultBasePath = "http://petstore.swagger.io:80/v2";
+    protected static final String defaultBasePath = "http://petstore.swagger.io:80/v2";
 
     // A reasonable default object mapper. Client can pass in a chosen ObjectMapper anyway, this is just for reasonable defaults.
-    private static ObjectMapper createDefaultObjectMapper() {
+    protected static ObjectMapper createDefaultObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -80,7 +80,7 @@ public class ApiClient {
 
     public class JacksonJsonHttpContent extends AbstractHttpContent {
         /* A POJO that can be serialized with a com.fasterxml Jackson ObjectMapper */
-        private final Object data;
+        protected final Object data;
 
         public JacksonJsonHttpContent(Object data) {
             super(Json.MEDIA_TYPE);

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiClient.java
@@ -87,13 +87,13 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -110,7 +110,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -297,13 +297,13 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -949,7 +949,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1263,7 +1263,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1325,7 +1325,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -87,13 +87,13 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -110,7 +110,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -297,13 +297,13 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -949,7 +949,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1263,7 +1263,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1325,7 +1325,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3-oneOf/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,13 +85,13 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://localhost";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -108,7 +108,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -262,7 +262,7 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
@@ -808,7 +808,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1106,7 +1106,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1168,7 +1168,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiClient.java
@@ -88,13 +88,13 @@ import org.openapitools.client.auth.OAuth;
  */
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -178,7 +178,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -379,13 +379,13 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -1031,7 +1031,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1345,7 +1345,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1407,7 +1407,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
@@ -54,17 +54,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
 
-  private HttpClient.Builder builder;
-  private ObjectMapper mapper;
-  private String scheme;
-  private String host;
-  private int port;
-  private String basePath;
-  private Consumer<HttpRequest.Builder> interceptor;
-  private Consumer<HttpResponse<InputStream>> responseInterceptor;
-  private Consumer<HttpResponse<String>> asyncResponseInterceptor;
-  private Duration readTimeout;
-  private Duration connectTimeout;
+  protected HttpClient.Builder builder;
+  protected ObjectMapper mapper;
+  protected String scheme;
+  protected String host;
+  protected int port;
+  protected String basePath;
+  protected Consumer<HttpRequest.Builder> interceptor;
+  protected Consumer<HttpResponse<InputStream>> responseInterceptor;
+  protected Consumer<HttpResponse<String>> asyncResponseInterceptor;
+  protected Duration readTimeout;
+  protected Duration connectTimeout;
 
   public static String valueToString(Object value) {
     if (value == null) {
@@ -207,7 +207,7 @@ public class ApiClient {
     return mapper;
   }
 
-  private String getDefaultBaseUri() {
+  protected String getDefaultBaseUri() {
     return "http://petstore.swagger.io:80/v2";
   }
 

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -54,17 +54,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
 
-  private HttpClient.Builder builder;
-  private ObjectMapper mapper;
-  private String scheme;
-  private String host;
-  private int port;
-  private String basePath;
-  private Consumer<HttpRequest.Builder> interceptor;
-  private Consumer<HttpResponse<InputStream>> responseInterceptor;
-  private Consumer<HttpResponse<String>> asyncResponseInterceptor;
-  private Duration readTimeout;
-  private Duration connectTimeout;
+  protected HttpClient.Builder builder;
+  protected ObjectMapper mapper;
+  protected String scheme;
+  protected String host;
+  protected int port;
+  protected String basePath;
+  protected Consumer<HttpRequest.Builder> interceptor;
+  protected Consumer<HttpResponse<InputStream>> responseInterceptor;
+  protected Consumer<HttpResponse<String>> asyncResponseInterceptor;
+  protected Duration readTimeout;
+  protected Duration connectTimeout;
 
   public static String valueToString(Object value) {
     if (value == null) {
@@ -207,7 +207,7 @@ public class ApiClient {
     return mapper;
   }
 
-  private String getDefaultBaseUri() {
+  protected String getDefaultBaseUri() {
     return "http://petstore.swagger.io/v2";
   }
 

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -54,17 +54,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient {
 
-  private HttpClient.Builder builder;
-  private ObjectMapper mapper;
-  private String scheme;
-  private String host;
-  private int port;
-  private String basePath;
-  private Consumer<HttpRequest.Builder> interceptor;
-  private Consumer<HttpResponse<InputStream>> responseInterceptor;
-  private Consumer<HttpResponse<String>> asyncResponseInterceptor;
-  private Duration readTimeout;
-  private Duration connectTimeout;
+  protected HttpClient.Builder builder;
+  protected ObjectMapper mapper;
+  protected String scheme;
+  protected String host;
+  protected int port;
+  protected String basePath;
+  protected Consumer<HttpRequest.Builder> interceptor;
+  protected Consumer<HttpResponse<InputStream>> responseInterceptor;
+  protected Consumer<HttpResponse<String>> asyncResponseInterceptor;
+  protected Duration readTimeout;
+  protected Duration connectTimeout;
 
   public static String valueToString(Object value) {
     if (value == null) {
@@ -207,7 +207,7 @@ public class ApiClient {
     return mapper;
   }
 
-  private String getDefaultBaseUri() {
+  protected String getDefaultBaseUri() {
     return "http://petstore.swagger.io:80/v2";
   }
 

--- a/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1-duplicated-operationid/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -195,11 +195,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -209,7 +209,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1530,7 +1530,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1543,7 +1543,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1565,7 +1565,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1586,7 +1586,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1648,7 +1648,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1665,7 +1665,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -195,11 +195,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -209,7 +209,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1530,7 +1530,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1543,7 +1543,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1565,7 +1565,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1586,7 +1586,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1648,7 +1648,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1665,7 +1665,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiClient.java
@@ -67,7 +67,7 @@ import org.openapitools.client.auth.AWS4Auth;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -77,26 +77,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -199,11 +199,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -213,7 +213,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1550,7 +1550,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1563,7 +1563,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1585,7 +1585,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1606,7 +1606,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1668,7 +1668,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1685,7 +1685,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
@@ -72,7 +72,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io:80/v2",
@@ -82,28 +82,28 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
-    private Map<String, ApiOperation> operationLookupMap = new HashMap<>();
+    protected Map<String, ApiOperation> operationLookupMap = new HashMap<>();
 
     /**
      * Basic constructor for ApiClient
@@ -209,11 +209,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -223,7 +223,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1535,7 +1535,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1548,7 +1548,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1570,7 +1570,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1591,7 +1591,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1653,7 +1653,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1680,7 +1680,7 @@ public class ApiClient {
         return this;
     }
 
-    private void addOperationLookupEntry(String path, String method, Operation operation) {
+    protected void addOperationLookupEntry(String path, String method, Operation operation) {
         if ( operation != null && operation.getOperationId() != null) {
             operationLookupMap.put(
                     operation.getOperationId(),
@@ -1739,7 +1739,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -195,11 +195,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -209,7 +209,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1530,7 +1530,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1543,7 +1543,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1565,7 +1565,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1586,7 +1586,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1648,7 +1648,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1665,7 +1665,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -198,11 +198,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -212,7 +212,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1533,7 +1533,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1546,7 +1546,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1568,7 +1568,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1589,7 +1589,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1651,7 +1651,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1668,7 +1668,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io:80/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -201,11 +201,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -215,7 +215,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1536,7 +1536,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1549,7 +1549,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1571,7 +1571,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1592,7 +1592,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1654,7 +1654,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1671,7 +1671,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -195,11 +195,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -209,7 +209,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1530,7 +1530,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1543,7 +1543,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1565,7 +1565,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1586,7 +1586,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1648,7 +1648,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1665,7 +1665,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://petstore.swagger.io/v2",
@@ -76,26 +76,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -195,11 +195,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -209,7 +209,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1530,7 +1530,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1543,7 +1543,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1565,7 +1565,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1586,7 +1586,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1648,7 +1648,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1665,7 +1665,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -66,7 +66,7 @@ import org.openapitools.client.auth.OAuthFlow;
  */
 public class ApiClient {
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
     protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>(Arrays.asList(
     new ServerConfiguration(
       "http://{server}.swagger.io:{port}/v2",
@@ -119,26 +119,26 @@ public class ApiClient {
   ));
     protected Integer serverIndex = 0;
     protected Map<String, String> serverVariables = null;
-    private boolean debugging = false;
-    private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-    private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-    private String tempFolderPath = null;
+    protected boolean debugging = false;
+    protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+    protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+    protected String tempFolderPath = null;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
-    private DateFormat datetimeFormat;
-    private boolean lenientDatetimeFormat;
-    private int dateLength;
+    protected DateFormat dateFormat;
+    protected DateFormat datetimeFormat;
+    protected boolean lenientDatetimeFormat;
+    protected int dateLength;
 
-    private InputStream sslCaCert;
-    private boolean verifyingSsl;
-    private KeyManager[] keyManagers;
+    protected InputStream sslCaCert;
+    protected boolean verifyingSsl;
+    protected KeyManager[] keyManagers;
 
-    private OkHttpClient httpClient;
-    private JSON json;
+    protected OkHttpClient httpClient;
+    protected JSON json;
 
-    private HttpLoggingInterceptor loggingInterceptor;
+    protected HttpLoggingInterceptor loggingInterceptor;
 
     /**
      * Basic constructor for ApiClient
@@ -247,11 +247,11 @@ public class ApiClient {
         authentications = Collections.unmodifiableMap(authentications);
     }
 
-    private void initHttpClient() {
+    protected void initHttpClient() {
         initHttpClient(Collections.<Interceptor>emptyList());
     }
 
-    private void initHttpClient(List<Interceptor> interceptors) {
+    protected void initHttpClient(List<Interceptor> interceptors) {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.addNetworkInterceptor(getProgressInterceptor());
         for (Interceptor interceptor: interceptors) {
@@ -261,7 +261,7 @@ public class ApiClient {
         httpClient = builder.build();
     }
 
-    private void init() {
+    protected void init() {
         verifyingSsl = true;
 
         json = new JSON();
@@ -1604,7 +1604,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param file The file to add to the Header
      */ 
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, File file) {
         Headers partHeaders = Headers.of("Content-Disposition", "form-data; name=\"" + key + "\"; filename=\"" + file.getName() + "\"");
         MediaType mediaType = MediaType.parse(guessContentTypeFromFile(file));
         mpBuilder.addPart(partHeaders, RequestBody.create(file, mediaType));
@@ -1617,7 +1617,7 @@ public class ApiClient {
      * @param key The key of the Header element
      * @param obj The complex object to add to the Header
      */
-    private void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
+    protected void addPartToMultiPartBuilder(MultipartBody.Builder mpBuilder, String key, Object obj) {
         RequestBody requestBody;
         if (obj instanceof String) {
             requestBody = RequestBody.create((String) obj, MediaType.parse("text/plain"));
@@ -1639,7 +1639,7 @@ public class ApiClient {
      * Get network interceptor to add it to the httpClient to track download progress for
      * async requests.
      */
-    private Interceptor getProgressInterceptor() {
+    protected Interceptor getProgressInterceptor() {
         return new Interceptor() {
             @Override
             public Response intercept(Interceptor.Chain chain) throws IOException {
@@ -1660,7 +1660,7 @@ public class ApiClient {
      * Apply SSL related settings to httpClient according to the current values of
      * verifyingSsl and sslCaCert.
      */
-    private void applySslSettings() {
+    protected void applySslSettings() {
         try {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
@@ -1722,7 +1722,7 @@ public class ApiClient {
         }
     }
 
-    private KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
+    protected KeyStore newEmptyKeyStore(char[] password) throws GeneralSecurityException {
         try {
             KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(null, password);
@@ -1739,7 +1739,7 @@ public class ApiClient {
      * @return The string representation of the HTTP request body
      * @throws org.openapitools.client.ApiException If fail to serialize the request body object into a string
      */
-    private String requestBodyToString(RequestBody requestBody) throws ApiException {
+    protected String requestBodyToString(RequestBody requestBody) throws ApiException {
         if (requestBody != null) {
             try {
                 final Buffer buffer = new Buffer();

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/ApiClient.java
@@ -26,9 +26,9 @@ import static org.openapitools.client.JacksonObjectMapper.jackson;
 public class ApiClient {
     public static final String BASE_URI = "http://petstore.swagger.io:80/v2";
 
-    private final Config config;
+    protected final Config config;
 
-    private ApiClient(Config config) {
+    protected ApiClient(Config config) {
         this.config = config;
     }
 
@@ -56,7 +56,7 @@ public class ApiClient {
     }
 
     public static class Config {
-        private Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
+        protected Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
                 .setBaseUri(BASE_URI)
                 .setConfig(config().objectMapperConfig(objectMapperConfig().defaultObjectMapper(jackson())));
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/ApiClient.java
@@ -26,9 +26,9 @@ import static org.openapitools.client.GsonObjectMapper.gson;
 public class ApiClient {
     public static final String BASE_URI = "http://petstore.swagger.io:80/v2";
 
-    private final Config config;
+    protected final Config config;
 
-    private ApiClient(Config config) {
+    protected ApiClient(Config config) {
         this.config = config;
     }
 
@@ -56,7 +56,7 @@ public class ApiClient {
     }
 
     public static class Config {
-        private Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
+        protected Supplier<RequestSpecBuilder> reqSpecSupplier = () -> new RequestSpecBuilder()
                 .setBaseUri(BASE_URI)
                 .setConfig(config().objectMapperConfig(objectMapperConfig().defaultObjectMapper(gson())));
 

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -62,26 +62,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -103,7 +103,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -578,7 +578,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -604,7 +604,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -680,7 +680,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -63,26 +63,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -104,7 +104,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -598,7 +598,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -700,7 +700,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ApiClient.java
@@ -63,26 +63,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -104,7 +104,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -598,7 +598,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -700,7 +700,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -63,26 +63,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -104,7 +104,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -598,7 +598,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -700,7 +700,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -63,26 +63,26 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
         CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private final HttpHeaders defaultHeaders = new HttpHeaders();
-    private final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
+    protected final HttpHeaders defaultHeaders = new HttpHeaders();
+    protected final MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final RestClient restClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final RestClient restClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -104,7 +104,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.init();
     }
 
-    private ApiClient(RestClient restClient, DateFormat format) {
+    protected ApiClient(RestClient restClient, DateFormat format) {
         this(restClient, createDefaultObjectMapper(format), format);
     }
 
@@ -598,7 +598,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected RestClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {
@@ -700,7 +700,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiClient.java
@@ -63,21 +63,21 @@ import org.openapitools.client.auth.OAuth;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private Map<String, String> defaultCookieMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io:80/v2";
-  private boolean debugging = false;
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected Map<String, String> defaultCookieMap = new HashMap<String, String>();
+  protected String basePath = "http://petstore.swagger.io:80/v2";
+  protected boolean debugging = false;
 
-  private Client httpClient;
-  private JSON json;
-  private String tempFolderPath = null;
+  protected Client httpClient;
+  protected JSON json;
+  protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     json = new JSON();
@@ -713,7 +713,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response invoke(Invocation.Builder invocationBuilder, String method, Entity<?> entity) throws ApiException {
+  protected Response invoke(Invocation.Builder invocationBuilder, String method, Entity<?> entity) throws ApiException {
     Response response = null;
 
     if ("GET".equals(method)) {
@@ -742,7 +742,7 @@ public class ApiClient extends JavaTimeFormatter {
   /**
    * Build the Client used to make HTTP requests.
    */
-  private Client buildHttpClient(boolean debugging) {
+  protected Client buildHttpClient(boolean debugging) {
     final ClientConfiguration clientConfig = new ClientConfiguration(ResteasyProviderFactory.getInstance());
     clientConfig.register(json);
     if(debugging){
@@ -750,7 +750,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
     return ClientBuilder.newClient(clientConfig);
   }
-  private Map<String, List<String>> buildResponseHeaders(Response response) {
+  protected Map<String, List<String>> buildResponseHeaders(Response response) {
     Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
@@ -768,7 +768,7 @@ public class ApiClient extends JavaTimeFormatter {
    *
    * @param authNames The authentications to apply
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams, Map<String, String> cookieParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -80,7 +80,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -78,33 +78,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -771,7 +771,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -815,8 +815,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -826,21 +826,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -857,7 +857,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -80,7 +80,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -78,33 +78,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -771,7 +771,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -815,8 +815,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -826,21 +826,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -857,7 +857,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -80,7 +80,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -78,33 +78,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://petstore.swagger.io/v2";
+    protected String basePath = "http://petstore.swagger.io/v2";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -771,7 +771,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -815,8 +815,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -826,21 +826,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -857,7 +857,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,33 +85,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -834,7 +834,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -886,8 +886,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -897,21 +897,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -928,7 +928,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -87,7 +87,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -80,33 +80,33 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
+        protected final String separator;
 
-        private CollectionFormat(String separator) {
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private boolean debugging = false;
+    protected boolean debugging = false;
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private int maxAttemptsForRetry = 1;
+    protected int maxAttemptsForRetry = 1;
 
-    private long waitTimeMillis = 10;
+    protected long waitTimeMillis = 10;
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private RestTemplate restTemplate;
+    protected RestTemplate restTemplate;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
-    private DateFormat dateFormat;
+    protected DateFormat dateFormat;
 
     public ApiClient() {
         this.restTemplate = buildRestTemplate();
@@ -829,7 +829,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param cookies map all cookies
      * @return header string for cookies.
      */
-    private String buildCookieHeader(MultiValueMap<String, String> cookies) {
+    protected String buildCookieHeader(MultiValueMap<String, String> cookies) {
         final StringBuilder cookieValue = new StringBuilder();
         String delimiter = "";
         for (final Map.Entry<String, List<String>> entry : cookies.entrySet()) {
@@ -873,8 +873,8 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
-        private final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
+    protected class ApiClientHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+        protected final Log log = LogFactory.getLog(ApiClientHttpRequestInterceptor.class);
 
         @Override
         public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
@@ -884,21 +884,21 @@ public class ApiClient extends JavaTimeFormatter {
             return response;
         }
 
-        private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
+        protected void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
             log.info("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
-        private void logResponse(ClientHttpResponse response) throws IOException {
+        protected void logResponse(ClientHttpResponse response) throws IOException {
             log.info("HTTP Status Code: " + response.getStatusCode().value());
             log.info("Status Text: " + response.getStatusText());
             log.info("HTTP Headers: " + headersToString(response.getHeaders()));
             log.info("Response Body: " + bodyToString(response.getBody()));
         }
 
-        private String headersToString(HttpHeaders headers) {
+        protected String headersToString(HttpHeaders headers) {
             if(headers == null || headers.isEmpty()) {
                 return "";
             }
@@ -915,7 +915,7 @@ public class ApiClient extends JavaTimeFormatter {
             return builder.toString();
         }
 
-        private String bodyToString(InputStream body) throws IOException {
+        protected String bodyToString(InputStream body) throws IOException {
             StringBuilder builder = new StringBuilder();
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(body, StandardCharsets.UTF_8));
             String line = bufferedReader.readLine();

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -82,7 +82,7 @@ public class ApiClient extends JavaTimeFormatter {
 
         protected final String separator;
 
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2-play26/src/main/java/org/openapitools/client/ApiClient.java
@@ -46,22 +46,22 @@ import org.openapitools.client.auth.Authentication;
 public class ApiClient {
 
     /** Underlying HTTP-client */
-    private WSClient wsClient;
+    protected WSClient wsClient;
 
     /** Creates HTTP call instances */
-    private Play26CallFactory callFactory;
+    protected Play26CallFactory callFactory;
 
     /** Create {@link java.util.concurrent.CompletionStage} instances from HTTP calls */
-    private Play26CallAdapterFactory callAdapterFactory;
+    protected Play26CallAdapterFactory callAdapterFactory;
 
     /** Supported auths */
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
     /** API base path */
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
     /** Default ObjectMapper */
-    private ObjectMapper defaultMapper;
+    protected ObjectMapper defaultMapper;
 
     public ApiClient(WSClient wsClient) {
         this();

--- a/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2/src/main/java/org/openapitools/client/ApiClient.java
@@ -44,11 +44,11 @@ import java.util.HashMap;
 
 public class ApiClient {
 
-  private Map<String, Interceptor> apiAuthorizations;
-  private OkHttpClient.Builder okBuilder;
-  private Retrofit.Builder adapterBuilder;
-  private JSON json;
-  private OkHttpClient okHttpClient;
+  protected Map<String, Interceptor> apiAuthorizations;
+  protected OkHttpClient.Builder okBuilder;
+  protected Retrofit.Builder adapterBuilder;
+  protected JSON json;
+  protected OkHttpClient okHttpClient;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, Interceptor>();
@@ -372,8 +372,8 @@ public class ApiClient {
  * expected type is String, then just return the body string.
  */
 class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T> {
-  private final Gson gson;
-  private final Type type;
+  protected final Gson gson;
+  protected final Type type;
 
   GsonResponseBodyConverterToString(Gson gson, Type type) {
     this.gson = gson;
@@ -393,14 +393,14 @@ class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T>
 
 class GsonCustomConverterFactory extends Converter.Factory
 {
-  private final Gson gson;
-  private final GsonConverterFactory gsonConverterFactory;
+  protected final Gson gson;
+  protected final GsonConverterFactory gsonConverterFactory;
 
   public static GsonCustomConverterFactory create(Gson gson) {
     return new GsonCustomConverterFactory(gson);
   }
 
-  private GsonCustomConverterFactory(Gson gson) {
+  protected GsonCustomConverterFactory(Gson gson) {
     if (gson == null)
       throw new NullPointerException("gson == null");
     this.gson = gson;

--- a/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx2/src/main/java/org/openapitools/client/ApiClient.java
@@ -45,11 +45,11 @@ import java.util.HashMap;
 
 public class ApiClient {
 
-  private Map<String, Interceptor> apiAuthorizations;
-  private OkHttpClient.Builder okBuilder;
-  private Retrofit.Builder adapterBuilder;
-  private JSON json;
-  private OkHttpClient okHttpClient;
+  protected Map<String, Interceptor> apiAuthorizations;
+  protected OkHttpClient.Builder okBuilder;
+  protected Retrofit.Builder adapterBuilder;
+  protected JSON json;
+  protected OkHttpClient okHttpClient;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, Interceptor>();
@@ -374,8 +374,8 @@ public class ApiClient {
  * expected type is String, then just return the body string.
  */
 class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T> {
-  private final Gson gson;
-  private final Type type;
+  protected final Gson gson;
+  protected final Type type;
 
   GsonResponseBodyConverterToString(Gson gson, Type type) {
     this.gson = gson;
@@ -395,14 +395,14 @@ class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T>
 
 class GsonCustomConverterFactory extends Converter.Factory
 {
-  private final Gson gson;
-  private final GsonConverterFactory gsonConverterFactory;
+  protected final Gson gson;
+  protected final GsonConverterFactory gsonConverterFactory;
 
   public static GsonCustomConverterFactory create(Gson gson) {
     return new GsonCustomConverterFactory(gson);
   }
 
-  private GsonCustomConverterFactory(Gson gson) {
+  protected GsonCustomConverterFactory(Gson gson) {
     if (gson == null)
       throw new NullPointerException("gson == null");
     this.gson = gson;

--- a/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/retrofit2rx3/src/main/java/org/openapitools/client/ApiClient.java
@@ -45,11 +45,11 @@ import java.util.HashMap;
 
 public class ApiClient {
 
-  private Map<String, Interceptor> apiAuthorizations;
-  private OkHttpClient.Builder okBuilder;
-  private Retrofit.Builder adapterBuilder;
-  private JSON json;
-  private OkHttpClient okHttpClient;
+  protected Map<String, Interceptor> apiAuthorizations;
+  protected OkHttpClient.Builder okBuilder;
+  protected Retrofit.Builder adapterBuilder;
+  protected JSON json;
+  protected OkHttpClient okHttpClient;
 
   public ApiClient() {
     apiAuthorizations = new LinkedHashMap<String, Interceptor>();
@@ -374,8 +374,8 @@ public class ApiClient {
  * expected type is String, then just return the body string.
  */
 class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T> {
-  private final Gson gson;
-  private final Type type;
+  protected final Gson gson;
+  protected final Type type;
 
   GsonResponseBodyConverterToString(Gson gson, Type type) {
     this.gson = gson;
@@ -395,14 +395,14 @@ class GsonResponseBodyConverterToString<T> implements Converter<ResponseBody, T>
 
 class GsonCustomConverterFactory extends Converter.Factory
 {
-  private final Gson gson;
-  private final GsonConverterFactory gsonConverterFactory;
+  protected final Gson gson;
+  protected final GsonConverterFactory gsonConverterFactory;
 
   public static GsonCustomConverterFactory create(Gson gson) {
     return new GsonCustomConverterFactory(gson);
   }
 
-  private GsonCustomConverterFactory(Gson gson) {
+  protected GsonCustomConverterFactory(Gson gson) {
     if (gson == null)
       throw new NullPointerException("gson == null");
     this.gson = gson;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
@@ -53,21 +53,21 @@ import static java.util.stream.Collectors.toMap;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
 
-    private static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-    private static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
+    protected static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+    protected static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
 
-    private final Vertx vertx;
-    private final JsonObject config;
-    private final String identifier;
+    protected final Vertx vertx;
+    protected final JsonObject config;
+    protected final String identifier;
 
-    private MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
-    private MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
-    private Map<String, Authentication> authentications;
-    private String basePath = "http://petstore.swagger.io:80/v2";
-    private DateFormat dateFormat;
-    private ObjectMapper objectMapper;
-    private String downloadsDir = "";
-    private int timeout = -1;
+    protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
+    protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
+    protected Map<String, Authentication> authentications;
+    protected String basePath = "http://petstore.swagger.io:80/v2";
+    protected DateFormat dateFormat;
+    protected ObjectMapper objectMapper;
+    protected String downloadsDir = "";
+    protected int timeout = -1;
 
     public ApiClient(Vertx vertx, JsonObject config) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
@@ -383,7 +383,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param mime MIME
      * @return True if the MIME type is JSON
      */
-    private boolean isJsonMime(String mime) {
+    protected boolean isJsonMime(String mime) {
         String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
         return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
     }
@@ -521,7 +521,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private String buildCookieHeader(MultiMap cookies) {
+    protected String buildCookieHeader(MultiMap cookies) {
       final StringBuilder cookieValue = new StringBuilder();
       String delimiter = "";
       for (final Map.Entry<String, String> entry : cookies.entries()) {
@@ -678,7 +678,7 @@ public class ApiClient extends JavaTimeFormatter {
 
     public static class AuthInfo {
 
-        private final Map<String, Authentication> authentications = new LinkedHashMap<>();
+        protected final Map<String, Authentication> authentications = new LinkedHashMap<>();
 
         public void addPetstoreAuthAuthentication(String accessToken) {
            OAuth auth = new OAuth();

--- a/samples/client/petstore/java/vertx-supportVertxFuture/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx-supportVertxFuture/src/main/java/org/openapitools/client/ApiClient.java
@@ -54,21 +54,21 @@ import static java.util.stream.Collectors.toMap;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
 
-    private static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-    private static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
+    protected static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+    protected static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
 
-    private final Vertx vertx;
-    private final JsonObject config;
-    private final String identifier;
+    protected final Vertx vertx;
+    protected final JsonObject config;
+    protected final String identifier;
 
-    private MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
-    private MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
-    private Map<String, Authentication> authentications;
-    private String basePath = "http://petstore.swagger.io:80/v2";
-    private DateFormat dateFormat;
-    private ObjectMapper objectMapper;
-    private String downloadsDir = "";
-    private int timeout = -1;
+    protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
+    protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
+    protected Map<String, Authentication> authentications;
+    protected String basePath = "http://petstore.swagger.io:80/v2";
+    protected DateFormat dateFormat;
+    protected ObjectMapper objectMapper;
+    protected String downloadsDir = "";
+    protected int timeout = -1;
 
     public ApiClient(Vertx vertx, JsonObject config) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
@@ -387,7 +387,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param mime MIME
      * @return True if the MIME type is JSON
      */
-    private boolean isJsonMime(String mime) {
+    protected boolean isJsonMime(String mime) {
         String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
         return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
     }
@@ -525,7 +525,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private String buildCookieHeader(MultiMap cookies) {
+    protected String buildCookieHeader(MultiMap cookies) {
       final StringBuilder cookieValue = new StringBuilder();
       String delimiter = "";
       for (final Map.Entry<String, String> entry : cookies.entries()) {
@@ -682,7 +682,7 @@ public class ApiClient extends JavaTimeFormatter {
 
     public static class AuthInfo {
 
-        private final Map<String, Authentication> authentications = new LinkedHashMap<>();
+        protected final Map<String, Authentication> authentications = new LinkedHashMap<>();
 
         public void addPetstoreAuthAuthentication(String accessToken) {
            OAuth auth = new OAuth();

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
@@ -54,21 +54,21 @@ import static java.util.stream.Collectors.toMap;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
 
-    private static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
-    private static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
+    protected static final Pattern CONTENT_DISPOSITION_PATTERN = Pattern.compile("filename=['\"]?([^'\"\\s]+)['\"]?");
+    protected static final OpenOptions FILE_DOWNLOAD_OPTIONS = new OpenOptions().setCreate(true).setTruncateExisting(true);
 
-    private final Vertx vertx;
-    private final JsonObject config;
-    private final String identifier;
+    protected final Vertx vertx;
+    protected final JsonObject config;
+    protected final String identifier;
 
-    private MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
-    private MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
-    private Map<String, Authentication> authentications;
-    private String basePath = "http://petstore.swagger.io:80/v2";
-    private DateFormat dateFormat;
-    private ObjectMapper objectMapper;
-    private String downloadsDir = "";
-    private int timeout = -1;
+    protected MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
+    protected MultiMap defaultCookies = MultiMap.caseInsensitiveMultiMap();
+    protected Map<String, Authentication> authentications;
+    protected String basePath = "http://petstore.swagger.io:80/v2";
+    protected DateFormat dateFormat;
+    protected ObjectMapper objectMapper;
+    protected String downloadsDir = "";
+    protected int timeout = -1;
 
     public ApiClient(Vertx vertx, JsonObject config) {
         Objects.requireNonNull(vertx, "Vertx must not be null");
@@ -387,7 +387,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param mime MIME
      * @return True if the MIME type is JSON
      */
-    private boolean isJsonMime(String mime) {
+    protected boolean isJsonMime(String mime) {
         String jsonMime = "(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
         return mime != null && (mime.matches(jsonMime) || mime.equalsIgnoreCase("application/json-patch+json"));
     }
@@ -525,7 +525,7 @@ public class ApiClient extends JavaTimeFormatter {
         }
     }
 
-    private String buildCookieHeader(MultiMap cookies) {
+    protected String buildCookieHeader(MultiMap cookies) {
       final StringBuilder cookieValue = new StringBuilder();
       String delimiter = "";
       for (final Map.Entry<String, String> entry : cookies.entries()) {
@@ -682,7 +682,7 @@ public class ApiClient extends JavaTimeFormatter {
 
     public static class AuthInfo {
 
-        private final Map<String, Authentication> authentications = new LinkedHashMap<>();
+        protected final Map<String, Authentication> authentications = new LinkedHashMap<>();
 
         public void addPetstoreAuthAuthentication(String accessToken) {
            OAuth auth = new OAuth();

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -86,7 +86,7 @@ public class ApiClient extends JavaTimeFormatter {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,28 +85,28 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -650,7 +650,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,7 +85,7 @@ public class ApiClient extends JavaTimeFormatter {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -84,28 +84,28 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "http://localhost";
+    protected String basePath = "http://localhost";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -127,7 +127,7 @@ public class ApiClient extends JavaTimeFormatter {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -604,7 +604,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -630,7 +630,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -86,7 +86,7 @@ public class ApiClient extends JavaTimeFormatter {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,28 +85,28 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -650,7 +650,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -86,7 +86,7 @@ public class ApiClient extends JavaTimeFormatter {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,28 +85,28 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -650,7 +650,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -86,7 +86,7 @@ public class ApiClient extends JavaTimeFormatter {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
         protected final String separator;
-        protected CollectionFormat(String separator) {
+        CollectionFormat(String separator) {
             this.separator = separator;
         }
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,28 +85,28 @@ public class ApiClient extends JavaTimeFormatter {
     public enum CollectionFormat {
         CSV(","), TSV("\t"), SSV(" "), PIPES("|"), MULTI(null);
 
-        private final String separator;
-        private CollectionFormat(String separator) {
+        protected final String separator;
+        protected CollectionFormat(String separator) {
             this.separator = separator;
         }
 
-        private String collectionToString(Collection<?> collection) {
+        protected String collectionToString(Collection<?> collection) {
             return StringUtils.collectionToDelimitedString(collection, separator);
         }
     }
 
-    private static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
+    protected static final String URI_TEMPLATE_ATTRIBUTE = WebClient.class.getName() + ".uriTemplate";
 
-    private HttpHeaders defaultHeaders = new HttpHeaders();
-    private MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
+    protected HttpHeaders defaultHeaders = new HttpHeaders();
+    protected MultiValueMap<String, String> defaultCookies = new LinkedMultiValueMap<String, String>();
 
-    private String basePath = "http://petstore.swagger.io:80/v2";
+    protected String basePath = "http://petstore.swagger.io:80/v2";
 
-    private final WebClient webClient;
-    private final DateFormat dateFormat;
-    private final ObjectMapper objectMapper;
+    protected final WebClient webClient;
+    protected final DateFormat dateFormat;
+    protected final ObjectMapper objectMapper;
 
-    private Map<String, Authentication> authentications;
+    protected Map<String, Authentication> authentications;
 
 
     public ApiClient() {
@@ -128,7 +128,7 @@ public class ApiClient extends JavaTimeFormatter {
         this(Optional.ofNullable(webClient).orElseGet(() -> buildWebClient(mapper.copy())), format);
     }
 
-    private ApiClient(WebClient webClient, DateFormat format) {
+    protected ApiClient(WebClient webClient, DateFormat format) {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
@@ -624,7 +624,7 @@ public class ApiClient extends JavaTimeFormatter {
      * @param uriParams The path parameters
      * return templatized query string
      */
-    private String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
+    protected String generateQueryUri(MultiValueMap<String, String> queryParams, Map<String, Object> uriParams) {
         StringBuilder queryBuilder = new StringBuilder();
         queryParams.forEach((name, values) -> {
             if (CollectionUtils.isEmpty(values)) {
@@ -650,7 +650,7 @@ public class ApiClient extends JavaTimeFormatter {
         return queryBuilder.toString();
     }
 
-    private WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
+    protected WebClient.RequestBodySpec prepareRequest(String path, HttpMethod method, Map<String, Object> pathParams,
         MultiValueMap<String, String> queryParams, Object body, HttpHeaders headerParams,
         MultiValueMap<String, String> cookieParams, MultiValueMap<String, Object> formParams, List<MediaType> accept,
         MediaType contentType, String[] authNames) {

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,13 +85,13 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -140,7 +140,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -311,7 +311,7 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
@@ -857,7 +857,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1155,7 +1155,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1217,7 +1217,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiClient.java
@@ -85,13 +85,13 @@ import org.openapitools.client.auth.ApiKeyAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://localhost";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -108,7 +108,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -262,7 +262,7 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
@@ -808,7 +808,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1106,7 +1106,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1168,7 +1168,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -87,13 +87,13 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -110,7 +110,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -281,13 +281,13 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -933,7 +933,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1247,7 +1247,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1309,7 +1309,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -87,13 +87,13 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -110,7 +110,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -281,13 +281,13 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -933,7 +933,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1247,7 +1247,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1309,7 +1309,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiClient.java
@@ -88,13 +88,13 @@ import org.openapitools.client.auth.OAuth;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.14.0-SNAPSHOT")
 public class ApiClient extends JavaTimeFormatter {
-  private static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
+  protected static final Pattern JSON_MIME_PATTERN = Pattern.compile("(?i)^(application/json|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$");
 
   protected Map<String, String> defaultHeaderMap = new HashMap<>();
   protected Map<String, String> defaultCookieMap = new HashMap<>();
   protected String basePath = "http://petstore.swagger.io:80/v2";
   protected String userAgent;
-  private static final Logger log = Logger.getLogger(ApiClient.class.getName());
+  protected static final Logger log = Logger.getLogger(ApiClient.class.getName());
 
   protected List<ServerConfiguration> servers = new ArrayList<>(Arrays.asList(
           new ServerConfiguration(
@@ -178,7 +178,7 @@ public class ApiClient extends JavaTimeFormatter {
   protected boolean debugging = false;
   protected ClientConfig clientConfig;
   protected int connectionTimeout = 0;
-  private int readTimeout = 0;
+  protected int readTimeout = 0;
 
   protected Client httpClient;
   protected JSON json;
@@ -379,13 +379,13 @@ public class ApiClient extends JavaTimeFormatter {
     return this;
   }
 
-  private void updateBasePath() {
+  protected void updateBasePath() {
     if (serverIndex != null) {
         setBasePath(servers.get(serverIndex).URL(serverVariables));
     }
   }
 
-  private void setOauthBasePath(String basePath) {
+  protected void setOauthBasePath(String basePath) {
     for(Authentication auth : authentications.values()) {
       if (auth instanceof OAuth) {
         ((OAuth) auth).setBasePath(basePath);
@@ -1031,7 +1031,7 @@ public class ApiClient extends JavaTimeFormatter {
    * @param key Key of the object
    * @param multiPart MultiPart to add the form param to
    */
-  private void addParamToMultipart(Object value, String key, MultiPart multiPart) {
+  protected void addParamToMultipart(Object value, String key, MultiPart multiPart) {
     if (value instanceof File) {
       File file = (File) value;
       FormDataContentDisposition contentDisp = FormDataContentDisposition.name(key)
@@ -1345,7 +1345,7 @@ public class ApiClient extends JavaTimeFormatter {
     }
   }
 
-  private Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
+  protected Response sendRequest(String method, Invocation.Builder invocationBuilder, Entity<?> entity) {
     Response response;
     if ("POST".equals(method)) {
       response = invocationBuilder.post(entity);
@@ -1407,7 +1407,7 @@ public class ApiClient extends JavaTimeFormatter {
     return clientConfig;
   }
 
-  private void applyDebugSetting(ClientConfig clientConfig) {
+  protected void applyDebugSetting(ClientConfig clientConfig) {
     if (debugging) {
       clientConfig.register(new LoggingFeature(java.util.logging.Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024*50 /* Log payloads up to 50K */));
       clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);


### PR DESCRIPTION
Fixes #21250

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

Fun Fact: You could create a GitHub team for that so that I don't have to mention everyone separately
