### PR TITLE
[Scala] Add enums to scala-http4s-server

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sServerCodegen.java
@@ -350,7 +350,16 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
                 // model oneOf as sealed trait
 
                 CodegenModel cModel = model.getModel();
-                cModel.getVendorExtensions().put("x-isSealedTrait", !cModel.oneOf.isEmpty());
+
+                if (!cModel.oneOf.isEmpty()) {
+                    cModel.getVendorExtensions().put("x-isSealedTrait", true);
+                }
+                else if (cModel.isEnum) {
+                    cModel.getVendorExtensions().put("x-isEnum", true);
+
+                } else {
+                    cModel.getVendorExtensions().put("x-another", true);
+                }
 
                 if (cModel.discriminator != null) {
                     cModel.getVendorExtensions().put("x-use-discr", true);

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/types.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/types.mustache
@@ -13,6 +13,13 @@ import {{.}}
 
 {{#models}}
 {{#model}}
+{{#vendorExtensions.x-isEnum}}
+import {{modelPackage}}.{{classname}}.{{classname}}
+{{/vendorExtensions.x-isEnum}}
+{{/model}}
+{{/models}}
+{{#models}}
+{{#model}}
 /**
 * {{{description}}}
 {{#vars}}
@@ -82,7 +89,19 @@ object {{classname}} {
 }
 {{/vendorExtensions.x-isSealedTrait}}
 
-{{^vendorExtensions.x-isSealedTrait}}
+{{#vendorExtensions.x-isEnum}}
+object {{classname}} extends Enumeration {
+    type {{classname}} = Value
+    {{#allowableValues}}
+    {{#values}}
+    val {{.}} = Value
+    {{/values}}
+    {{/allowableValues}}
+    implicit val decoder: Decoder[{{classname}}.Value] = Decoder.decodeEnumeration({{classname}})
+    implicit val encoder: Encoder[{{classname}}.Value] = Encoder.encodeEnumeration({{classname}})
+}
+{{/vendorExtensions.x-isEnum}}
+{{#vendorExtensions.x-another}}
 case class {{classname}}(
 {{#vars}}
   {{name}}: {{^required}}Option[{{{vendorExtensions.x-type}}}]{{/required}}{{#required}}{{{vendorExtensions.x-type}}}{{/required}}{{^-last}},{{/-last}}
@@ -92,7 +111,7 @@ object {{classname}} {
   implicit val encoder{{classname}}: Encoder[{{classname}}] = deriveEncoder[{{classname}}].mapJson(_.dropNullValues)
   implicit val decoder{{classname}}: Decoder[{{classname}}] = deriveDecoder[{{classname}}]
 }
-{{/vendorExtensions.x-isSealedTrait}}
+{{/vendorExtensions.x-another}}
 
 {{/model}}
 {{/models}}


### PR DESCRIPTION
There is an example of correct openAPI specification:
```openapi: 3.0.0
info:
  title: TestApi
  version: latest

components:
  schemas:
    EnumType:
      type: string
      enum:
        - Fix
        - Max
paths:
  /test/method:
    post:
      responses:
        '200':
          description: "success answer"
          content:
            application/json:
              schema:
                type: object
                required:
                  - constraint
                properties:
                  constraint:
                    $ref: '#/components/schemas/EnumType'
```

For given OpenAPI specification generated not valid type for enum EnumType - empty case class:

```case class EnumType()```

I added enum handling for scala-http4s-server.
Trying to fix  https://github.com/OpenAPITools/openapi-generator/issues/9987 for scala-http4s-server.