### PR TITLE
Replace deprecated `to_dict` with `model_dump` for Pydantic v2 compatibility

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/model_generic.mustache
@@ -114,8 +114,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> {{^hasChildren}}Self{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union[{{#children}}Self{{^-last}}, {{/-last}}{{/children}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}{{/hasChildren}}:

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -127,8 +127,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[{{^hasChildren}}Self{{/hasChildren}}{{#hasChildren}}{{#discriminator}}Union[{{#mappedModels}}{{{modelName}}}{{^-last}}, {{/-last}}{{/mappedModels}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}{{/hasChildren}}]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/bird.py
@@ -44,8 +44,7 @@ class Bird(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/category.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/category.py
@@ -44,8 +44,7 @@ class Category(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/data_query.py
@@ -47,8 +47,7 @@ class DataQuery(Query):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/default_value.py
@@ -62,8 +62,7 @@ class DefaultValue(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/number_properties_only.py
@@ -46,8 +46,7 @@ class NumberPropertiesOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/pet.py
@@ -60,8 +60,7 @@ class Pet(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/query.py
@@ -55,8 +55,7 @@ class Query(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/tag.py
@@ -44,8 +44,7 @@ class Tag(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_form_object_multipart_request_marker.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_form_object_multipart_request_marker.py
@@ -43,8 +43,7 @@ class TestFormObjectMultipartRequestMarker(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -46,8 +46,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_query_style_form_explode_true_array_integer_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_query_style_form_explode_true_array_integer_query_object_parameter.py
@@ -43,8 +43,7 @@ class TestQueryStyleFormExplodeTrueArrayIntegerQueryObjectParameter(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -43,8 +43,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python/openapi_client/models/bird.py
@@ -44,8 +44,7 @@ class Bird(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/category.py
+++ b/samples/client/echo_api/python/openapi_client/models/category.py
@@ -44,8 +44,7 @@ class Category(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python/openapi_client/models/data_query.py
@@ -47,8 +47,7 @@ class DataQuery(Query):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -62,8 +62,7 @@ class DefaultValue(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
@@ -46,8 +46,7 @@ class NumberPropertiesOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -60,8 +60,7 @@ class Pet(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/query.py
+++ b/samples/client/echo_api/python/openapi_client/models/query.py
@@ -55,8 +55,7 @@ class Query(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python/openapi_client/models/tag.py
@@ -44,8 +44,7 @@ class Tag(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/test_form_object_multipart_request_marker.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_form_object_multipart_request_marker.py
@@ -43,8 +43,7 @@ class TestFormObjectMultipartRequestMarker(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -46,8 +46,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_integer_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_integer_query_object_parameter.py
@@ -43,8 +43,7 @@ class TestQueryStyleFormExplodeTrueArrayIntegerQueryObjectParameter(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -43,8 +43,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesAnyType(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesObject(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_super_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_super_model.py
@@ -42,8 +42,7 @@ class AllOfSuperModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -44,8 +44,7 @@ class AllOfWithSingleRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -66,8 +66,7 @@ class Animal(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[Cat, Dog]]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -43,8 +43,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -42,8 +42,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
@@ -42,8 +42,7 @@ class ArrayOfNumberOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -47,8 +47,7 @@ class ArrayTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/base_discriminator.py
@@ -65,8 +65,7 @@ class BaseDiscriminator(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[PrimitiveString, Info]]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
@@ -43,8 +43,7 @@ class BasquePig(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/bathing.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/bathing.py
@@ -58,8 +58,7 @@ class Bathing(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
@@ -47,8 +47,7 @@ class Capitalization(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
@@ -43,8 +43,7 @@ class Cat(Animal):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
@@ -43,8 +43,7 @@ class Category(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_all_of_ref.py
@@ -43,8 +43,7 @@ class CircularAllOfRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -43,8 +43,7 @@ class CircularReferenceModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -42,8 +42,7 @@ class ClassModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
@@ -42,8 +42,7 @@ class Client(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -66,8 +66,7 @@ class Creature(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[HuntingDog]]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
@@ -42,8 +42,7 @@ class CreatureInfo(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
@@ -43,8 +43,7 @@ class DanishPig(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
@@ -42,8 +42,7 @@ class DeprecatedObject(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/discriminator_all_of_sub.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/discriminator_all_of_sub.py
@@ -42,8 +42,7 @@ class DiscriminatorAllOfSub(DiscriminatorAllOfSuper):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/discriminator_all_of_super.py
@@ -64,8 +64,7 @@ class DiscriminatorAllOfSuper(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[DiscriminatorAllOfSub]]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
@@ -43,8 +43,7 @@ class Dog(Animal):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -43,8 +43,7 @@ class DummyModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
@@ -64,8 +64,7 @@ class EnumArrays(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -127,8 +127,7 @@ class EnumTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/feeding.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/feeding.py
@@ -58,8 +58,7 @@ class Feeding(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -42,8 +42,7 @@ class File(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -44,8 +44,7 @@ class FileSchemaTestClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -43,8 +43,7 @@ class FirstRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
@@ -42,8 +42,7 @@ class Foo(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -43,8 +43,7 @@ class FooGetDefaultResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -101,8 +101,7 @@ class FormatTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
@@ -43,8 +43,7 @@ class HasOnlyReadOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -42,8 +42,7 @@ class HealthCheckResult(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/hunting_dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/hunting_dog.py
@@ -44,8 +44,7 @@ class HuntingDog(Creature):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/info.py
@@ -43,8 +43,7 @@ class Info(BaseDiscriminator):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -42,8 +42,7 @@ class InnerDictWithProperty(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/input_all_of.py
@@ -43,8 +43,7 @@ class InputAllOf(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
@@ -42,8 +42,7 @@ class ListClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -43,8 +43,7 @@ class MapOfArrayOfModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -56,8 +56,7 @@ class MapTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -46,8 +46,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -43,8 +43,7 @@ class Model200Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_api_response.py
@@ -44,8 +44,7 @@ class ModelApiResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_field.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_field.py
@@ -42,8 +42,7 @@ class ModelField(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -42,8 +42,7 @@ class ModelReturn(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/multi_arrays.py
@@ -45,8 +45,7 @@ class MultiArrays(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -45,8 +45,7 @@ class Name(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -56,8 +56,7 @@ class NullableClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -54,8 +54,7 @@ class NullableProperty(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
@@ -42,8 +42,7 @@ class NumberOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -42,8 +42,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -46,8 +46,7 @@ class ObjectWithDeprecatedFields(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
@@ -58,8 +58,7 @@ class Order(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
@@ -44,8 +44,7 @@ class OuterComposite(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -45,8 +45,7 @@ class OuterObjectWithEnumProperty(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -43,8 +43,7 @@ class Parent(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -43,8 +43,7 @@ class ParentWithOptionalDict(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -60,8 +60,7 @@ class Pet(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/poop_cleaning.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/poop_cleaning.py
@@ -58,8 +58,7 @@ class PoopCleaning(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/primitive_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/primitive_string.py
@@ -43,8 +43,7 @@ class PrimitiveString(BaseDiscriminator):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_map.py
@@ -43,8 +43,7 @@ class PropertyMap(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
@@ -44,8 +44,7 @@ class PropertyNameCollision(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
@@ -43,8 +43,7 @@ class ReadOnlyFirst(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_circular_all_of_ref.py
@@ -43,8 +43,7 @@ class SecondCircularAllOfRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -43,8 +43,7 @@ class SecondRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -43,8 +43,7 @@ class SelfReferenceModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
@@ -42,8 +42,7 @@ class SpecialModelName(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
@@ -55,8 +55,7 @@ class SpecialName(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
@@ -43,8 +43,7 @@ class Tag(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/task.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/task.py
@@ -44,8 +44,7 @@ class Task(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model400_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model400_response.py
@@ -42,8 +42,7 @@ class TestErrorResponsesWithModel400Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model404_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model404_response.py
@@ -42,8 +42,7 @@ class TestErrorResponsesWithModel404Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -43,8 +43,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_model_with_enum_default.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_model_with_enum_default.py
@@ -58,8 +58,7 @@ class TestModelWithEnumDefault(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_object_for_multipart_requests_request_marker.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_object_for_multipart_requests_request_marker.py
@@ -42,8 +42,7 @@ class TestObjectForMultipartRequestsRequestMarker(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
@@ -42,8 +42,7 @@ class Tiger(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -43,8 +43,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -42,8 +42,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/upload_file_with_additional_properties_request_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/upload_file_with_additional_properties_request_object.py
@@ -42,8 +42,7 @@ class UploadFileWithAdditionalPropertiesRequestObject(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
@@ -49,8 +49,7 @@ class User(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -46,8 +46,7 @@ class WithNestedOneOf(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))  
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesAnyType(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -44,8 +44,7 @@ class AdditionalPropertiesClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesObject(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
@@ -43,8 +43,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/all_of_super_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/all_of_super_model.py
@@ -43,8 +43,7 @@ class AllOfSuperModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
@@ -45,8 +45,7 @@ class AllOfWithSingleRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -67,8 +67,7 @@ class Animal(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[Cat, Dog]]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -44,8 +44,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
@@ -43,8 +43,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
@@ -43,8 +43,7 @@ class ArrayOfNumberOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -48,8 +48,7 @@ class ArrayTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/base_discriminator.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/base_discriminator.py
@@ -66,8 +66,7 @@ class BaseDiscriminator(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[PrimitiveString, Info]]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
@@ -44,8 +44,7 @@ class BasquePig(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/bathing.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/bathing.py
@@ -59,8 +59,7 @@ class Bathing(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
@@ -48,8 +48,7 @@ class Capitalization(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
@@ -44,8 +44,7 @@ class Cat(Animal):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/category.py
@@ -44,8 +44,7 @@ class Category(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_all_of_ref.py
@@ -44,8 +44,7 @@ class CircularAllOfRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
@@ -44,8 +44,7 @@ class CircularReferenceModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
@@ -43,8 +43,7 @@ class ClassModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/client.py
@@ -43,8 +43,7 @@ class Client(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
@@ -67,8 +67,7 @@ class Creature(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[HuntingDog]]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
@@ -43,8 +43,7 @@ class CreatureInfo(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
@@ -44,8 +44,7 @@ class DanishPig(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
@@ -43,8 +43,7 @@ class DeprecatedObject(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/discriminator_all_of_sub.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/discriminator_all_of_sub.py
@@ -43,8 +43,7 @@ class DiscriminatorAllOfSub(DiscriminatorAllOfSuper):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/discriminator_all_of_super.py
@@ -65,8 +65,7 @@ class DiscriminatorAllOfSuper(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Union[DiscriminatorAllOfSub]]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
@@ -44,8 +44,7 @@ class Dog(Animal):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
@@ -44,8 +44,7 @@ class DummyModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -65,8 +65,7 @@ class EnumArrays(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -128,8 +128,7 @@ class EnumTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/feeding.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/feeding.py
@@ -59,8 +59,7 @@ class Feeding(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file.py
@@ -43,8 +43,7 @@ class File(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
@@ -45,8 +45,7 @@ class FileSchemaTestClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
@@ -44,8 +44,7 @@ class FirstRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
@@ -43,8 +43,7 @@ class Foo(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
@@ -44,8 +44,7 @@ class FooGetDefaultResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -102,8 +102,7 @@ class FormatTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
@@ -44,8 +44,7 @@ class HasOnlyReadOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
@@ -43,8 +43,7 @@ class HealthCheckResult(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/hunting_dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/hunting_dog.py
@@ -45,8 +45,7 @@ class HuntingDog(Creature):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/info.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/info.py
@@ -44,8 +44,7 @@ class Info(BaseDiscriminator):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
@@ -43,8 +43,7 @@ class InnerDictWithProperty(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/input_all_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/input_all_of.py
@@ -44,8 +44,7 @@ class InputAllOf(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/list_class.py
@@ -43,8 +43,7 @@ class ListClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -44,8 +44,7 @@ class MapOfArrayOfModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
@@ -57,8 +57,7 @@ class MapTest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -47,8 +47,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
@@ -44,8 +44,7 @@ class Model200Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_api_response.py
@@ -45,8 +45,7 @@ class ModelApiResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_field.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_field.py
@@ -43,8 +43,7 @@ class ModelField(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
@@ -43,8 +43,7 @@ class ModelReturn(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/multi_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/multi_arrays.py
@@ -46,8 +46,7 @@ class MultiArrays(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/name.py
@@ -46,8 +46,7 @@ class Name(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -56,8 +56,7 @@ class NullableClass(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -55,8 +55,7 @@ class NullableProperty(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
@@ -43,8 +43,7 @@ class NumberOnly(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
@@ -43,8 +43,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
@@ -47,8 +47,7 @@ class ObjectWithDeprecatedFields(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/order.py
@@ -59,8 +59,7 @@ class Order(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
@@ -45,8 +45,7 @@ class OuterComposite(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
@@ -46,8 +46,7 @@ class OuterObjectWithEnumProperty(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -44,8 +44,7 @@ class Parent(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -44,8 +44,7 @@ class ParentWithOptionalDict(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
@@ -61,8 +61,7 @@ class Pet(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/poop_cleaning.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/poop_cleaning.py
@@ -59,8 +59,7 @@ class PoopCleaning(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/primitive_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/primitive_string.py
@@ -44,8 +44,7 @@ class PrimitiveString(BaseDiscriminator):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_map.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_map.py
@@ -44,8 +44,7 @@ class PropertyMap(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
@@ -45,8 +45,7 @@ class PropertyNameCollision(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
@@ -44,8 +44,7 @@ class ReadOnlyFirst(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_circular_all_of_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_circular_all_of_ref.py
@@ -44,8 +44,7 @@ class SecondCircularAllOfRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
@@ -44,8 +44,7 @@ class SecondRef(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
@@ -44,8 +44,7 @@ class SelfReferenceModel(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
@@ -43,8 +43,7 @@ class SpecialModelName(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
@@ -56,8 +56,7 @@ class SpecialName(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
@@ -44,8 +44,7 @@ class Tag(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/task.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/task.py
@@ -45,8 +45,7 @@ class Task(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model400_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model400_response.py
@@ -43,8 +43,7 @@ class TestErrorResponsesWithModel400Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model404_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model404_response.py
@@ -43,8 +43,7 @@ class TestErrorResponsesWithModel404Response(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -43,8 +43,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_model_with_enum_default.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_model_with_enum_default.py
@@ -59,8 +59,7 @@ class TestModelWithEnumDefault(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_object_for_multipart_requests_request_marker.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_object_for_multipart_requests_request_marker.py
@@ -43,8 +43,7 @@ class TestObjectForMultipartRequestsRequestMarker(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
@@ -43,8 +43,7 @@ class Tiger(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -44,8 +44,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -43,8 +43,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/upload_file_with_additional_properties_request_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/upload_file_with_additional_properties_request_object.py
@@ -43,8 +43,7 @@ class UploadFileWithAdditionalPropertiesRequestObject(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/user.py
@@ -50,8 +50,7 @@ class User(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
@@ -47,8 +47,7 @@ class WithNestedOneOf(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/api_response.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/api_response.py
@@ -49,8 +49,7 @@ class ApiResponse(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/category.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/category.py
@@ -59,8 +59,7 @@ class Category(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/order.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/order.py
@@ -63,8 +63,7 @@ class Order(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/pet.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/pet.py
@@ -64,8 +64,7 @@ class Pet(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/tag.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/tag.py
@@ -48,8 +48,7 @@ class Tag(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/samples/server/petstore/python-fastapi/src/openapi_server/models/user.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/models/user.py
@@ -54,8 +54,7 @@ class User(BaseModel):
 
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
-        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:


### PR DESCRIPTION
 <!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

### Description

This pull request updates code generation to replace the deprecated `to_dict()` method from Pydantic v2 models with the recommended `model_dump()` method.
Verified that generated models using Pydantic v2 successfully serialize with `model_dump()` and produce the same output as before by running a unittest with this code.
```python
import unittest
import json
from pydantic import BaseModel, Field
  
class MyModel(BaseModel):
    id: int = Field(alias="identifier")
    name: str
    optional_field: str | None = None
  
    def to_dict(self):
        # Simulate old deprecated behavior (Pydantic v2 removed it)
        return self.model_dump(by_alias=True, exclude_unset=True)
  
    def old_json(self):
        return json.dumps(self.to_dict())
  
    def new_json(self):
        return json.dumps(self.model_dump(by_alias=True, exclude_unset=True))
  
class TestModelSerialization(unittest.TestCase):
    def test_json_output_equivalence(self):
        model = MyModel(identifier=1, name="Test")
        self.assertEqual(model.old_json(), model.new_json())
  
if __name__ == "__main__":
    unittest.main()
```
<!-- Please check the completed items below -->
### PR checklist
  
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapigenerator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here $
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ```
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking change$
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-t$