### PR TITLE
fix: #21329 Java Native, Provide Null Check before toString on param variables

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -484,7 +484,9 @@ public class {{classname}} {
         hasFiles = true;
         {{/isFile}}
         {{^isFile}}
-        multiPartBuilder.addTextBody("{{{baseName}}}", {{paramName}}.get(i).toString());
+        if ({{paramName}}.get(i) != null) {
+            multiPartBuilder.addTextBody("{{{baseName}}}", {{paramName}}.get(i).toString());
+        }
         {{/isFile}}
     }
     {{/isArray}}
@@ -494,7 +496,9 @@ public class {{classname}} {
     hasFiles = true;
     {{/isFile}}
     {{^isFile}}
-    multiPartBuilder.addTextBody("{{{baseName}}}", {{paramName}}.toString());
+    if ({{paramName}} != null) {
+        multiPartBuilder.addTextBody("{{{baseName}}}", {{paramName}}.toString());
+    }
     {{/isFile}}
     {{/isArray}}
     {{/formParams}}

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/FormApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/FormApi.java
@@ -260,7 +260,9 @@ public class FormApi {
 
     MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
     boolean hasFiles = false;
-    multiPartBuilder.addTextBody("marker", marker.toString());
+    if (marker != null) {
+        multiPartBuilder.addTextBody("marker", marker.toString());
+    }
     HttpEntity entity = multiPartBuilder.build();
     HttpRequest.BodyPublisher formDataPublisher;
     if (hasFiles) {

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/api/PetApi.java
@@ -847,7 +847,9 @@ public class PetApi {
 
     MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
     boolean hasFiles = false;
-    multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    if (additionalMetadata != null) {
+        multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    }
     multiPartBuilder.addBinaryBody("file", _file);
     hasFiles = true;
     HttpEntity entity = multiPartBuilder.build();
@@ -983,7 +985,9 @@ public class PetApi {
 
     MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
     boolean hasFiles = false;
-    multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    if (additionalMetadata != null) {
+        multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    }
     multiPartBuilder.addBinaryBody("requiredFile", requiredFile);
     hasFiles = true;
     HttpEntity entity = multiPartBuilder.build();

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
@@ -814,7 +814,9 @@ public class PetApi {
 
     MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
     boolean hasFiles = false;
-    multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    if (additionalMetadata != null) {
+        multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    }
     multiPartBuilder.addBinaryBody("file", _file);
     hasFiles = true;
     HttpEntity entity = multiPartBuilder.build();

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/api/PetApi.java
@@ -794,7 +794,9 @@ public class PetApi {
 
     MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
     boolean hasFiles = false;
-    multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    if (additionalMetadata != null) {
+        multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    }
     multiPartBuilder.addBinaryBody("file", _file);
     hasFiles = true;
     HttpEntity entity = multiPartBuilder.build();
@@ -920,7 +922,9 @@ public class PetApi {
 
     MultipartEntityBuilder multiPartBuilder = MultipartEntityBuilder.create();
     boolean hasFiles = false;
-    multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    if (additionalMetadata != null) {
+        multiPartBuilder.addTextBody("additionalMetadata", additionalMetadata.toString());
+    }
     multiPartBuilder.addBinaryBody("requiredFile", requiredFile);
     hasFiles = true;
     HttpEntity entity = multiPartBuilder.build();


### PR DESCRIPTION
Fixes #21329 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
