### PR TITLE
[JAVA] Correct generation of schema default values of type object (issue #21051)

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3604,8 +3604,6 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
 
-        JavaClientCodegen codegen = new JavaClientCodegen();
-        codegen.setOutputDir(output.getAbsolutePath());
         Map<String, Object> properties = new HashMap<>();
         properties.put(APIS, false);
         properties.put(API_DOCS, false);
@@ -3613,7 +3611,6 @@ public class JavaClientCodegenTest {
         properties.put(MODEL_DOCS, false);
         properties.put(MODEL_TESTS, false);
 
-        codegen.additionalProperties().putAll(properties);
         Generator generator = new DefaultGenerator();
         CodegenConfigurator configurator = new CodegenConfigurator()
                 .setInputSpec("src/test/resources/3_1/issue_21051.yaml")
@@ -3625,7 +3622,7 @@ public class JavaClientCodegenTest {
                 .generate();
         System.out.println("Generator Settings: " + clientOptInput.getGeneratorSettings());
         String outputPath = output.getAbsolutePath() + "/src/main/java/org/openapitools";
-        File testModel = new File(outputPath, "/client/model/Test.java");
+        File testModel = new File(outputPath, "/client/model/TestCase.java");
         String fileContent = Files.readString(testModel.toPath());
 
         System.out.println(fileContent);

--- a/modules/openapi-generator/src/test/resources/3_1/issue_21051.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_21051.yaml
@@ -33,7 +33,7 @@ components:
           type: string
           nullable: true
       nullable: true
-    Test:
+    TestCase:
       type: object
       properties:
         testEmptyInlineObject:

--- a/modules/openapi-generator/src/test/resources/3_1/issue_21051.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_21051.yaml
@@ -1,0 +1,114 @@
+# Modified from the original
+openapi: 3.1.0
+info:
+  title: Petstore API
+  description: Petstore API
+  version: 1.0.0
+servers:
+  - url: 'http://localhost'
+components:
+  schemas:
+    # Not generated - free-form object
+    EmptyReferenceObject:
+      type: object
+      default: {}
+    ComplexReferenceObject:
+      type: object
+      default:
+        foo: bar
+      properties:
+        foo:
+          type: string
+          nullable: true
+    NullableEmptyReferenceObject:
+      type: object
+      default: {}
+      nullable: true
+    NullableComplexReferenceObject:
+      type: object
+      default:
+        foo: bar
+      properties:
+        foo:
+          type: string
+          nullable: true
+      nullable: true
+    Test:
+      type: object
+      properties:
+        testEmptyInlineObject:
+          type: object
+          default: {}
+        testComplexInlineObject:
+          type: object
+          default:
+            foo: bar
+            fooInt: 28
+            fooLong: 5000000000
+            fooBool: true
+            fooFloat: 32.5
+            fooDouble: 3332.555
+            fooNumber: 120.6
+            fooDateTime: "2000-01-01T20:20:20+00:00"
+            fooUUID: "a0ed70ec-5fe5-415a-be97-a7bf13db9fb6"
+            void: empty
+            nonExistentDefault: 27
+          properties:
+            foo:
+              type: string
+              nullable: true
+            fooInt:
+              type: integer
+              nullable: true
+            fooLong:
+              type: integer
+              format: int64
+              nullable: true
+            fooBool:
+              type: boolean
+            fooFloat:
+              type: number
+              format: float
+              nullable: true
+            fooDouble:
+              type: number
+              format: double
+              nullable: true
+            fooNumber:
+              type: number
+              nullable: true
+            fooDateTime:
+              type: string
+              format: date-time
+              nullable: true
+            fooUUID:
+              type: string
+              format: uuid
+              nullable: true
+            void: # Java keyword
+              type: string
+              nullable: true
+            nonDefaultedProperty:
+              type: string
+              nullable: true
+        testNullableEmptyInlineObject:
+          type: object
+          default: {}
+          nullable: true
+        testNullableComplexInlineObject:
+          type: object
+          default:
+            foo: bar
+          properties:
+            foo:
+              type: string
+              nullable: true
+          nullable: true
+        testEmptyReference:
+          $ref: '#/components/schemas/EmptyReferenceObject'
+        testComplexReference:
+          $ref: '#/components/schemas/ComplexReferenceObject'
+        testNullableEmptyReference:
+          $ref: '#/components/schemas/NullableEmptyReferenceObject'
+        testNullableComplexReference:
+          $ref: '#/components/schemas/NullableComplexReferenceObject'


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

https://github.com/OpenAPITools/openapi-generator/issues/21051
@martin-mfg , please help review

I think I've covered all the proper schema sub-types, here's what a newly generated sample looks like:
```java
public class Test {
  public static final String SERIALIZED_NAME_TEST_EMPTY_INLINE_OBJECT = "testEmptyInlineObject";
  @SerializedName(SERIALIZED_NAME_TEST_EMPTY_INLINE_OBJECT)
  @javax.annotation.Nullable
  private Object testEmptyInlineObject = new Object();

  public static final String SERIALIZED_NAME_TEST_COMPLEX_INLINE_OBJECT = "testComplexInlineObject";
  @SerializedName(SERIALIZED_NAME_TEST_COMPLEX_INLINE_OBJECT)
  @javax.annotation.Nullable
  private TestTestComplexInlineObject testComplexInlineObject = new TestTestComplexInlineObject().foo("bar").fooInt(28).fooLong(5000000000l).fooBool(true).fooFloat(32.5f).fooDouble(3332.555d).fooNumber(new java.math.BigDecimal("120.6")).fooDateTime(java.time.OffsetDateTime.parse("2000-01-01T20:20:20+00:00", java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(java.time.ZoneId.systemDefault()))).fooUUID(java.util.UUID.fromString("a0ed70ec-5fe5-415a-be97-a7bf13db9fb6"))._void("empty");

  public static final String SERIALIZED_NAME_TEST_NULLABLE_EMPTY_INLINE_OBJECT = "testNullableEmptyInlineObject";
  @SerializedName(SERIALIZED_NAME_TEST_NULLABLE_EMPTY_INLINE_OBJECT)
  @javax.annotation.Nullable
  private Object testNullableEmptyInlineObject = new Object();

  public static final String SERIALIZED_NAME_TEST_NULLABLE_COMPLEX_INLINE_OBJECT = "testNullableComplexInlineObject";
  @SerializedName(SERIALIZED_NAME_TEST_NULLABLE_COMPLEX_INLINE_OBJECT)
  @javax.annotation.Nullable
  private TestTestNullableComplexInlineObject testNullableComplexInlineObject = new TestTestNullableComplexInlineObject().foo("bar");

  public static final String SERIALIZED_NAME_TEST_EMPTY_REFERENCE = "testEmptyReference";
  @SerializedName(SERIALIZED_NAME_TEST_EMPTY_REFERENCE)
  @javax.annotation.Nullable
  private Object testEmptyReference = new Object();

  public static final String SERIALIZED_NAME_TEST_COMPLEX_REFERENCE = "testComplexReference";
  @SerializedName(SERIALIZED_NAME_TEST_COMPLEX_REFERENCE)
  @javax.annotation.Nullable
  private ComplexReferenceObject testComplexReference = new ComplexReferenceObject().foo("bar");

  public static final String SERIALIZED_NAME_TEST_NULLABLE_EMPTY_REFERENCE = "testNullableEmptyReference";
  @SerializedName(SERIALIZED_NAME_TEST_NULLABLE_EMPTY_REFERENCE)
  @javax.annotation.Nullable
  private Object testNullableEmptyReference = new Object();

  public static final String SERIALIZED_NAME_TEST_NULLABLE_COMPLEX_REFERENCE = "testNullableComplexReference";
  @SerializedName(SERIALIZED_NAME_TEST_NULLABLE_COMPLEX_REFERENCE)
  @javax.annotation.Nullable
  private NullableComplexReferenceObject testNullableComplexReference = new NullableComplexReferenceObject().foo("bar");
...
}
```
This is probably a non-issue, but `testComplexInlineObject ` has a very long line, do you have any ideas on how I can break it apart neatly, or should I leave it as-is?