### PR TITLE
[python-fastapi] Upgrade dependencies to support Python 3.13

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -27,10 +27,10 @@ PyYAML>=5.4.1,<6.1.0
 requests==2.32.0
 Rx==1.6.1
 starlette==0.40.0
-typing-extensions==4.8.0
+typing-extensions==4.13.2
 ujson==4.0.2
 urllib3==1.26.19
 uvicorn==0.13.4
-uvloop==0.19.0
+uvloop==0.21.0
 watchgod==0.7
 websockets==10.0

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -27,10 +27,10 @@ PyYAML>=5.4.1,<6.1.0
 requests==2.32.0
 Rx==1.6.1
 starlette==0.40.0
-typing-extensions==4.8.0
+typing-extensions==4.13.2
 ujson==4.0.2
 urllib3==1.26.19
 uvicorn==0.13.4
-uvloop==0.19.0
+uvloop==0.21.0
 watchgod==0.7
 websockets==10.0


### PR DESCRIPTION
Currently, installing dependencies fails for FastAPI projects when using Python 3.13. This bumps up `typing-extensions` and `uvloop` to the latest versions to include 3.13 support. Using these new dependency versions with previous Python versions does not appear to cause any new problems when running `pip install`.

@krjakbrjak @fa0311 @multani 

Fixes #20058 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
