### PR TITLE
fix: Parent model is generated when using discriminator and object has no properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -881,7 +881,7 @@ public class ModelUtils {
             } else if (schema.getAdditionalProperties() instanceof JsonSchema) {
                 return true;
             } else if (schema.getTypes() != null) {
-                if (schema.getTypes().size() == 1) { // types = [object]
+                if (schema.getTypes().size() == 1 && schema.getDiscriminator() == null) { // types = [object]
                     return SchemaTypeUtil.OBJECT_TYPE.equals(schema.getTypes().iterator().next());
                 } else { // has more than 1 type, e.g. types = [integer, string]
                     return false;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -4816,6 +4816,25 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testParentModelGeneratedEvenWithoutProperties() throws Exception {
+        File output = Files.createTempDirectory("test_7638_").toFile();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setInputSpec("src/test/resources/3_1/issue_7638.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        TestUtils.ensureContainsFile(files, output, "src/main/java/org/openapitools/client/model/Pet.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/org/openapitools/client/model/Dog.java");
+
+        output.deleteOnExit();
+    }
+
+    @Test
     public void testReferencedEnumType() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue-5676-enums.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/3_1/issue_7638.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_7638.yaml
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Parent Model Generated Even Without Properties",
+    "version": "1.0.0-SNAPSHOT"
+  },
+  "servers": [ ],
+  "paths": { },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        }
+      },
+      "Dog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "legs": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Previously, models acting as superclasses with only a discriminator and no defined properties were incorrectly treated as free-form objects, preventing class generation. This fix updates the free-form object detection logic to correctly handle such cases, ensuring base models are generated when a discriminator is present.

Fix #7638

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
