### PR TITLE
[python] Explicitly define github workflow permissions

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
+++ b/modules/openapi-generator/src/main/resources/python/github-workflow.mustache
@@ -8,6 +8,9 @@ name: {{packageName}} Python package
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/.github/workflows/python.yml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/.github/workflows/python.yml
@@ -7,6 +7,9 @@ name: openapi_client Python package
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/samples/client/echo_api/python/.github/workflows/python.yml
+++ b/samples/client/echo_api/python/.github/workflows/python.yml
@@ -7,6 +7,9 @@ name: openapi_client Python package
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python-aiohttp/.github/workflows/python.yml
@@ -7,6 +7,9 @@ name: petstore_api Python package
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/samples/openapi3/client/petstore/python/.github/workflows/python.yml
+++ b/samples/openapi3/client/petstore/python/.github/workflows/python.yml
@@ -7,6 +7,9 @@ name: petstore_api Python package
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Info from CodeQL on repos containing a generated python client:

"Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}"

"If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write."

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. (@cbornet @tomplus @krjakbrjak @fa0311 @multani)
