### PR TITLE
[php-flight] fix: use static PHPUnit assertions

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-flight/register_routes_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-flight/register_routes_test.mustache
@@ -26,7 +26,7 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
         {{/operations}}
         };
         \{{invokerPackage}}\RegisterRoutes::registerRoutes($handler);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 {{/apis}}
 {{#models}}
@@ -41,7 +41,7 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
         {{/-first}}
         {{/enumVars}}
         {{/allowableValues}}
-        $this->assertEquals(
+        self::assertEquals(
             parseParam($value, '\\{{escapedModelPackage}}\\{{classname}}'),
             \{{modelPackage}}\{{classname}}::{{#allowableValues}}{{#enumVars}}{{#-first}}{{{name}}}{{/-first}}{{/enumVars}}{{/allowableValues}}
         );

--- a/samples/server/petstore/php-flight/Test/RegisterRoutesTest.php
+++ b/samples/server/petstore/php-flight/Test/RegisterRoutesTest.php
@@ -29,7 +29,7 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
             }
         };
         \OpenAPIServer\RegisterRoutes::registerRoutes($handler);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
     public function testRegisterRoutesAbstractStoreApi(): void
     {
@@ -39,7 +39,7 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
             }
         };
         \OpenAPIServer\RegisterRoutes::registerRoutes($handler);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
     public function testRegisterRoutesAbstractUserApi(): void
     {
@@ -49,12 +49,12 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
             }
         };
         \OpenAPIServer\RegisterRoutes::registerRoutes($handler);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
     public function testParseParamsEnumFindPetsByStatusStatusParameterInner(): void
     {
         $value = 'available';
-        $this->assertEquals(
+        self::assertEquals(
             parseParam($value, '\\OpenAPIServer\\Model\\FindPetsByStatusStatusParameterInner'),
             \OpenAPIServer\Model\FindPetsByStatusStatusParameterInner::AVAILABLE
         );
@@ -62,7 +62,7 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
     public function testParseParamsEnumOrderStatus(): void
     {
         $value = 'placed';
-        $this->assertEquals(
+        self::assertEquals(
             parseParam($value, '\\OpenAPIServer\\Model\\OrderStatus'),
             \OpenAPIServer\Model\OrderStatus::PLACED
         );
@@ -70,7 +70,7 @@ class RegisterRoutesTest extends \PHPUnit\Framework\TestCase {
     public function testParseParamsEnumPetStatus(): void
     {
         $value = 'available';
-        $this->assertEquals(
+        self::assertEquals(
             parseParam($value, '\\OpenAPIServer\\Model\\PetStatus'),
             \OpenAPIServer\Model\PetStatus::AVAILABLE
         );


### PR DESCRIPTION
Hi

Static analysis tools such as PHPStan report errors when dynamic calls are used for static methods.

```
ERROR Dynamic call to static method PHPUnit\Framework\Assert::assertEquals().
```

According to the source code of PHPUnit
(https://github.com/sebastianbergmann/phpunit/blob/9.5.0/src/Framework/Assert.php) the function is indeed static.

```php
public static function assertTrue($condition, string $message = ''): void
```

This change updates to PHP Flight test template `register_routes_test.mustache` to use static calls for PHPUnit assertions.

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon: Thanks for having a look at this PR. Please inform me if there's anything I'd have to improve to get this merged.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
