### PR TITLE
[php-symfony] fix handling of endpoints with "text/plain" or "image/png" response type

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -417,7 +417,17 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
                 op.vendorExtensions.put("x-comment-type", "void");
             }
             // Create a variable to add typing for return value of interface
-            if (op.returnType != null) {
+            if ("bool".equals(op.returnType)) {
+                op.vendorExtensions.put("x-return-type", "bool");
+            } else if ("UploadedFile".equals(op.returnType)) {
+                op.vendorExtensions.put("x-return-type", "string");
+            } else if ("int".equals(op.returnType)) {
+                op.vendorExtensions.put("x-return-type", "int");
+            } else if ("float".equals(op.returnType)) {
+                op.vendorExtensions.put("x-return-type", "float");
+            } else if ("string".equals(op.returnType)) {
+                op.vendorExtensions.put("x-return-type", "string");
+            } else if (op.returnType != null) {
                 op.vendorExtensions.put("x-return-type", "array|object|null");
             } else {
                 op.vendorExtensions.put("x-return-type", "void");

--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -204,6 +204,10 @@ class Controller extends AbstractController
             return 'application/xml';
         }
 
+        if (in_array('*/*', $accept)) {
+            return $produced[0];
+        }
+
         // If we reach this point, we don't have a common ground between server and client
         return null;
     }

--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -29,7 +29,12 @@ class JmsSerializer implements SerializerInterface
      */
     public function serialize($data, string $format): string
     {
-        return SerializerBuilder::create()->build()->serialize($data, $this->convertFormat($format));
+       $convertFormat = $this->convertFormat($format);
+       if ($convertFormat !== null) {
+        return SerializerBuilder::create()->build()->serialize($data, $convertFormat);
+       } else {
+         return is_string($data) ? $data : var_export($data, true);
+       }
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/StoreApiInterface.php
@@ -77,12 +77,12 @@ interface StoreApiInterface
      * @param  int     &$responseCode    The HTTP Response Code
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return array|object|null
+     * @return int
      */
     public function getInventory(
         int &$responseCode,
         array &$responseHeaders
-    ): array|object|null;
+    ): int;
 
     /**
      * Operation getOrderById

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/UserApiInterface.php
@@ -147,14 +147,14 @@ interface UserApiInterface
      * @param  int     &$responseCode    The HTTP Response Code
      * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
      *
-     * @return array|object|null
+     * @return string
      */
     public function loginUser(
         string $username,
         string $password,
         int &$responseCode,
         array &$responseHeaders
-    ): array|object|null;
+    ): string;
 
     /**
      * Operation logoutUser

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -214,6 +214,10 @@ class Controller extends AbstractController
             return 'application/xml';
         }
 
+        if (in_array('*/*', $accept)) {
+            return $produced[0];
+        }
+
         // If we reach this point, we don't have a common ground between server and client
         return null;
     }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -29,7 +29,12 @@ class JmsSerializer implements SerializerInterface
      */
     public function serialize($data, string $format): string
     {
-        return SerializerBuilder::create()->build()->serialize($data, $this->convertFormat($format));
+       $convertFormat = $this->convertFormat($format);
+       if ($convertFormat !== null) {
+        return SerializerBuilder::create()->build()->serialize($data, $convertFormat);
+       } else {
+         return is_string($data) ? $data : var_export($data, true);
+       }
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/docs/Api/StoreApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/docs/Api/StoreApiInterface.md
@@ -107,7 +107,7 @@ class StoreApi implements StoreApiInterface
     /**
      * Implementation of StoreApiInterface#getInventory
      */
-    public function getInventory(int &$responseCode, array &$responseHeaders): array|object|null
+    public function getInventory(int &$responseCode, array &$responseHeaders): int
     {
         // Implement the operation ...
     }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/docs/Api/UserApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/docs/Api/UserApiInterface.md
@@ -351,7 +351,7 @@ class UserApi implements UserApiInterface
     /**
      * Implementation of UserApiInterface#loginUser
      */
-    public function loginUser(string $username, string $password, int &$responseCode, array &$responseHeaders): array|object|null
+    public function loginUser(string $username, string $password, int &$responseCode, array &$responseHeaders): string
     {
         // Implement the operation ...
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


This fixes #21256 (and this subsequently fixes #13334, which is a subset of the other one).

This PR implements the 3 fixes that are required to be able to handle all the endpoints described in this OpenApi specification:

```yaml
openapi: 3.0.3
info:
  title: repro issue openapi-generator
  version: 0.0.1
paths:
  /get-bool:
    get:
      summary: get a boolean
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: boolean
  /get-image:
    get:
      summary: get an image
      responses:
        "200":
          description: OK
          content:
            image/png:
              schema:
                type: string
                format: binary
  /get-string:
    get:
      summary: get a string
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: string
  /get-int:
    get:
      summary: get an int
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: integer
  /get-number:
    get:
      summary: get a number
      responses:
        "200":
          description: OK
          content:
            text/plain:
              schema:
                type: number
```

Namely this:
- ensures the generated method `Controller.getOutputFormat` returns a valid format when the user accepts `*/*`
- does not try to call `->serialize($data, ...)`` when the 2nd argument is `null` (it would crash (error 500)). Instead it uses a straightforward way to handle the serialization in those simple cases
- define relevant return type when the specification declares response with context `text/plain`

(nb: to make it easier to review I did a separate commit for each of those 3 fixes)

Ping technical committed, ie: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon (and thanks for your work!)