### PR TITLE
[Php-Symfony] add text/plain and image/png endpoint in petstore.yaml

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_0/php-symfony/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/php-symfony/petstore.yaml
@@ -283,6 +283,74 @@ paths:
                   description: file to upload
                   type: string
                   format: binary
+  '/pet/{petId}/downloadImage':
+    get:
+      tags:
+        - pet
+      summary: downloads an image
+      description: response may be an image
+      operationId: downloadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to download an image from
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+  '/pet/{petId}/age':
+    get:
+      tags:
+        - pet
+      summary: Get the age of the pet
+      description: response may be an int
+      operationId: petAge
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            text/plain:
+              schema:
+                type: integer
+                format: int64
+  '/pet/{petId}/available-for-sale':
+    get:
+      tags:
+        - pet
+      summary: Whether the pet can currently be bought
+      description: response may be a boolean
+      operationId: petAvailableForSale
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            text/plain:
+              schema:
+                type: boolean
   /store/inventory:
     get:
       tags:

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Api/PetApiInterface.php
@@ -99,6 +99,23 @@ interface PetApiInterface
     ): void;
 
     /**
+     * Operation downloadFile
+     *
+     * downloads an image
+     *
+     * @param  int $petId  ID of pet to download an image from (required)
+     * @param  int     &$responseCode    The HTTP Response Code
+     * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
+     *
+     * @return mixed
+     */
+    public function downloadFile(
+        int $petId,
+        int &$responseCode,
+        array &$responseHeaders
+    ): mixed;
+
+    /**
      * Operation findPetsByStatus
      *
      * Finds Pets by status
@@ -149,6 +166,40 @@ interface PetApiInterface
         int &$responseCode,
         array &$responseHeaders
     ): array|object|null;
+
+    /**
+     * Operation petAge
+     *
+     * Get the age of the pet
+     *
+     * @param  int $petId  ID of pet (required)
+     * @param  int     &$responseCode    The HTTP Response Code
+     * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
+     *
+     * @return int
+     */
+    public function petAge(
+        int $petId,
+        int &$responseCode,
+        array &$responseHeaders
+    ): int;
+
+    /**
+     * Operation petAvailableForSale
+     *
+     * Whether the pet can currently be bought
+     *
+     * @param  int $petId  ID of pet (required)
+     * @param  int     &$responseCode    The HTTP Response Code
+     * @param  array   $responseHeaders  Additional HTTP headers to return with the response ()
+     *
+     * @return bool
+     */
+    public function petAvailableForSale(
+        int $petId,
+        int &$responseCode,
+        array &$responseHeaders
+    ): bool;
 
     /**
      * Operation updatePet

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -216,6 +216,79 @@ class PetController extends Controller
     }
 
     /**
+     * Operation downloadFile
+     *
+     * downloads an image
+     *
+     * @param Request $request The Symfony request to handle.
+     * @return Response The Symfony response.
+     */
+    public function downloadFileAction(Request $request, $petId)
+    {
+        // Figure out what data format to return to the client
+        $produces = ['image/png'];
+        // Figure out what the client accepts
+        $clientAccepts = $request->headers->has('Accept')?$request->headers->get('Accept'):'*/*';
+        $responseFormat = $this->getOutputFormat($clientAccepts, $produces);
+        if ($responseFormat === null) {
+            return new Response('', 406);
+        }
+
+        // Handle authentication
+
+        // Read out all input parameter values into variables
+
+        // Use the default value if no value was provided
+
+        // Deserialize the input values that needs it
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
+
+        // Validate the input values
+        $asserts = [];
+        $asserts[] = new Assert\NotNull();
+        $asserts[] = new Assert\Type("int");
+        $response = $this->validate($petId, $asserts);
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+
+        try {
+            $handler = $this->getApiHandler();
+
+
+            // Make the call to the business logic
+            $responseCode = 200;
+            $responseHeaders = [];
+
+            $result = $handler->downloadFile($petId, $responseCode, $responseHeaders);
+
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                default => '',
+            };
+
+            return new Response(
+                $result !== null ?$this->serialize($result, $responseFormat):'',
+                $responseCode,
+                array_merge(
+                    $responseHeaders,
+                    [
+                        'Content-Type' => $responseFormat,
+                        'X-OpenAPI-Message' => $message
+                    ]
+                )
+            );
+        } catch (\Throwable $fallthrough) {
+            return $this->createErrorResponse(new HttpException(500, 'An unsuspected error occurred.', $fallthrough));
+        }
+    }
+
+    /**
      * Operation findPetsByStatus
      *
      * Finds Pets by status
@@ -446,6 +519,152 @@ class PetController extends Controller
                 200 => 'successful operation',
                 400 => 'Invalid ID supplied',
                 404 => 'Pet not found',
+                default => '',
+            };
+
+            return new Response(
+                $result !== null ?$this->serialize($result, $responseFormat):'',
+                $responseCode,
+                array_merge(
+                    $responseHeaders,
+                    [
+                        'Content-Type' => $responseFormat,
+                        'X-OpenAPI-Message' => $message
+                    ]
+                )
+            );
+        } catch (\Throwable $fallthrough) {
+            return $this->createErrorResponse(new HttpException(500, 'An unsuspected error occurred.', $fallthrough));
+        }
+    }
+
+    /**
+     * Operation petAge
+     *
+     * Get the age of the pet
+     *
+     * @param Request $request The Symfony request to handle.
+     * @return Response The Symfony response.
+     */
+    public function petAgeAction(Request $request, $petId)
+    {
+        // Figure out what data format to return to the client
+        $produces = ['text/plain'];
+        // Figure out what the client accepts
+        $clientAccepts = $request->headers->has('Accept')?$request->headers->get('Accept'):'*/*';
+        $responseFormat = $this->getOutputFormat($clientAccepts, $produces);
+        if ($responseFormat === null) {
+            return new Response('', 406);
+        }
+
+        // Handle authentication
+
+        // Read out all input parameter values into variables
+
+        // Use the default value if no value was provided
+
+        // Deserialize the input values that needs it
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
+
+        // Validate the input values
+        $asserts = [];
+        $asserts[] = new Assert\NotNull();
+        $asserts[] = new Assert\Type("int");
+        $response = $this->validate($petId, $asserts);
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+
+        try {
+            $handler = $this->getApiHandler();
+
+
+            // Make the call to the business logic
+            $responseCode = 200;
+            $responseHeaders = [];
+
+            $result = $handler->petAge($petId, $responseCode, $responseHeaders);
+
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                default => '',
+            };
+
+            return new Response(
+                $result !== null ?$this->serialize($result, $responseFormat):'',
+                $responseCode,
+                array_merge(
+                    $responseHeaders,
+                    [
+                        'Content-Type' => $responseFormat,
+                        'X-OpenAPI-Message' => $message
+                    ]
+                )
+            );
+        } catch (\Throwable $fallthrough) {
+            return $this->createErrorResponse(new HttpException(500, 'An unsuspected error occurred.', $fallthrough));
+        }
+    }
+
+    /**
+     * Operation petAvailableForSale
+     *
+     * Whether the pet can currently be bought
+     *
+     * @param Request $request The Symfony request to handle.
+     * @return Response The Symfony response.
+     */
+    public function petAvailableForSaleAction(Request $request, $petId)
+    {
+        // Figure out what data format to return to the client
+        $produces = ['text/plain'];
+        // Figure out what the client accepts
+        $clientAccepts = $request->headers->has('Accept')?$request->headers->get('Accept'):'*/*';
+        $responseFormat = $this->getOutputFormat($clientAccepts, $produces);
+        if ($responseFormat === null) {
+            return new Response('', 406);
+        }
+
+        // Handle authentication
+
+        // Read out all input parameter values into variables
+
+        // Use the default value if no value was provided
+
+        // Deserialize the input values that needs it
+        try {
+            $petId = $this->deserialize($petId, 'int', 'string');
+        } catch (SerializerRuntimeException $exception) {
+            return $this->createBadRequestResponse($exception->getMessage());
+        }
+
+        // Validate the input values
+        $asserts = [];
+        $asserts[] = new Assert\NotNull();
+        $asserts[] = new Assert\Type("int");
+        $response = $this->validate($petId, $asserts);
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+
+        try {
+            $handler = $this->getApiHandler();
+
+
+            // Make the call to the business logic
+            $responseCode = 200;
+            $responseHeaders = [];
+
+            $result = $handler->petAvailableForSale($petId, $responseCode, $responseHeaders);
+
+            $message = match($responseCode) {
+                200 => 'successful operation',
                 default => '',
             };
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/README.md
@@ -120,9 +120,12 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *PetApiInterface* | [**addPet**](docs/Api/PetApiInterface.md#addpet) | **POST** /pet | Add a new pet to the store
 *PetApiInterface* | [**deletePet**](docs/Api/PetApiInterface.md#deletepet) | **DELETE** /pet/{petId} | Deletes a pet
+*PetApiInterface* | [**downloadFile**](docs/Api/PetApiInterface.md#downloadfile) | **GET** /pet/{petId}/downloadImage | downloads an image
 *PetApiInterface* | [**findPetsByStatus**](docs/Api/PetApiInterface.md#findpetsbystatus) | **GET** /pet/findByStatus | Finds Pets by status
 *PetApiInterface* | [**findPetsByTags**](docs/Api/PetApiInterface.md#findpetsbytags) | **GET** /pet/findByTags | Finds Pets by tags
 *PetApiInterface* | [**getPetById**](docs/Api/PetApiInterface.md#getpetbyid) | **GET** /pet/{petId} | Find pet by ID
+*PetApiInterface* | [**petAge**](docs/Api/PetApiInterface.md#petage) | **GET** /pet/{petId}/age | Get the age of the pet
+*PetApiInterface* | [**petAvailableForSale**](docs/Api/PetApiInterface.md#petavailableforsale) | **GET** /pet/{petId}/available-for-sale | Whether the pet can currently be bought
 *PetApiInterface* | [**updatePet**](docs/Api/PetApiInterface.md#updatepet) | **PUT** /pet | Update an existing pet
 *PetApiInterface* | [**updatePetWithForm**](docs/Api/PetApiInterface.md#updatepetwithform) | **POST** /pet/{petId} | Updates a pet in the store with form data
 *PetApiInterface* | [**uploadFile**](docs/Api/PetApiInterface.md#uploadfile) | **POST** /pet/{petId}/uploadImage | uploads an image

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/routing.yaml
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Resources/config/routing.yaml
@@ -17,6 +17,14 @@ open_api_server_pet_deletepet:
     requirements:
         petId: '\d+'
 
+open_api_server_pet_downloadfile:
+    path:     /pet/{petId}/downloadImage
+    methods:  [GET]
+    defaults:
+        _controller: open_api_server.controller.pet::downloadFileAction
+    requirements:
+        petId: '\d+'
+
 open_api_server_pet_findpetsbystatus:
     path:     /pet/findByStatus
     methods:  [GET]
@@ -34,6 +42,22 @@ open_api_server_pet_getpetbyid:
     methods:  [GET]
     defaults:
         _controller: open_api_server.controller.pet::getPetByIdAction
+    requirements:
+        petId: '\d+'
+
+open_api_server_pet_petage:
+    path:     /pet/{petId}/age
+    methods:  [GET]
+    defaults:
+        _controller: open_api_server.controller.pet::petAgeAction
+    requirements:
+        petId: '\d+'
+
+open_api_server_pet_petavailableforsale:
+    path:     /pet/{petId}/available-for-sale
+    methods:  [GET]
+    defaults:
+        _controller: open_api_server.controller.pet::petAvailableForSaleAction
     requirements:
         petId: '\d+'
 

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/docs/Api/PetApiInterface.md
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/docs/Api/PetApiInterface.md
@@ -6,9 +6,12 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**addPet**](PetApiInterface.md#addPet) | **POST** /pet | Add a new pet to the store
 [**deletePet**](PetApiInterface.md#deletePet) | **DELETE** /pet/{petId} | Deletes a pet
+[**downloadFile**](PetApiInterface.md#downloadFile) | **GET** /pet/{petId}/downloadImage | downloads an image
 [**findPetsByStatus**](PetApiInterface.md#findPetsByStatus) | **GET** /pet/findByStatus | Finds Pets by status
 [**findPetsByTags**](PetApiInterface.md#findPetsByTags) | **GET** /pet/findByTags | Finds Pets by tags
 [**getPetById**](PetApiInterface.md#getPetById) | **GET** /pet/{petId} | Find pet by ID
+[**petAge**](PetApiInterface.md#petAge) | **GET** /pet/{petId}/age | Get the age of the pet
+[**petAvailableForSale**](PetApiInterface.md#petAvailableForSale) | **GET** /pet/{petId}/available-for-sale | Whether the pet can currently be bought
 [**updatePet**](PetApiInterface.md#updatePet) | **PUT** /pet | Update an existing pet
 [**updatePetWithForm**](PetApiInterface.md#updatePetWithForm) | **POST** /pet/{petId} | Updates a pet in the store with form data
 [**uploadFile**](PetApiInterface.md#uploadFile) | **POST** /pet/{petId}/uploadImage | uploads an image
@@ -147,6 +150,60 @@ void (empty response body)
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+## **downloadFile**
+> UploadedFile downloadFile($petId)
+
+downloads an image
+
+response may be an image
+
+### Example Implementation
+```php
+<?php
+// src/Acme/MyBundle/Api/PetApiInterface.php
+
+namespace Acme\MyBundle\Api;
+
+use OpenAPI\Server\Api\PetApiInterface;
+
+class PetApi implements PetApiInterface
+{
+
+    // ...
+
+    /**
+     * Implementation of PetApiInterface#downloadFile
+     */
+    public function downloadFile(int $petId, int &$responseCode, array &$responseHeaders): mixed
+    {
+        // Implement the operation ...
+    }
+
+    // ...
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **int**| ID of pet to download an image from |
+
+### Return type
+
+**UploadedFile**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: image/png
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 
@@ -333,6 +390,114 @@ Name | Type | Description  | Notes
 
  - **Content-Type**: Not defined
  - **Accept**: application/xml, application/json
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+## **petAge**
+> int petAge($petId)
+
+Get the age of the pet
+
+response may be an int
+
+### Example Implementation
+```php
+<?php
+// src/Acme/MyBundle/Api/PetApiInterface.php
+
+namespace Acme\MyBundle\Api;
+
+use OpenAPI\Server\Api\PetApiInterface;
+
+class PetApi implements PetApiInterface
+{
+
+    // ...
+
+    /**
+     * Implementation of PetApiInterface#petAge
+     */
+    public function petAge(int $petId, int &$responseCode, array &$responseHeaders): int
+    {
+        // Implement the operation ...
+    }
+
+    // ...
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **int**| ID of pet |
+
+### Return type
+
+**int**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+## **petAvailableForSale**
+> bool petAvailableForSale($petId)
+
+Whether the pet can currently be bought
+
+response may be a boolean
+
+### Example Implementation
+```php
+<?php
+// src/Acme/MyBundle/Api/PetApiInterface.php
+
+namespace Acme\MyBundle\Api;
+
+use OpenAPI\Server\Api\PetApiInterface;
+
+class PetApi implements PetApiInterface
+{
+
+    // ...
+
+    /**
+     * Implementation of PetApiInterface#petAvailableForSale
+     */
+    public function petAvailableForSale(int $petId, int &$responseCode, array &$responseHeaders): bool
+    {
+        // Implement the operation ...
+    }
+
+    // ...
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **petId** | **int**| ID of pet |
+
+### Return type
+
+**bool**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


PR #21261 added support for endpoints with response of type text/plain or even image/png.

This commit adds such endpoints (and the subsequently generated samples) so that:
- the way those are supported is clearer (as it is now directly visible in the generated sample files)
- if a future commit impacts this part of the generation it will be easier to assess that impact

(nb: first time I'm editing an openapi specification in that repo, I hope I'm doing that commit correctly. Please let me know if I'm doing something wrong, or missing something)

Ping PHP committee: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon 