### PR TITLE
(csharp generator) Add useIEnumerable in additionalProperties for des…

### DIFF
--- a/docs/generators/aspnet-fastendpoints.md
+++ b/docs/generators/aspnet-fastendpoints.md
@@ -71,6 +71,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>Guid</li>
 <li>Guid?</li>
 <li>ICollection</li>
+<li>IEnumerable</li>
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>

--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -89,6 +89,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>Guid</li>
 <li>Guid?</li>
 <li>ICollection</li>
+<li>IEnumerable</li>
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>

--- a/docs/generators/csharp-functions.md
+++ b/docs/generators/csharp-functions.md
@@ -81,6 +81,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>Guid</li>
 <li>Guid?</li>
 <li>ICollection</li>
+<li>IEnumerable</li>
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>

--- a/docs/generators/csharp.md
+++ b/docs/generators/csharp.md
@@ -91,6 +91,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>Guid</li>
 <li>Guid?</li>
 <li>ICollection</li>
+<li>IEnumerable</li>
 <li>Int32</li>
 <li>Int64</li>
 <li>List</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -205,6 +205,9 @@ public class CodegenConstants {
     public static final String USE_COLLECTION = "useCollection";
     public static final String USE_COLLECTION_DESC = "Deserialize array types to Collection<T> instead of List<T>.";
 
+    public static final String USE_IENUMERABLE = "useIEnumerable";
+    public static final String USE_IENUMERABLE_DESC = "Deserialize array types to IEnumerable<T> instead of List<T>.";
+
     public static final String INTERFACE_PREFIX = "interfacePrefix";
     public static final String INTERFACE_PREFIX_DESC = "Prefix interfaces with a community standard or widely accepted prefix.";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -60,6 +60,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
     protected boolean useDateTimeOffsetFlag = false;
     protected boolean useDateTimeForDateFlag = false;
     protected boolean useCollection = false;
+    protected boolean useIEnumerable = false;
     @Setter protected boolean returnICollection = false;
     @Setter protected boolean netCoreProjectFileFlag = false;
     protected boolean nullReferenceTypesFlag = false;
@@ -187,6 +188,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
                         "byte[]",
                         "ICollection",
                         "Collection",
+                        "IEnumerable",
                         "List",
                         "Dictionary",
                         "DateTime?",
@@ -217,6 +219,15 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
         if (useCollection) {
             instantiationTypes.put("array", "Collection");
             instantiationTypes.put("list", "Collection");
+        }
+        this.setTypeMapping();
+    }
+
+    public void setUseIEnumerable(boolean useIEnumerable) {
+        this.useIEnumerable = useIEnumerable;
+        if (useIEnumerable) {
+            instantiationTypes.put("array", "IEnumerable");
+            instantiationTypes.put("list", "IEnumerable");
         }
         this.setTypeMapping();
     }
@@ -364,6 +375,12 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
             setUseCollection(convertPropertyToBooleanAndWriteBack(CodegenConstants.USE_COLLECTION));
         } else {
             additionalProperties.put(CodegenConstants.USE_COLLECTION, useCollection);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.USE_IENUMERABLE)) {
+            setUseIEnumerable(convertPropertyToBooleanAndWriteBack(CodegenConstants.USE_IENUMERABLE));
+        } else {
+            additionalProperties.put(CodegenConstants.USE_IENUMERABLE, useIEnumerable);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.RETURN_ICOLLECTION)) {
@@ -770,7 +787,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
 
         property.name = patchPropertyName(model, property.name, null);
 
-        String[] nestedTypes = {"List", "Collection", "ICollection", "Dictionary"};
+        String[] nestedTypes = {"List", "Collection", "ICollection", "Dictionary", "IEnumerable" };
 
         Arrays.stream(nestedTypes).forEach(nestedType -> {
             // fix incorrect data types for maps of maps
@@ -1277,7 +1294,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
     }
 
     protected void processOperation(CodegenOperation operation) {
-        String[] nestedTypes = {"List", "Collection", "ICollection", "Dictionary"};
+        String[] nestedTypes = {"List", "Collection", "ICollection", "Dictionary", "IEnumerable" };
 
         Arrays.stream(nestedTypes).forEach(nestedType -> {
             if (operation.returnProperty != null && operation.returnType.contains("<" + nestedType + ">") && operation.returnProperty.items != null) {
@@ -2066,6 +2083,10 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
         if (this.useCollection) {
             typeMapping.put("array", "Collection");
             typeMapping.put("list", "Collection");
+        }
+        if (this.useIEnumerable) {
+            typeMapping.put("array", "IEnumerable");
+            typeMapping.put("list", "IEnumerable");
         }
     }
 }


### PR DESCRIPTION
…erializing array types to IEnumerable<T> instead of List<T>.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Our client code prefers IEnumerable to List for arrays. And right now OpenAPI generator only supports List.
It's also mentioned in [https://github.com/OpenAPITools/openapi-generator/issues/19664](url)

@mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)
Please kindly review the pr.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
