### PR TITLE
[GO] Go Server: Adds ordered routes to go-server router

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -66,6 +66,7 @@ func (c *{{classname}}Controller) Routes() Routes {
 {{#operations}}
 	{{#operation}}
 		"{{operationId}}": Route{
+			"{{operationId}}",
 			strings.ToUpper("{{httpMethod}}"),
 			"{{{basePathWithoutHost}}}{{{path}}}",
 			c.{{operationId}},
@@ -73,7 +74,25 @@ func (c *{{classname}}Controller) Routes() Routes {
 	{{/operation}}
 {{/operations}}
 	}
-}{{#operations}}{{#operation}}
+}
+
+// OrderedRoutes returns all the api routes in a deterministic order for the {{classname}}Controller
+func (c *{{classname}}Controller) OrderedRoutes() []Route {
+	return []Route{
+{{#operations}}
+	{{#operation}}
+		Route{
+			"{{operationId}}",
+			strings.ToUpper("{{httpMethod}}"),
+			"{{{basePathWithoutHost}}}{{{path}}}",
+			c.{{operationId}},
+		},
+	{{/operation}}
+{{/operations}}
+	}
+}
+
+{{#operations}}{{#operation}}
 
 // {{nickname}} - {{{summary}}}
 {{#isDeprecated}}

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -66,7 +66,7 @@ func (c *{{classname}}Controller) Routes() Routes {
 {{#operations}}
 	{{#operation}}
 		"{{operationId}}": Route{
-			"{{operationId}}",
+			"{{{operationId}}}",
 			strings.ToUpper("{{httpMethod}}"),
 			"{{{basePathWithoutHost}}}{{{path}}}",
 			c.{{operationId}},
@@ -82,7 +82,7 @@ func (c *{{classname}}Controller) OrderedRoutes() []Route {
 {{#operations}}
 	{{#operation}}
 		Route{
-			"{{operationId}}",
+			"{{{operationId}}}",
 			strings.ToUpper("{{httpMethod}}"),
 			"{{{basePathWithoutHost}}}{{{path}}}",
 			c.{{operationId}},

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -33,7 +33,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
-    OrderedRoutes() []Route
+	OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers

--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -21,8 +21,9 @@ import (
 
 // A Route defines the parameters for an api endpoint
 type Route struct {
-	Method	  string
-	Pattern	 string
+	Name        string
+	Method	    string
+	Pattern	    string
 	HandlerFunc http.HandlerFunc
 }
 
@@ -32,6 +33,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+    OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers
@@ -49,11 +51,11 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 	{{/chi}}
 {{/routers}}
 	for _, api := range routers {
-		for {{#routers}}{{#mux}}name{{/mux}}{{#chi}}_{{/chi}}{{/routers}}, route := range api.Routes() {
+		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc
 {{#routers}}
 	{{#mux}}
-			handler = Logger(handler, name)
+			handler = Logger(handler, route.Name)
 			{{#featureCORS}}
 			handler = handlers.CORS()(handler)
 			{{/featureCORS}}
@@ -61,7 +63,7 @@ func NewRouter(routers ...Router) {{#routers}}{{#mux}}*mux.Router{{/mux}}{{#chi}
 			router.
 				Methods(route.Method).
 				Path(route.Pattern).
-				Name(name).
+				Name(route.Name).
 				Handler(handler)
 	{{/mux}}
 	{{#chi}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/goserver/GoServerCodegenTest.java
@@ -70,7 +70,7 @@ public class GoServerCodegenTest {
         // verify /getPath/latest is first route
         Assert.assertEquals(Files.readAllLines(Paths.get(output + "/go/api_dev.go")).get(52), "\t\t\"GetLatest\": Route{");
         // verify /getPath/{id} is second route
-        Assert.assertEquals(Files.readAllLines(Paths.get(output + "/go/api_dev.go")).get(57), "\t\t\"GetById\": Route{");
+        Assert.assertEquals(Files.readAllLines(Paths.get(output + "/go/api_dev.go")).get(58), "\t\t\"GetById\": Route{");
 
     }
 

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
@@ -53,47 +53,111 @@ func NewPetAPIController(s PetAPIServicer, opts ...PetAPIOption) *PetAPIControll
 func (c *PetAPIController) Routes() Routes {
 	return Routes{
 		"UpdatePet": Route{
+			"UpdatePet",
 			strings.ToUpper("Put"),
 			"/v2/pet",
 			c.UpdatePet,
 		},
 		"AddPet": Route{
+			"AddPet",
 			strings.ToUpper("Post"),
 			"/v2/pet",
 			c.AddPet,
 		},
 		"FindPetsByStatus": Route{
+			"FindPetsByStatus",
 			strings.ToUpper("Get"),
 			"/v2/pet/findByStatus",
 			c.FindPetsByStatus,
 		},
 		"FindPetsByTags": Route{
+			"FindPetsByTags",
 			strings.ToUpper("Get"),
 			"/v2/pet/findByTags",
 			c.FindPetsByTags,
 		},
 		"GetPetById": Route{
+			"GetPetById",
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}",
 			c.GetPetById,
 		},
 		"UpdatePetWithForm": Route{
+			"UpdatePetWithForm",
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}",
 			c.UpdatePetWithForm,
 		},
 		"DeletePet": Route{
+			"DeletePet",
 			strings.ToUpper("Delete"),
 			"/v2/pet/{petId}",
 			c.DeletePet,
 		},
 		"UploadFile": Route{
+			"UploadFile",
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}/uploadImage",
 			c.UploadFile,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the PetAPIController
+func (c *PetAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"UpdatePet",
+			strings.ToUpper("Put"),
+			"/v2/pet",
+			c.UpdatePet,
+		},
+		Route{
+			"AddPet",
+			strings.ToUpper("Post"),
+			"/v2/pet",
+			c.AddPet,
+		},
+		Route{
+			"FindPetsByStatus",
+			strings.ToUpper("Get"),
+			"/v2/pet/findByStatus",
+			c.FindPetsByStatus,
+		},
+		Route{
+			"FindPetsByTags",
+			strings.ToUpper("Get"),
+			"/v2/pet/findByTags",
+			c.FindPetsByTags,
+		},
+		Route{
+			"GetPetById",
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}",
+			c.GetPetById,
+		},
+		Route{
+			"UpdatePetWithForm",
+			strings.ToUpper("Post"),
+			"/v2/pet/{petId}",
+			c.UpdatePetWithForm,
+		},
+		Route{
+			"DeletePet",
+			strings.ToUpper("Delete"),
+			"/v2/pet/{petId}",
+			c.DeletePet,
+		},
+		Route{
+			"UploadFile",
+			strings.ToUpper("Post"),
+			"/v2/pet/{petId}/uploadImage",
+			c.UploadFile,
+		},
+	}
+}
+
+
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
@@ -52,27 +52,63 @@ func NewStoreAPIController(s StoreAPIServicer, opts ...StoreAPIOption) *StoreAPI
 func (c *StoreAPIController) Routes() Routes {
 	return Routes{
 		"GetInventory": Route{
+			"GetInventory",
 			strings.ToUpper("Get"),
 			"/v2/store/inventory",
 			c.GetInventory,
 		},
 		"PlaceOrder": Route{
+			"PlaceOrder",
 			strings.ToUpper("Post"),
 			"/v2/store/order",
 			c.PlaceOrder,
 		},
 		"GetOrderById": Route{
+			"GetOrderById",
 			strings.ToUpper("Get"),
 			"/v2/store/order/{orderId}",
 			c.GetOrderById,
 		},
 		"DeleteOrder": Route{
+			"DeleteOrder",
 			strings.ToUpper("Delete"),
 			"/v2/store/order/{orderId}",
 			c.DeleteOrder,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the StoreAPIController
+func (c *StoreAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"GetInventory",
+			strings.ToUpper("Get"),
+			"/v2/store/inventory",
+			c.GetInventory,
+		},
+		Route{
+			"PlaceOrder",
+			strings.ToUpper("Post"),
+			"/v2/store/order",
+			c.PlaceOrder,
+		},
+		Route{
+			"GetOrderById",
+			strings.ToUpper("Get"),
+			"/v2/store/order/{orderId}",
+			c.GetOrderById,
+		},
+		Route{
+			"DeleteOrder",
+			strings.ToUpper("Delete"),
+			"/v2/store/order/{orderId}",
+			c.DeleteOrder,
+		},
+	}
+}
+
+
 
 // GetInventory - Returns pet inventories by status
 func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
@@ -52,47 +52,111 @@ func NewUserAPIController(s UserAPIServicer, opts ...UserAPIOption) *UserAPICont
 func (c *UserAPIController) Routes() Routes {
 	return Routes{
 		"CreateUser": Route{
+			"CreateUser",
 			strings.ToUpper("Post"),
 			"/v2/user",
 			c.CreateUser,
 		},
 		"CreateUsersWithArrayInput": Route{
+			"CreateUsersWithArrayInput",
 			strings.ToUpper("Post"),
 			"/v2/user/createWithArray",
 			c.CreateUsersWithArrayInput,
 		},
 		"CreateUsersWithListInput": Route{
+			"CreateUsersWithListInput",
 			strings.ToUpper("Post"),
 			"/v2/user/createWithList",
 			c.CreateUsersWithListInput,
 		},
 		"LoginUser": Route{
+			"LoginUser",
 			strings.ToUpper("Get"),
 			"/v2/user/login",
 			c.LoginUser,
 		},
 		"LogoutUser": Route{
+			"LogoutUser",
 			strings.ToUpper("Get"),
 			"/v2/user/logout",
 			c.LogoutUser,
 		},
 		"GetUserByName": Route{
+			"GetUserByName",
 			strings.ToUpper("Get"),
 			"/v2/user/{username}",
 			c.GetUserByName,
 		},
 		"UpdateUser": Route{
+			"UpdateUser",
 			strings.ToUpper("Put"),
 			"/v2/user/{username}",
 			c.UpdateUser,
 		},
 		"DeleteUser": Route{
+			"DeleteUser",
 			strings.ToUpper("Delete"),
 			"/v2/user/{username}",
 			c.DeleteUser,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the UserAPIController
+func (c *UserAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"CreateUser",
+			strings.ToUpper("Post"),
+			"/v2/user",
+			c.CreateUser,
+		},
+		Route{
+			"CreateUsersWithArrayInput",
+			strings.ToUpper("Post"),
+			"/v2/user/createWithArray",
+			c.CreateUsersWithArrayInput,
+		},
+		Route{
+			"CreateUsersWithListInput",
+			strings.ToUpper("Post"),
+			"/v2/user/createWithList",
+			c.CreateUsersWithListInput,
+		},
+		Route{
+			"LoginUser",
+			strings.ToUpper("Get"),
+			"/v2/user/login",
+			c.LoginUser,
+		},
+		Route{
+			"LogoutUser",
+			strings.ToUpper("Get"),
+			"/v2/user/logout",
+			c.LogoutUser,
+		},
+		Route{
+			"GetUserByName",
+			strings.ToUpper("Get"),
+			"/v2/user/{username}",
+			c.GetUserByName,
+		},
+		Route{
+			"UpdateUser",
+			strings.ToUpper("Put"),
+			"/v2/user/{username}",
+			c.UpdateUser,
+		},
+		Route{
+			"DeleteUser",
+			strings.ToUpper("Delete"),
+			"/v2/user/{username}",
+			c.DeleteUser,
+		},
+	}
+}
+
+
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
@@ -29,7 +29,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
-    OrderedRoutes() []Route
+	OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers

--- a/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
@@ -17,8 +17,9 @@ import (
 
 // A Route defines the parameters for an api endpoint
 type Route struct {
-	Method	  string
-	Pattern	 string
+	Name        string
+	Method	    string
+	Pattern	    string
 	HandlerFunc http.HandlerFunc
 }
 
@@ -28,6 +29,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+    OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers
@@ -35,7 +37,7 @@ func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()
 	router.Use(Logger)
 	for _, api := range routers {
-		for _, route := range api.Routes() {
+		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc
 			router.Method(route.Method, route.Pattern, handler)
 		}

--- a/samples/server/others/go-server/no-body-path-params/go/api_body.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_body.go
@@ -50,12 +50,27 @@ func NewBodyAPIController(s BodyAPIServicer, opts ...BodyAPIOption) *BodyAPICont
 func (c *BodyAPIController) Routes() Routes {
 	return Routes{
 		"Body": Route{
+			"Body",
 			strings.ToUpper("Post"),
 			"/body/endpoint",
 			c.Body,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the BodyAPIController
+func (c *BodyAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"Body",
+			strings.ToUpper("Post"),
+			"/body/endpoint",
+			c.Body,
+		},
+	}
+}
+
+
 
 // Body - summary
 func (c *BodyAPIController) Body(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/others/go-server/no-body-path-params/go/api_both.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_both.go
@@ -52,12 +52,27 @@ func NewBothAPIController(s BothAPIServicer, opts ...BothAPIOption) *BothAPICont
 func (c *BothAPIController) Routes() Routes {
 	return Routes{
 		"Both": Route{
+			"Both",
 			strings.ToUpper("Post"),
 			"/both/endpoint/{pathParam}",
 			c.Both,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the BothAPIController
+func (c *BothAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"Both",
+			strings.ToUpper("Post"),
+			"/both/endpoint/{pathParam}",
+			c.Both,
+		},
+	}
+}
+
+
 
 // Both - summary
 func (c *BothAPIController) Both(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/others/go-server/no-body-path-params/go/api_none.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_none.go
@@ -49,12 +49,27 @@ func NewNoneAPIController(s NoneAPIServicer, opts ...NoneAPIOption) *NoneAPICont
 func (c *NoneAPIController) Routes() Routes {
 	return Routes{
 		"One": Route{
+			"One",
 			strings.ToUpper("Get"),
 			"/none/endpoint",
 			c.One,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the NoneAPIController
+func (c *NoneAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"One",
+			strings.ToUpper("Get"),
+			"/none/endpoint",
+			c.One,
+		},
+	}
+}
+
+
 
 // One - summary
 func (c *NoneAPIController) One(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/others/go-server/no-body-path-params/go/api_path.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_path.go
@@ -51,12 +51,27 @@ func NewPathAPIController(s PathAPIServicer, opts ...PathAPIOption) *PathAPICont
 func (c *PathAPIController) Routes() Routes {
 	return Routes{
 		"Path": Route{
+			"Path",
 			strings.ToUpper("Get"),
 			"/path/endpoint/{pathParam}",
 			c.Path,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the PathAPIController
+func (c *PathAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"Path",
+			strings.ToUpper("Get"),
+			"/path/endpoint/{pathParam}",
+			c.Path,
+		},
+	}
+}
+
+
 
 // Path - summary
 func (c *PathAPIController) Path(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/others/go-server/no-body-path-params/go/routers.go
+++ b/samples/server/others/go-server/no-body-path-params/go/routers.go
@@ -29,7 +29,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
-    OrderedRoutes() []Route
+	OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers

--- a/samples/server/others/go-server/no-body-path-params/go/routers.go
+++ b/samples/server/others/go-server/no-body-path-params/go/routers.go
@@ -17,8 +17,9 @@ import (
 
 // A Route defines the parameters for an api endpoint
 type Route struct {
-	Method	  string
-	Pattern	 string
+	Name        string
+	Method	    string
+	Pattern	    string
 	HandlerFunc http.HandlerFunc
 }
 
@@ -28,20 +29,21 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+    OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, api := range routers {
-		for name, route := range api.Routes() {
+		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc
-			handler = Logger(handler, name)
+			handler = Logger(handler, route.Name)
 
 			router.
 				Methods(route.Method).
 				Path(route.Pattern).
-				Name(name).
+				Name(route.Name).
 				Handler(handler)
 		}
 	}

--- a/samples/server/petstore/go-api-server/go/api_fake.go
+++ b/samples/server/petstore/go-api-server/go/api_fake.go
@@ -50,12 +50,27 @@ func NewFakeAPIController(s FakeAPIServicer, opts ...FakeAPIOption) *FakeAPICont
 func (c *FakeAPIController) Routes() Routes {
 	return Routes{
 		"FakePostTest": Route{
+			"FakePostTest",
 			strings.ToUpper("Post"),
 			"/v2/fake/collection/test",
 			c.FakePostTest,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the FakeAPIController
+func (c *FakeAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"FakePostTest",
+			strings.ToUpper("Post"),
+			"/v2/fake/collection/test",
+			c.FakePostTest,
+		},
+	}
+}
+
+
 
 // FakePostTest - POST a test batch
 func (c *FakeAPIController) FakePostTest(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -54,77 +54,183 @@ func NewPetAPIController(s PetAPIServicer, opts ...PetAPIOption) *PetAPIControll
 func (c *PetAPIController) Routes() Routes {
 	return Routes{
 		"UpdatePet": Route{
+			"UpdatePet",
 			strings.ToUpper("Put"),
 			"/v2/pet",
 			c.UpdatePet,
 		},
 		"AddPet": Route{
+			"AddPet",
 			strings.ToUpper("Post"),
 			"/v2/pet",
 			c.AddPet,
 		},
 		"FindPetsByStatus": Route{
+			"FindPetsByStatus",
 			strings.ToUpper("Get"),
 			"/v2/pet/findByStatus",
 			c.FindPetsByStatus,
 		},
 		"SearchPet": Route{
+			"SearchPet",
 			strings.ToUpper("Get"),
 			"/v2/pet/searchPetWithManyFilters",
 			c.SearchPet,
 		},
 		"FindPetsByTags": Route{
+			"FindPetsByTags",
 			strings.ToUpper("Get"),
 			"/v2/pet/findByTags",
 			c.FindPetsByTags,
 		},
 		"FilterPetsByCategory": Route{
+			"FilterPetsByCategory",
 			strings.ToUpper("Get"),
 			"/v2/pet/filterPets/{gender}",
 			c.FilterPetsByCategory,
 		},
 		"GetPetById": Route{
+			"GetPetById",
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}",
 			c.GetPetById,
 		},
 		"UpdatePetWithForm": Route{
+			"UpdatePetWithForm",
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}",
 			c.UpdatePetWithForm,
 		},
 		"DeletePet": Route{
+			"DeletePet",
 			strings.ToUpper("Delete"),
 			"/v2/pet/{petId}",
 			c.DeletePet,
 		},
 		"GetPetImageById": Route{
+			"GetPetImageById",
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}/uploadImage",
 			c.GetPetImageById,
 		},
 		"UploadFile": Route{
+			"UploadFile",
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}/uploadImage",
 			c.UploadFile,
 		},
 		"UploadFileArrayOfFiles": Route{
+			"UploadFileArrayOfFiles",
 			strings.ToUpper("Post"),
 			"/v2/fake/uploadImage/array of_file",
 			c.UploadFileArrayOfFiles,
 		},
 		"GetPetsUsingBooleanQueryParameters": Route{
+			"GetPetsUsingBooleanQueryParameters",
 			strings.ToUpper("Get"),
 			"/v2/pets/boolean/parsing",
 			c.GetPetsUsingBooleanQueryParameters,
 		},
 		"GetPetsByTime": Route{
+			"GetPetsByTime",
 			strings.ToUpper("Get"),
 			"/v2/pets/byTime/{createdTime}",
 			c.GetPetsByTime,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the PetAPIController
+func (c *PetAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"UpdatePet",
+			strings.ToUpper("Put"),
+			"/v2/pet",
+			c.UpdatePet,
+		},
+		Route{
+			"AddPet",
+			strings.ToUpper("Post"),
+			"/v2/pet",
+			c.AddPet,
+		},
+		Route{
+			"FindPetsByStatus",
+			strings.ToUpper("Get"),
+			"/v2/pet/findByStatus",
+			c.FindPetsByStatus,
+		},
+		Route{
+			"SearchPet",
+			strings.ToUpper("Get"),
+			"/v2/pet/searchPetWithManyFilters",
+			c.SearchPet,
+		},
+		Route{
+			"FindPetsByTags",
+			strings.ToUpper("Get"),
+			"/v2/pet/findByTags",
+			c.FindPetsByTags,
+		},
+		Route{
+			"FilterPetsByCategory",
+			strings.ToUpper("Get"),
+			"/v2/pet/filterPets/{gender}",
+			c.FilterPetsByCategory,
+		},
+		Route{
+			"GetPetById",
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}",
+			c.GetPetById,
+		},
+		Route{
+			"UpdatePetWithForm",
+			strings.ToUpper("Post"),
+			"/v2/pet/{petId}",
+			c.UpdatePetWithForm,
+		},
+		Route{
+			"DeletePet",
+			strings.ToUpper("Delete"),
+			"/v2/pet/{petId}",
+			c.DeletePet,
+		},
+		Route{
+			"GetPetImageById",
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}/uploadImage",
+			c.GetPetImageById,
+		},
+		Route{
+			"UploadFile",
+			strings.ToUpper("Post"),
+			"/v2/pet/{petId}/uploadImage",
+			c.UploadFile,
+		},
+		Route{
+			"UploadFileArrayOfFiles",
+			strings.ToUpper("Post"),
+			"/v2/fake/uploadImage/array of_file",
+			c.UploadFileArrayOfFiles,
+		},
+		Route{
+			"GetPetsUsingBooleanQueryParameters",
+			strings.ToUpper("Get"),
+			"/v2/pets/boolean/parsing",
+			c.GetPetsUsingBooleanQueryParameters,
+		},
+		Route{
+			"GetPetsByTime",
+			strings.ToUpper("Get"),
+			"/v2/pets/byTime/{createdTime}",
+			c.GetPetsByTime,
+		},
+	}
+}
+
+
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -52,27 +52,63 @@ func NewStoreAPIController(s StoreAPIServicer, opts ...StoreAPIOption) *StoreAPI
 func (c *StoreAPIController) Routes() Routes {
 	return Routes{
 		"GetInventory": Route{
+			"GetInventory",
 			strings.ToUpper("Get"),
 			"/v2/store/inventory",
 			c.GetInventory,
 		},
 		"PlaceOrder": Route{
+			"PlaceOrder",
 			strings.ToUpper("Post"),
 			"/v2/store/order",
 			c.PlaceOrder,
 		},
 		"GetOrderById": Route{
+			"GetOrderById",
 			strings.ToUpper("Get"),
 			"/v2/store/order/{orderId}",
 			c.GetOrderById,
 		},
 		"DeleteOrder": Route{
+			"DeleteOrder",
 			strings.ToUpper("Delete"),
 			"/v2/store/order/{orderId}",
 			c.DeleteOrder,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the StoreAPIController
+func (c *StoreAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"GetInventory",
+			strings.ToUpper("Get"),
+			"/v2/store/inventory",
+			c.GetInventory,
+		},
+		Route{
+			"PlaceOrder",
+			strings.ToUpper("Post"),
+			"/v2/store/order",
+			c.PlaceOrder,
+		},
+		Route{
+			"GetOrderById",
+			strings.ToUpper("Get"),
+			"/v2/store/order/{orderId}",
+			c.GetOrderById,
+		},
+		Route{
+			"DeleteOrder",
+			strings.ToUpper("Delete"),
+			"/v2/store/order/{orderId}",
+			c.DeleteOrder,
+		},
+	}
+}
+
+
 
 // GetInventory - Returns pet inventories by status
 func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -52,52 +52,123 @@ func NewUserAPIController(s UserAPIServicer, opts ...UserAPIOption) *UserAPICont
 func (c *UserAPIController) Routes() Routes {
 	return Routes{
 		"CreateUserNullable": Route{
+			"CreateUserNullable",
 			strings.ToUpper("Put"),
 			"/v2/user",
 			c.CreateUserNullable,
 		},
 		"CreateUser": Route{
+			"CreateUser",
 			strings.ToUpper("Post"),
 			"/v2/user",
 			c.CreateUser,
 		},
 		"CreateUsersWithArrayInput": Route{
+			"CreateUsersWithArrayInput",
 			strings.ToUpper("Post"),
 			"/v2/user/createWithArray",
 			c.CreateUsersWithArrayInput,
 		},
 		"CreateUsersWithListInput": Route{
+			"CreateUsersWithListInput",
 			strings.ToUpper("Post"),
 			"/v2/user/createWithList",
 			c.CreateUsersWithListInput,
 		},
 		"LoginUser": Route{
+			"LoginUser",
 			strings.ToUpper("Get"),
 			"/v2/user/login",
 			c.LoginUser,
 		},
 		"LogoutUser": Route{
+			"LogoutUser",
 			strings.ToUpper("Get"),
 			"/v2/user/logout",
 			c.LogoutUser,
 		},
 		"GetUserByName": Route{
+			"GetUserByName",
 			strings.ToUpper("Get"),
 			"/v2/user/{username}",
 			c.GetUserByName,
 		},
 		"UpdateUser": Route{
+			"UpdateUser",
 			strings.ToUpper("Put"),
 			"/v2/user/{username}",
 			c.UpdateUser,
 		},
 		"DeleteUser": Route{
+			"DeleteUser",
 			strings.ToUpper("Delete"),
 			"/v2/user/{username}",
 			c.DeleteUser,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the UserAPIController
+func (c *UserAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"CreateUserNullable",
+			strings.ToUpper("Put"),
+			"/v2/user",
+			c.CreateUserNullable,
+		},
+		Route{
+			"CreateUser",
+			strings.ToUpper("Post"),
+			"/v2/user",
+			c.CreateUser,
+		},
+		Route{
+			"CreateUsersWithArrayInput",
+			strings.ToUpper("Post"),
+			"/v2/user/createWithArray",
+			c.CreateUsersWithArrayInput,
+		},
+		Route{
+			"CreateUsersWithListInput",
+			strings.ToUpper("Post"),
+			"/v2/user/createWithList",
+			c.CreateUsersWithListInput,
+		},
+		Route{
+			"LoginUser",
+			strings.ToUpper("Get"),
+			"/v2/user/login",
+			c.LoginUser,
+		},
+		Route{
+			"LogoutUser",
+			strings.ToUpper("Get"),
+			"/v2/user/logout",
+			c.LogoutUser,
+		},
+		Route{
+			"GetUserByName",
+			strings.ToUpper("Get"),
+			"/v2/user/{username}",
+			c.GetUserByName,
+		},
+		Route{
+			"UpdateUser",
+			strings.ToUpper("Put"),
+			"/v2/user/{username}",
+			c.UpdateUser,
+		},
+		Route{
+			"DeleteUser",
+			strings.ToUpper("Delete"),
+			"/v2/user/{username}",
+			c.DeleteUser,
+		},
+	}
+}
+
+
 
 // CreateUserNullable - Create user
 func (c *UserAPIController) CreateUserNullable(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -29,7 +29,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
-    OrderedRoutes() []Route
+	OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -17,8 +17,9 @@ import (
 
 // A Route defines the parameters for an api endpoint
 type Route struct {
-	Method	  string
-	Pattern	 string
+	Name        string
+	Method	    string
+	Pattern	    string
 	HandlerFunc http.HandlerFunc
 }
 
@@ -28,20 +29,21 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+    OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers
 func NewRouter(routers ...Router) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, api := range routers {
-		for name, route := range api.Routes() {
+		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc
-			handler = Logger(handler, name)
+			handler = Logger(handler, route.Name)
 
 			router.
 				Methods(route.Method).
 				Path(route.Pattern).
-				Name(name).
+				Name(route.Name).
 				Handler(handler)
 		}
 	}

--- a/samples/server/petstore/go-api-server/samples_tests/api_pet_test.go
+++ b/samples/server/petstore/go-api-server/samples_tests/api_pet_test.go
@@ -14,6 +14,7 @@ func Test_API_Pet(t *testing.T) {
 		filepath := "../go/api_pet.go"
 
 		expected := ("\t\t\"DeletePet\": Route{\n" +
+			"\t\t\t\"DeletePet\",\n" +
 			"\t\t\tstrings.ToUpper(\"Delete\"),\n" +
 			"\t\t\t\"/v2/pet/{petId}\",\n" +
 			"\t\t\tc.DeletePet,\n" +

--- a/samples/server/petstore/go-api-server/samples_tests/routers_test.go
+++ b/samples/server/petstore/go-api-server/samples_tests/routers_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/GIT_USER_ID/GIT_REPO_ID/samples_tests/utils"
 )
@@ -14,8 +14,9 @@ func Test_Routers(t *testing.T) {
 		filepath := "../go/routers.go"
 
 		expected := ("type Route struct {\n" +
-			"\tMethod\t  string\n" +
-			"\tPattern\t string\n" +
+			"\tName        string\n" +
+			"\tMethod	    string\n" +
+			"\tPattern	    string\n" +
 			"\tHandlerFunc http.HandlerFunc\n" +
 			"}")
 
@@ -31,8 +32,8 @@ func Test_Routers(t *testing.T) {
 		lines := utils.ReadLines(filepath)
 		expected := "type Routes map[string]Route"
 
-		if lines[25] != expected {
-			t.Errorf("Expected '%s', but got '%s'", expected, lines[25])
+		if lines[26] != expected {
+			t.Errorf("Expected '%s', but got '%s'", expected, lines[26])
 		}
 	})
 }

--- a/samples/server/petstore/go-chi-server/go/api_fake.go
+++ b/samples/server/petstore/go-chi-server/go/api_fake.go
@@ -50,12 +50,27 @@ func NewFakeAPIController(s FakeAPIServicer, opts ...FakeAPIOption) *FakeAPICont
 func (c *FakeAPIController) Routes() Routes {
 	return Routes{
 		"FakePostTest": Route{
+			"FakePostTest",
 			strings.ToUpper("Post"),
 			"/v2/fake/collection/test",
 			c.FakePostTest,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the FakeAPIController
+func (c *FakeAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"FakePostTest",
+			strings.ToUpper("Post"),
+			"/v2/fake/collection/test",
+			c.FakePostTest,
+		},
+	}
+}
+
+
 
 // FakePostTest - POST a test batch
 func (c *FakeAPIController) FakePostTest(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -54,77 +54,183 @@ func NewPetAPIController(s PetAPIServicer, opts ...PetAPIOption) *PetAPIControll
 func (c *PetAPIController) Routes() Routes {
 	return Routes{
 		"UpdatePet": Route{
+			"UpdatePet",
 			strings.ToUpper("Put"),
 			"/v2/pet",
 			c.UpdatePet,
 		},
 		"AddPet": Route{
+			"AddPet",
 			strings.ToUpper("Post"),
 			"/v2/pet",
 			c.AddPet,
 		},
 		"FindPetsByStatus": Route{
+			"FindPetsByStatus",
 			strings.ToUpper("Get"),
 			"/v2/pet/findByStatus",
 			c.FindPetsByStatus,
 		},
 		"SearchPet": Route{
+			"SearchPet",
 			strings.ToUpper("Get"),
 			"/v2/pet/searchPetWithManyFilters",
 			c.SearchPet,
 		},
 		"FindPetsByTags": Route{
+			"FindPetsByTags",
 			strings.ToUpper("Get"),
 			"/v2/pet/findByTags",
 			c.FindPetsByTags,
 		},
 		"FilterPetsByCategory": Route{
+			"FilterPetsByCategory",
 			strings.ToUpper("Get"),
 			"/v2/pet/filterPets/{gender}",
 			c.FilterPetsByCategory,
 		},
 		"GetPetById": Route{
+			"GetPetById",
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}",
 			c.GetPetById,
 		},
 		"UpdatePetWithForm": Route{
+			"UpdatePetWithForm",
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}",
 			c.UpdatePetWithForm,
 		},
 		"DeletePet": Route{
+			"DeletePet",
 			strings.ToUpper("Delete"),
 			"/v2/pet/{petId}",
 			c.DeletePet,
 		},
 		"GetPetImageById": Route{
+			"GetPetImageById",
 			strings.ToUpper("Get"),
 			"/v2/pet/{petId}/uploadImage",
 			c.GetPetImageById,
 		},
 		"UploadFile": Route{
+			"UploadFile",
 			strings.ToUpper("Post"),
 			"/v2/pet/{petId}/uploadImage",
 			c.UploadFile,
 		},
 		"UploadFileArrayOfFiles": Route{
+			"UploadFileArrayOfFiles",
 			strings.ToUpper("Post"),
 			"/v2/fake/uploadImage/array of_file",
 			c.UploadFileArrayOfFiles,
 		},
 		"GetPetsUsingBooleanQueryParameters": Route{
+			"GetPetsUsingBooleanQueryParameters",
 			strings.ToUpper("Get"),
 			"/v2/pets/boolean/parsing",
 			c.GetPetsUsingBooleanQueryParameters,
 		},
 		"GetPetsByTime": Route{
+			"GetPetsByTime",
 			strings.ToUpper("Get"),
 			"/v2/pets/byTime/{createdTime}",
 			c.GetPetsByTime,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the PetAPIController
+func (c *PetAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"UpdatePet",
+			strings.ToUpper("Put"),
+			"/v2/pet",
+			c.UpdatePet,
+		},
+		Route{
+			"AddPet",
+			strings.ToUpper("Post"),
+			"/v2/pet",
+			c.AddPet,
+		},
+		Route{
+			"FindPetsByStatus",
+			strings.ToUpper("Get"),
+			"/v2/pet/findByStatus",
+			c.FindPetsByStatus,
+		},
+		Route{
+			"SearchPet",
+			strings.ToUpper("Get"),
+			"/v2/pet/searchPetWithManyFilters",
+			c.SearchPet,
+		},
+		Route{
+			"FindPetsByTags",
+			strings.ToUpper("Get"),
+			"/v2/pet/findByTags",
+			c.FindPetsByTags,
+		},
+		Route{
+			"FilterPetsByCategory",
+			strings.ToUpper("Get"),
+			"/v2/pet/filterPets/{gender}",
+			c.FilterPetsByCategory,
+		},
+		Route{
+			"GetPetById",
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}",
+			c.GetPetById,
+		},
+		Route{
+			"UpdatePetWithForm",
+			strings.ToUpper("Post"),
+			"/v2/pet/{petId}",
+			c.UpdatePetWithForm,
+		},
+		Route{
+			"DeletePet",
+			strings.ToUpper("Delete"),
+			"/v2/pet/{petId}",
+			c.DeletePet,
+		},
+		Route{
+			"GetPetImageById",
+			strings.ToUpper("Get"),
+			"/v2/pet/{petId}/uploadImage",
+			c.GetPetImageById,
+		},
+		Route{
+			"UploadFile",
+			strings.ToUpper("Post"),
+			"/v2/pet/{petId}/uploadImage",
+			c.UploadFile,
+		},
+		Route{
+			"UploadFileArrayOfFiles",
+			strings.ToUpper("Post"),
+			"/v2/fake/uploadImage/array of_file",
+			c.UploadFileArrayOfFiles,
+		},
+		Route{
+			"GetPetsUsingBooleanQueryParameters",
+			strings.ToUpper("Get"),
+			"/v2/pets/boolean/parsing",
+			c.GetPetsUsingBooleanQueryParameters,
+		},
+		Route{
+			"GetPetsByTime",
+			strings.ToUpper("Get"),
+			"/v2/pets/byTime/{createdTime}",
+			c.GetPetsByTime,
+		},
+	}
+}
+
+
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -52,27 +52,63 @@ func NewStoreAPIController(s StoreAPIServicer, opts ...StoreAPIOption) *StoreAPI
 func (c *StoreAPIController) Routes() Routes {
 	return Routes{
 		"GetInventory": Route{
+			"GetInventory",
 			strings.ToUpper("Get"),
 			"/v2/store/inventory",
 			c.GetInventory,
 		},
 		"PlaceOrder": Route{
+			"PlaceOrder",
 			strings.ToUpper("Post"),
 			"/v2/store/order",
 			c.PlaceOrder,
 		},
 		"GetOrderById": Route{
+			"GetOrderById",
 			strings.ToUpper("Get"),
 			"/v2/store/order/{orderId}",
 			c.GetOrderById,
 		},
 		"DeleteOrder": Route{
+			"DeleteOrder",
 			strings.ToUpper("Delete"),
 			"/v2/store/order/{orderId}",
 			c.DeleteOrder,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the StoreAPIController
+func (c *StoreAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"GetInventory",
+			strings.ToUpper("Get"),
+			"/v2/store/inventory",
+			c.GetInventory,
+		},
+		Route{
+			"PlaceOrder",
+			strings.ToUpper("Post"),
+			"/v2/store/order",
+			c.PlaceOrder,
+		},
+		Route{
+			"GetOrderById",
+			strings.ToUpper("Get"),
+			"/v2/store/order/{orderId}",
+			c.GetOrderById,
+		},
+		Route{
+			"DeleteOrder",
+			strings.ToUpper("Delete"),
+			"/v2/store/order/{orderId}",
+			c.DeleteOrder,
+		},
+	}
+}
+
+
 
 // GetInventory - Returns pet inventories by status
 func (c *StoreAPIController) GetInventory(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -52,52 +52,123 @@ func NewUserAPIController(s UserAPIServicer, opts ...UserAPIOption) *UserAPICont
 func (c *UserAPIController) Routes() Routes {
 	return Routes{
 		"CreateUserNullable": Route{
+			"CreateUserNullable",
 			strings.ToUpper("Put"),
 			"/v2/user",
 			c.CreateUserNullable,
 		},
 		"CreateUser": Route{
+			"CreateUser",
 			strings.ToUpper("Post"),
 			"/v2/user",
 			c.CreateUser,
 		},
 		"CreateUsersWithArrayInput": Route{
+			"CreateUsersWithArrayInput",
 			strings.ToUpper("Post"),
 			"/v2/user/createWithArray",
 			c.CreateUsersWithArrayInput,
 		},
 		"CreateUsersWithListInput": Route{
+			"CreateUsersWithListInput",
 			strings.ToUpper("Post"),
 			"/v2/user/createWithList",
 			c.CreateUsersWithListInput,
 		},
 		"LoginUser": Route{
+			"LoginUser",
 			strings.ToUpper("Get"),
 			"/v2/user/login",
 			c.LoginUser,
 		},
 		"LogoutUser": Route{
+			"LogoutUser",
 			strings.ToUpper("Get"),
 			"/v2/user/logout",
 			c.LogoutUser,
 		},
 		"GetUserByName": Route{
+			"GetUserByName",
 			strings.ToUpper("Get"),
 			"/v2/user/{username}",
 			c.GetUserByName,
 		},
 		"UpdateUser": Route{
+			"UpdateUser",
 			strings.ToUpper("Put"),
 			"/v2/user/{username}",
 			c.UpdateUser,
 		},
 		"DeleteUser": Route{
+			"DeleteUser",
 			strings.ToUpper("Delete"),
 			"/v2/user/{username}",
 			c.DeleteUser,
 		},
 	}
 }
+
+// OrderedRoutes returns all the api routes in a deterministic order for the UserAPIController
+func (c *UserAPIController) OrderedRoutes() []Route {
+	return []Route{
+		Route{
+			"CreateUserNullable",
+			strings.ToUpper("Put"),
+			"/v2/user",
+			c.CreateUserNullable,
+		},
+		Route{
+			"CreateUser",
+			strings.ToUpper("Post"),
+			"/v2/user",
+			c.CreateUser,
+		},
+		Route{
+			"CreateUsersWithArrayInput",
+			strings.ToUpper("Post"),
+			"/v2/user/createWithArray",
+			c.CreateUsersWithArrayInput,
+		},
+		Route{
+			"CreateUsersWithListInput",
+			strings.ToUpper("Post"),
+			"/v2/user/createWithList",
+			c.CreateUsersWithListInput,
+		},
+		Route{
+			"LoginUser",
+			strings.ToUpper("Get"),
+			"/v2/user/login",
+			c.LoginUser,
+		},
+		Route{
+			"LogoutUser",
+			strings.ToUpper("Get"),
+			"/v2/user/logout",
+			c.LogoutUser,
+		},
+		Route{
+			"GetUserByName",
+			strings.ToUpper("Get"),
+			"/v2/user/{username}",
+			c.GetUserByName,
+		},
+		Route{
+			"UpdateUser",
+			strings.ToUpper("Put"),
+			"/v2/user/{username}",
+			c.UpdateUser,
+		},
+		Route{
+			"DeleteUser",
+			strings.ToUpper("Delete"),
+			"/v2/user/{username}",
+			c.DeleteUser,
+		},
+	}
+}
+
+
 
 // CreateUserNullable - Create user
 func (c *UserAPIController) CreateUserNullable(w http.ResponseWriter, r *http.Request) {

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -29,7 +29,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
-    OrderedRoutes() []Route
+	OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -17,8 +17,9 @@ import (
 
 // A Route defines the parameters for an api endpoint
 type Route struct {
-	Method	  string
-	Pattern	 string
+	Name        string
+	Method	    string
+	Pattern	    string
 	HandlerFunc http.HandlerFunc
 }
 
@@ -28,6 +29,7 @@ type Routes map[string]Route
 // Router defines the required methods for retrieving api routes
 type Router interface {
 	Routes() Routes
+    OrderedRoutes() []Route
 }
 
 // NewRouter creates a new router for any number of api routers
@@ -35,7 +37,7 @@ func NewRouter(routers ...Router) chi.Router {
 	router := chi.NewRouter()
 	router.Use(Logger)
 	for _, api := range routers {
-		for _, route := range api.Routes() {
+		for _, route := range api.OrderedRoutes() {
 			var handler http.Handler = route.HandlerFunc
 			router.Method(route.Method, route.Pattern, handler)
 		}


### PR DESCRIPTION
Go maps are never deterministically ordered, according to the [Go map documentation](https://pkg.go.dev/maps#All). 
> The iteration order is not specified and is not guaranteed to be the same from one call to the next

In the past, I think it was close enough to not be a problem, but since Go 1.24's refactor of how Go maps work (they are using swiss tables now) the orders are nearly random. This results in the returned `Routes`map being in a different iteration order each time, which is not ideal for cases where router-order matters (#19445 for instance)

To solve this, I have added a new function called `OrderedRoutes`which returns routes in an order-deterministic slice instead. I left the old `Routes()`getter for the time being for backwards compat.



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
