### PR TITLE
Primitive array items validity check

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -291,6 +291,16 @@ import {{packageName}}.infrastructure.ITransformForStorage
               String.format("Expected the field `{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}` to be an array in the JSON string but got `%s`", jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].toString())
             }
             {{/required}}
+            {{#items.isPrimitiveType}}
+            // ensure the items in json array are primitive
+            if (jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] != null) {
+              for (i in 0 until jsonObj.getAsJsonArray("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}").size()) {
+                require(jsonObj.getAsJsonArray("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}").get(i).isJsonPrimitive) {
+                  String.format("Expected the property in array `{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}` to be primitive")
+                }
+              }
+            }
+            {{/items.isPrimitiveType}}
             {{/items.isModel}}
             {{/isArray}}
             {{^isContainer}}


### PR DESCRIPTION
## Description
I opened an issue about that [here](https://github.com/OpenAPITools/openapi-generator/issues/21284) where I explain the issue in more details. Essentially the validateJsonElement() function should also check if an array of primitives are in fact primitives. This check was missing before.

The check that I implemented does not validate if a list of strings is in fact a list of strings or a list of floats is in fact a list of floats. The check only distinguishes between primitives and non-primitives.
For our business-needs this fix should be already enough and can be expanded for more precise implementation.

@dr4ke616 @karismann @Zomzog @andrewemery @4brunu @stefankoppier @e5l
