### PR TITLE
Fix broken build on Windows OS if the schema contains references to other schema files

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -563,11 +563,17 @@ public class CodeGenMojo extends AbstractMojo {
         }
 
         if (StringUtils.isNotBlank(inputSpecRootDirectory)) {
+            // make sure the path can be processed correct under Windows OS
+            inputSpecRootDirectory = inputSpecRootDirectory.replaceAll("\\\\", "/");
+
             inputSpec = new MergedSpecBuilder(inputSpecRootDirectory, mergedFileName,
                     mergedFileInfoName, mergedFileInfoDescription, mergedFileInfoVersion)
                     .buildMergedSpec();
             LOGGER.info("Merge input spec would be used - {}", inputSpec);
         }
+
+        // make sure the path can be processed correct under Windows OS
+        inputSpec = inputSpec.replaceAll("\\\\", "/");
 
         File inputSpecFile = new File(inputSpec);
 


### PR DESCRIPTION
Fix broken build on Windows OS if the schema contains references to other schema files. The same project configuration works under Linux without issues.
This is because the `${project.basedir}` maven variable contains `\` in the string representation and this causes the resolve of referenced schema files.

```
[INFO] --- openapi-generator:7.13.0:generate (default) @ ****-****-**** ---
[ERROR] Error resolving schema ./bidibnode.json#/$defs/node
java.net.URISyntaxException: Illegal character in opaque part at index 2: D:\sample\demo/src/main/resources/json-api/bidib.json
    at java.net.URI$Parser.fail (URI.java:2995)
    at java.net.URI$Parser.checkChars (URI.java:3166)
    at java.net.URI$Parser.parse (URI.java:3202)
    at java.net.URI.<init> (URI.java:645)
    at io.swagger.v3.parser.reference.ReferenceUtils.resolve (ReferenceUtils.java:29)
    at io.swagger.v3.parser.reference.ReferenceVisitor.resolveSchemaRef (ReferenceVisitor.java:227)
    at io.swagger.v3.parser.reference.ReferenceVisitor.visitSchema (ReferenceVisitor.java:141)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseSchema (OpenAPI31Traverser.java:790)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseMediaType (OpenAPI31Traverser.java:603)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseMap (OpenAPI31Traverser.java:933)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseResponse (OpenAPI31Traverser.java:299)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseMap (OpenAPI31Traverser.java:933)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseResponses (OpenAPI31Traverser.java:270)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseOperation (OpenAPI31Traverser.java:237)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traversePathItem (OpenAPI31Traverser.java:394)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseMap (OpenAPI31Traverser.java:933)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traversePaths (OpenAPI31Traverser.java:197)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverseOpenApi (OpenAPI31Traverser.java:124)
    at io.swagger.v3.parser.reference.OpenAPI31Traverser.traverse (OpenAPI31Traverser.java:65)
    at io.swagger.v3.parser.reference.OpenAPIDereferencer31.dereference (OpenAPIDereferencer31.java:74)
    at io.swagger.v3.parser.OpenAPIV3Parser.resolve (OpenAPIV3Parser.java:227)
    at io.swagger.v3.parser.OpenAPIV3Parser.readContents (OpenAPIV3Parser.java:183)
    at io.swagger.v3.parser.OpenAPIV3Parser.readLocation (OpenAPIV3Parser.java:97)
    at io.swagger.parser.OpenAPIParser.readLocation (OpenAPIParser.java:16)
    at org.openapitools.codegen.config.CodegenConfigurator.toContext (CodegenConfigurator.java:686)
    at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput (CodegenConfigurator.java:744)
    at org.openapitools.codegen.plugin.CodeGenMojo.execute (CodeGenMojo.java:966)

```