### PR TITLE
[python] Fix poetry deprecation warnings

### DIFF
--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -29,6 +29,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |packageName|python package name (convention: snake_case).| |openapi_client|
 |packageUrl|python package URL.| |null|
 |packageVersion|python package version.| |1.0.0|
+|poetry1|Fallback to formatting pyproject.toml to Poetry 1.x format.| |null|
 |projectName|python project name in setup.py (e.g. petstore-api).| |null|
 |recursionLimit|Set the recursion limit. If not set, use the system default value.| |null|
 |setEnsureAsciiToFalse|When set to true, add `ensure_ascii=False` in json.dumps when creating the HTTP request body.| |false|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonClientCodegen.java
@@ -47,6 +47,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
     public static final String DATETIME_FORMAT = "datetimeFormat";
     public static final String DATE_FORMAT = "dateFormat";
     public static final String SET_ENSURE_ASCII_TO_FALSE = "setEnsureAsciiToFalse";
+    public static final String POETRY1_FALLBACK = "poetry1";
 
     @Setter protected String packageUrl;
     protected String apiDocPath = "docs/";
@@ -149,6 +150,7 @@ public class PythonClientCodegen extends AbstractPythonCodegen implements Codege
         cliOptions.add(new CliOption(DATE_FORMAT, "date format for query parameters")
                 .defaultValue("%Y-%m-%d"));
         cliOptions.add(new CliOption(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP_DESC).defaultValue("false"));
+        cliOptions.add(new CliOption(POETRY1_FALLBACK, "Fallback to formatting pyproject.toml to Poetry 1.x format."));
 
         supportedLibraries.put("urllib3", "urllib3-based client");
         supportedLibraries.put("asyncio", "asyncio-based client");

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -1,13 +1,54 @@
+{{#poetry1}}
+[tool.poetry]
+{{/poetry1}}
+{{^poetry1}}
 [project]
+{{/poetry1}}
 name = "{{{packageName}}}"
 version = "{{{packageVersion}}}"
 description = "{{{appName}}}"
+{{#poetry1}}
+authors = ["{{infoName}}{{^infoName}}OpenAPI Generator Community{{/infoName}} <{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}>"]
+{{/poetry1}}
+{{^poetry1}}
 authors = [
   {name = "{{infoName}}{{^infoName}}OpenAPI Generator Community{{/infoName}}",email = "{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}"},
 ]
+{{/poetry1}}
 license = "{{{licenseInfo}}}{{^licenseInfo}}NoLicense{{/licenseInfo}}"
 readme = "README.md"
+{{#poetry1}}
+repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
+{{/poetry1}}
+{{^poetry1}}
+
+[project.urls]
+Repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
+
+{{/poetry1}}
 keywords = ["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"]
+{{#poetry1}}
+include = ["{{packageName}}/py.typed"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+urllib3 = ">= 2.1.0, < 3.0.0"
+python-dateutil = ">= 2.8.2"
+{{#asyncio}}
+aiohttp = ">= 3.8.4"
+aiohttp-retry = ">= 2.8.3"
+{{/asyncio}}
+{{#tornado}}
+tornado = ">=4.2, <5"
+{{/tornado}}
+{{#hasHttpSignatureMethods}}
+pem = ">= 19.3.0"
+pycryptodome = ">= 3.9.0"
+{{/hasHttpSignatureMethods}}
+pydantic = ">= 2"
+typing-extensions = ">= 4.7.1"
+{{/poetry1}}
+{{^poetry1}}
 requires-python = "^3.9"
 
 dependencies = [
@@ -27,11 +68,19 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)"
 ]
+{{/poetry1}}
 
+{{^poetry1}}
 [tool.poetry]
 requires-poetry = ">=2.0"
+{{/poetry1}}
 
+{{#poetry1}}
+[tool.poetry.dev-dependencies]
+{{/poetry1}}
+{{^poetry1}}
 [tool.poetry.group.dev.dependencies]
+{{/poetry1}}
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -20,12 +20,6 @@ readme = "README.md"
 {{#poetry1}}
 repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
 {{/poetry1}}
-{{^poetry1}}
-
-[project.urls]
-Repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
-
-{{/poetry1}}
 keywords = ["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"]
 {{#poetry1}}
 include = ["{{packageName}}/py.typed"]
@@ -68,8 +62,11 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)"
 ]
-{{/poetry1}}
 
+[project.urls]
+Repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
+
+{{/poetry1}}
 {{^poetry1}}
 [tool.poetry]
 requires-poetry = ">=2.0"

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -1,34 +1,37 @@
-[tool.poetry]
+[project]
 name = "{{{packageName}}}"
 version = "{{{packageVersion}}}"
 description = "{{{appName}}}"
-authors = ["{{infoName}}{{^infoName}}OpenAPI Generator Community{{/infoName}} <{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}>"]
+authors = [
+  {name = "{{infoName}}{{^infoName}}OpenAPI Generator Community{{/infoName}}",email = "{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}"},
+]
 license = "{{{licenseInfo}}}{{^licenseInfo}}NoLicense{{/licenseInfo}}"
 readme = "README.md"
-repository = "https://{{{gitHost}}}/{{{gitUserId}}}/{{{gitRepoId}}}"
 keywords = ["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"]
-include = ["{{packageName}}/py.typed"]
+requires-python = "^3.9"
 
-[tool.poetry.dependencies]
-python = "^3.9"
-
-urllib3 = ">= 2.1.0, < 3.0.0"
-python-dateutil = ">= 2.8.2"
+dependencies = [
+  "urllib3 (>=2.1.0,<3.0.0)",
+  "python-dateutil (>=2.8.2)",
 {{#asyncio}}
-aiohttp = ">= 3.8.4"
-aiohttp-retry = ">= 2.8.3"
+  "aiohttp (>=3.8.4)",
+  "aiohttp-retry (>=2.8.3)",
 {{/asyncio}}
 {{#tornado}}
-tornado = ">=4.2, <5"
+  "tornado (>=4.2,<5)",
 {{/tornado}}
 {{#hasHttpSignatureMethods}}
-pem = ">= 19.3.0"
-pycryptodome = ">= 3.9.0"
+  "pem (>=19.3.0)",
+  "pycryptodome (>=3.9.0)",
 {{/hasHttpSignatureMethods}}
-pydantic = ">= 2"
-typing-extensions = ">= 4.7.1"
+  "pydantic (>=2)",
+  "typing-extensions (>=4.7.1)"
+]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry]
+requires-poetry = ">=2.0"
+
+[tool.poetry.group.dev.dependencies]
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -7,6 +7,10 @@ authors = [
 ]
 license = "Apache 2.0"
 readme = "README.md"
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = "^3.9"
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -1,23 +1,26 @@
-[tool.poetry]
+[project]
 name = "openapi_client"
 version = "1.0.0"
 description = "Echo Server API"
-authors = ["OpenAPI Generator Community <team@openapitools.org>"]
+authors = [
+  {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
+]
 license = "Apache 2.0"
 readme = "README.md"
-repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
-include = ["openapi_client/py.typed"]
+requires-python = "^3.9"
 
-[tool.poetry.dependencies]
-python = "^3.9"
+dependencies = [
+  "urllib3 (>=2.1.0,<3.0.0)",
+  "python-dateutil (>=2.8.2)",
+  "pydantic (>=2)",
+  "typing-extensions (>=4.7.1)"
+]
 
-urllib3 = ">= 2.1.0, < 3.0.0"
-python-dateutil = ">= 2.8.2"
-pydantic = ">= 2"
-typing-extensions = ">= 4.7.1"
+[tool.poetry]
+requires-poetry = ">=2.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/pyproject.toml
@@ -7,10 +7,6 @@ authors = [
 ]
 license = "Apache 2.0"
 readme = "README.md"
-
-[project.urls]
-Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
-
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = "^3.9"
 
@@ -20,6 +16,9 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)"
 ]
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 
 [tool.poetry]
 requires-poetry = ">=2.0"

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -7,6 +7,10 @@ authors = [
 ]
 license = "Apache 2.0"
 readme = "README.md"
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = "^3.9"
 

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -1,23 +1,26 @@
-[tool.poetry]
+[project]
 name = "openapi_client"
 version = "1.0.0"
 description = "Echo Server API"
-authors = ["OpenAPI Generator Community <team@openapitools.org>"]
+authors = [
+  {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
+]
 license = "Apache 2.0"
 readme = "README.md"
-repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
-include = ["openapi_client/py.typed"]
+requires-python = "^3.9"
 
-[tool.poetry.dependencies]
-python = "^3.9"
+dependencies = [
+  "urllib3 (>=2.1.0,<3.0.0)",
+  "python-dateutil (>=2.8.2)",
+  "pydantic (>=2)",
+  "typing-extensions (>=4.7.1)"
+]
 
-urllib3 = ">= 2.1.0, < 3.0.0"
-python-dateutil = ">= 2.8.2"
-pydantic = ">= 2"
-typing-extensions = ">= 4.7.1"
+[tool.poetry]
+requires-poetry = ">=2.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -7,10 +7,6 @@ authors = [
 ]
 license = "Apache 2.0"
 readme = "README.md"
-
-[project.urls]
-Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
-
 keywords = ["OpenAPI", "OpenAPI-Generator", "Echo Server API"]
 requires-python = "^3.9"
 
@@ -20,6 +16,9 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)"
 ]
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 
 [tool.poetry]
 requires-poetry = ">=2.0"

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -7,10 +7,6 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-
-[project.urls]
-Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
-
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = "^3.9"
 
@@ -24,6 +20,9 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)"
 ]
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 
 [tool.poetry]
 requires-poetry = ">=2.0"

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -1,27 +1,30 @@
-[tool.poetry]
+[project]
 name = "petstore_api"
 version = "1.0.0"
 description = "OpenAPI Petstore"
-authors = ["OpenAPI Generator Community <team@openapitools.org>"]
+authors = [
+  {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
+]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
-include = ["petstore_api/py.typed"]
+requires-python = "^3.9"
 
-[tool.poetry.dependencies]
-python = "^3.9"
+dependencies = [
+  "urllib3 (>=2.1.0,<3.0.0)",
+  "python-dateutil (>=2.8.2)",
+  "aiohttp (>=3.8.4)",
+  "aiohttp-retry (>=2.8.3)",
+  "pem (>=19.3.0)",
+  "pycryptodome (>=3.9.0)",
+  "pydantic (>=2)",
+  "typing-extensions (>=4.7.1)"
+]
 
-urllib3 = ">= 2.1.0, < 3.0.0"
-python-dateutil = ">= 2.8.2"
-aiohttp = ">= 3.8.4"
-aiohttp-retry = ">= 2.8.3"
-pem = ">= 19.3.0"
-pycryptodome = ">= 3.9.0"
-pydantic = ">= 2"
-typing-extensions = ">= 4.7.1"
+[tool.poetry]
+requires-poetry = ">=2.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -7,6 +7,10 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = "^3.9"
 

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -1,25 +1,28 @@
-[tool.poetry]
+[project]
 name = "petstore_api"
 version = "1.0.0"
 description = "OpenAPI Petstore"
-authors = ["OpenAPI Generator Community <team@openapitools.org>"]
+authors = [
+  {name = "OpenAPI Generator Community",email = "team@openapitools.org"},
+]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
-include = ["petstore_api/py.typed"]
+requires-python = "^3.9"
 
-[tool.poetry.dependencies]
-python = "^3.9"
+dependencies = [
+  "urllib3 (>=2.1.0,<3.0.0)",
+  "python-dateutil (>=2.8.2)",
+  "pem (>=19.3.0)",
+  "pycryptodome (>=3.9.0)",
+  "pydantic (>=2)",
+  "typing-extensions (>=4.7.1)"
+]
 
-urllib3 = ">= 2.1.0, < 3.0.0"
-python-dateutil = ">= 2.8.2"
-pem = ">= 19.3.0"
-pycryptodome = ">= 3.9.0"
-pydantic = ">= 2"
-typing-extensions = ">= 4.7.1"
+[tool.poetry]
+requires-poetry = ">=2.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">= 7.2.1"
 pytest-cov = ">= 2.8.1"
 tox = ">= 3.9.0"

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -7,10 +7,6 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-
-[project.urls]
-Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
-
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = "^3.9"
 
@@ -22,6 +18,9 @@ dependencies = [
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)"
 ]
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
 
 [tool.poetry]
 requires-poetry = ">=2.0"

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -7,6 +7,10 @@ authors = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
+
+[project.urls]
+Repository = "https://github.com/GIT_USER_ID/GIT_REPO_ID"
+
 keywords = ["OpenAPI", "OpenAPI-Generator", "OpenAPI Petstore"]
 requires-python = "^3.9"
 


### PR DESCRIPTION
Since the release of Poetry 2.0.0 the format of `pyproject.toml` that it is expecting changed.
See also: https://python-poetry.org/blog/announcing-poetry-2.0.0

This PR aims to update the pyproject.toml file to a format that does not use (now) deprecated features introduced by Poetry 1.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (@cbornet @tomplus @krjakbrjak @fa0311 @multani)
