### PR TITLE
[PHP-Symfony] revamp the computation of the contentType

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -180,34 +180,56 @@ class Controller extends AbstractController
      */
     protected function getOutputFormat(string $accept, array $produced): ?string
     {
-        // Figure out what the client accepts
-        $accept = preg_split("/[\s,]+/", $accept);
+        // First get the list of formats accepted by the client by weight.
+        // eg: text/html,*/*; q=0.7, text/*;q=0.8,text/plain;format=fixed;q=0.6 is turned to
+        // [
+        //   text/html  => 1, // because when no weight is present then the default value is 1. See https://httpwg.org/specs/rfc9110.html#quality.values .
+        //   */*        => 0.7,
+        //   text/*     => 0.8,
+        //   text/plain => 0.6,
+        // ]
+        // So we can subsequently order that list by descending weight (because 1 is the most prefered value, 0.001 is the least preferred)
+        $weightedFormats = array();
+        foreach (explode(",", str_replace(' ', '', $accept)) as $accept) {
+            $exploded = explode(';', $accept);
 
-        // Remove q-factor weighting. E.g. "application/json;q=0.8" becomes "application/json"
-        $accept = array_map(function ($type) {return explode(';', $type)[0];}, $accept);
-
-        if (in_array('*/*', $accept) || in_array('application/*', $accept)) {
-            // Prefer JSON if the client has no preference
-            if (in_array('application/json', $produced)) {
-                return 'application/json';
+            // If no weight is present then the default value is 1 (see https://httpwg.org/specs/rfc9110.html#quality.values )
+            if (count($exploded) === 1) {
+                $weight = 1.0;
+            } else {
+                $lastItem = end($exploded);
+                if (str_starts_with($lastItem, "q=")) {
+                     $weight = (float) str_replace("q=", "", $lastItem);
+                } else {
+                     $weight = 1.0;
+                }
             }
-            if (in_array('application/xml', $produced)) {
-                return 'application/xml';
+            $weightedFormats[$exploded[0]] = $weight;
+        }
+        arsort($weightedFormats);
+
+        // Now return the first produced format that matches
+        foreach (array_keys($weightedFormats) as $acceptedFormat) {
+            $acceptedFormatParts = explode('/', $acceptedFormat);
+            if (count($acceptedFormatParts) != 2) {
+              // badly formatted header sent by the client. Let's continue (instead of crashing)
+              continue;
+            }
+            $acceptedFormatType = $acceptedFormatParts[0];
+            $acceptedFormatSubtype = $acceptedFormatParts[1];
+
+            foreach ($produced as $producedFormat) {
+                if ($acceptedFormat === $producedFormat) {
+                  return $producedFormat;
+                }
+                if ($acceptedFormatSubtype === '*' && $acceptedFormatType === explode("/", $producedFormat)[0]) {
+                  return $producedFormat;
+                }
+                if ($acceptedFormat === "*/*") {
+                  return $producedFormat;
+                }
             }
         }
-
-        if (in_array('application/json', $accept) && in_array('application/json', $produced)) {
-            return 'application/json';
-        }
-
-        if (in_array('application/xml', $accept) && in_array('application/xml', $produced)) {
-            return 'application/xml';
-        }
-
-        if (in_array('*/*', $accept)) {
-            return $produced[0];
-        }
-
         // If we reach this point, we don't have a common ground between server and client
         return null;
     }

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -190,34 +190,56 @@ class Controller extends AbstractController
      */
     protected function getOutputFormat(string $accept, array $produced): ?string
     {
-        // Figure out what the client accepts
-        $accept = preg_split("/[\s,]+/", $accept);
+        // First get the list of formats accepted by the client by weight.
+        // eg: text/html,*/*; q=0.7, text/*;q=0.8,text/plain;format=fixed;q=0.6 is turned to
+        // [
+        //   text/html  => 1, // because when no weight is present then the default value is 1. See https://httpwg.org/specs/rfc9110.html#quality.values .
+        //   */*        => 0.7,
+        //   text/*     => 0.8,
+        //   text/plain => 0.6,
+        // ]
+        // So we can subsequently order that list by descending weight (because 1 is the most prefered value, 0.001 is the least preferred)
+        $weightedFormats = array();
+        foreach (explode(",", str_replace(' ', '', $accept)) as $accept) {
+            $exploded = explode(';', $accept);
 
-        // Remove q-factor weighting. E.g. "application/json;q=0.8" becomes "application/json"
-        $accept = array_map(function ($type) {return explode(';', $type)[0];}, $accept);
-
-        if (in_array('*/*', $accept) || in_array('application/*', $accept)) {
-            // Prefer JSON if the client has no preference
-            if (in_array('application/json', $produced)) {
-                return 'application/json';
+            // If no weight is present then the default value is 1 (see https://httpwg.org/specs/rfc9110.html#quality.values )
+            if (count($exploded) === 1) {
+                $weight = 1.0;
+            } else {
+                $lastItem = end($exploded);
+                if (str_starts_with($lastItem, "q=")) {
+                     $weight = (float) str_replace("q=", "", $lastItem);
+                } else {
+                     $weight = 1.0;
+                }
             }
-            if (in_array('application/xml', $produced)) {
-                return 'application/xml';
+            $weightedFormats[$exploded[0]] = $weight;
+        }
+        arsort($weightedFormats);
+
+        // Now return the first produced format that matches
+        foreach (array_keys($weightedFormats) as $acceptedFormat) {
+            $acceptedFormatParts = explode('/', $acceptedFormat);
+            if (count($acceptedFormatParts) != 2) {
+              // badly formatted header sent by the client. Let's continue (instead of crashing)
+              continue;
+            }
+            $acceptedFormatType = $acceptedFormatParts[0];
+            $acceptedFormatSubtype = $acceptedFormatParts[1];
+
+            foreach ($produced as $producedFormat) {
+                if ($acceptedFormat === $producedFormat) {
+                  return $producedFormat;
+                }
+                if ($acceptedFormatSubtype === '*' && $acceptedFormatType === explode("/", $producedFormat)[0]) {
+                  return $producedFormat;
+                }
+                if ($acceptedFormat === "*/*") {
+                  return $producedFormat;
+                }
             }
         }
-
-        if (in_array('application/json', $accept) && in_array('application/json', $produced)) {
-            return 'application/json';
-        }
-
-        if (in_array('application/xml', $accept) && in_array('application/xml', $produced)) {
-            return 'application/xml';
-        }
-
-        if (in_array('*/*', $accept)) {
-            return $produced[0];
-        }
-
         // If we reach this point, we don't have a common ground between server and client
         return null;
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Why this commit

recent commit 40894382fc9fe959f3beacd20cfd6421eaf840b0 already improved that method: before that other commit it was just impossible to query a endpoint with a response type that was something else than `application/json` or `application/xml`. With that commit it became possible to query such endpoint provided that the client declare in its `Accept` header that it can cope with `*/*` (or provided that the client omitted that header altogether).

But there were still cases badly handled. For instance if an endpoint returns a response of type `image/png` and that it receives a query with header `Accept: image/png`, then it would reply with `406` (instead of just serving the image).

To avoid any other issues with type resolution, this commit revamps the `getOutputFormat` function more thoroughly and does it by implementing the specification (available at
https://httpwg.org/specs/rfc9110.html#field.accept ), which means in particular that the format accepted by the client are ordered by the relative weights specified (if any).

Nb: note that merging this PR would make it possible to close the PR #15560 since this one is a kind of superset of that other one.

### How to test this commit

Use a simple openapi specification with an endpoint that can serve several different response type. I used:

```
openapi: 3.0.0
servers:
  - url: 'http://petstore.swagger.io/v2'
info:
  version: 1.0.0
  title: OpenAPI Petstore
paths:
  '/pet/{petId}':
      get:
        tags:
          - pet
        summary: Find pet by ID
        description: Returns a single pet
        operationId: getPetById
        parameters:
          - name: petId
            in: path
            description: ID of pet to return
            required: true
            schema:
              type: integer
              format: int64
        responses:
          '200':
            description: successful operation
            content:
              application/xml:
                schema:
                  $ref: '#/components/schemas/Pet'
              application/json:
                schema:
                  $ref: '#/components/schemas/Pet'
              text/plain:
                schema:
                  type: string
              text/html:
                schema:
                  type: string
components:
  schemas:
    Pet:
      title: a Pet
      description: A pet for sale in the pet store
      type: object
      required:
        - name
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
          example: doggie
      xml:
        name: Pet

```

then generate the symfony bundle and create a Symfony app with a placeholder implementation of the generated interface. I used:

```
<?php
namespace App\Controller;

use OpenAPI\Server\Api\PetApiInterface;
use OpenAPI\Server\Model\Pet;

class PetApi implements PetApiInterface // An interface is autogenerated
{
    public function getPetById(
        int $petId,
        int &$responseCode,
        array &$responseHeaders
    ): array|object|null {
            return new Pet(array('id' => $petId, 'name' => "medor"));
    }
}
```

then I ran against that server the following curl queries, with the `-i` flag to check the content type of the response (nb: we don't care at all about the body of the response: only the content type header is important for those tests):

#### Some basic checks:
- `curl -i -H 'Accept: text/plain'  http://localhost:8000/pet/1` => response should have content type `text/plain` (without this patch this query yields a `406`)
- `curl -i -H 'Accept: text/html'  http://localhost:8000/pet/1 ` => response should have content type `text/html` (it receives a `406` without this patch
- `curl -i -H 'Accept: application/json'  http://localhost:8000/pet/1` => should be `application/json`

#### when there are not common format
- `curl -i -H 'Accept: image/png'  http://localhost:8000/pet/1` => should return a `406`

#### queries with weight
- `curl -i -H 'Accept: text/html, application/xml ; q=0.8'  http://localhost:8000/pet/1` => when there are no explicit weight then the default value is 1. So response should have content type `text/html` (nb: this query also has a bunch of whitespaces in the `Accept` header to make sure it is correctly handled). (nb: without this commit, the response has content type `application/xml`, which does not conform to the spec)
- `curl -i -H 'Accept: text/html;q=0.7, application/xml ; q=0.8'  http://localhost:8000/pet/1` => this ensure it works when the format with higher priority is not provided first in the list
- `curl -i -H 'Accept: image/png;q=0.9,text/html;q=0.8'  http://localhost:8000/pet/1` => tests that when the format with higher value is not supported, we correctly fallback to another one
- `curl -i -H 'Accept: text/*, application/xml ; q=0.8'  http://localhost:8000/pet/1` => tests that we can match when the subtype is a wildcard
- `curl -i -H 'Accept: */*'  http://localhost:8000/pet/1` => tests that we can match when both the type and subtype are wildcard

#### Testing with parameters in the header
- `curl -i -H 'Accept: text/plain;format=fixed;q=0.4'  http://localhost:8000/pet/1` => response should have content type `text/plain`
- `curl -i -H 'Accept: text/plain;format=fixed'  http://localhost:8000/pet/1` => same test but without explicit weight
- `curl -i -H 'Accept: text/plain;format=fixed;q=0.4,text/html;q=0.5'  http://localhost:8000/pet/1` => response should be `text/html`
- `curl -i -H 'Accept: text/plain;format=fixed;q=0.4,text/html;q=0.3'  http://localhost:8000/pet/1`> response should be `text/plain`
- `curl -i -H 'Accept: text/plain;format=fixed,text/html;q=0.3'  http://localhost:8000/pet/1` => response should be `text/plain`

#### Test with some badly formatted query, to ensure we can fallback to an acceptable format instead of crashing
- `curl -i -H 'Accept: text;q=0.9, application/xml ; q=0.8'  http://localhost:8000/pet/1` => the type with higher weigh has no subtype, which is invalid. With this commit we receive a response of type `application/xml` in thise case (as is the case without this commit)
- `curl -i -H 'Accept: application/xml ; q=0.8,'  http://localhost:8000/pet/1` => the header has a trailing comma. This ensure we can still reply a response of type `application/xml`


Edit: I forgot to ping the technical committee: @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon