### PR TITLE
fix(python-fastapi): remove 200 fallback code and use default (#12481)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PythonFastAPIServerCodegen.java
@@ -232,15 +232,6 @@ public class PythonFastAPIServerCodegen extends AbstractPythonCodegen {
         if (operations != null) {
             List<CodegenOperation> ops = operations.getOperation();
             for (final CodegenOperation operation : ops) {
-                List<CodegenResponse> responses = operation.responses;
-                if (responses != null) {
-                    for (final CodegenResponse resp : responses) {
-                        // Convert "default" value (0) to OK (200).
-                        if ("0".equals(resp.code)) {
-                            resp.code = "200";
-                        }
-                    }
-                }
                 List<CodegenSecurity> securityMethods = operation.authMethods;
                 if (securityMethods != null) {
                     for (final CodegenSecurity securityMethod : securityMethods) {

--- a/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/api.mustache
@@ -41,7 +41,7 @@ for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
     "{{{path}}}",
     responses={
         {{#responses}}
-        {{code}}: {{=<% %>=}}{<%#dataType%>"model": <%dataType%>, "description": "<%message%>"<%/dataType%><%^dataType%>"description": "<%message%>"<%/dataType%>}<%={{ }}=%>,
+        {{#isDefault}}"default"{{/isDefault}}{{^isDefault}}{{code}}{{/isDefault}}: {{=<% %>=}}{<%#dataType%>"model": <%dataType%>, "description": "<%message%>"<%/dataType%><%^dataType%>"description": "<%message%>"<%/dataType%>}<%={{ }}=%>,
         {{/responses}}
     },
     tags=[{{#tags}}"{{name}}"{{^-last}},{{/-last}}{{/tags}}],

--- a/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
+++ b/samples/server/petstore/python-fastapi/src/openapi_server/apis/user_api.py
@@ -39,7 +39,7 @@ for _, name, _ in pkgutil.iter_modules(ns_pkg.__path__, ns_pkg.__name__ + "."):
 @router.post(
     "/user",
     responses={
-        200: {"description": "successful operation"},
+        "default": {"description": "successful operation"},
     },
     tags=["user"],
     summary="Create user",
@@ -60,7 +60,7 @@ async def create_user(
 @router.post(
     "/user/createWithArray",
     responses={
-        200: {"description": "successful operation"},
+        "default": {"description": "successful operation"},
     },
     tags=["user"],
     summary="Creates list of users with given input array",
@@ -81,7 +81,7 @@ async def create_users_with_array_input(
 @router.post(
     "/user/createWithList",
     responses={
-        200: {"description": "successful operation"},
+        "default": {"description": "successful operation"},
     },
     tags=["user"],
     summary="Creates list of users with given input array",
@@ -164,7 +164,7 @@ async def login_user(
 @router.get(
     "/user/logout",
     responses={
-        200: {"description": "successful operation"},
+        "default": {"description": "successful operation"},
     },
     tags=["user"],
     summary="Logs out current logged in user session",


### PR DESCRIPTION
Currently the default code of the Python FastAPI would be 200 when in reality it would be more suitable to keep it empty (or 0), as stated in #12481.

Here is the OpenAPI.yaml that was used as input:
https://github.com/OAI/OpenAPI-Specification/blob/aa91a19c43f8a12c02efa42d64794e396473f3b1/examples/v3.0/petstore-expanded.yaml#L51

Here is what it currently produces: 
```
    responses={
        200: {"model": Pet, "description": "pet response"},
        200: {"model": Error, "description": "unexpected error"},
    },
```

this is what it now produces:
```
    responses={
        200: {"model": Pet, "description": "pet response"},
        "default": {"model": Error, "description": "unexpected error"},
    },
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@cbornet,  @tomplus, @krjakbrjak, @fa0311, @multani
