### PR TITLE
[cpp-restsdk] store Object as a shared pointer

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppRestSdkClientCodegen.java
@@ -387,6 +387,8 @@ public class CppRestSdkClientCodegen extends AbstractCppCodegen {
                 || ModelUtils.isFileSchema(p) || ModelUtils.isUUIDSchema(p)
                 || languageSpecificPrimitives.contains(openAPIType)) {
             return toModelName(openAPIType);
+        } else if (ModelUtils.isObjectSchema(p)) {
+            return "std::shared_ptr<Object>";
         } else if(typeMapping.containsKey(super.getSchemaType(p))) {
             return openAPIType;
         }

--- a/modules/openapi-generator/src/test/resources/3_0/cpp-restsdk/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/cpp-restsdk/petstore.yaml
@@ -798,6 +798,8 @@ components:
             - available
             - pending
             - sold
+        metadata:
+          type: object
       xml:
         name: Pet
     Color:

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/CreateUserOrPet_request.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/CreateUserOrPet_request.h
@@ -27,6 +27,7 @@
 #include "CppRestPetstoreClient/model/Tag.h"
 #include "CppRestPetstoreClient/model/Category.h"
 #include <cpprest/details/basic_types.h>
+#include "CppRestPetstoreClient/Object.h"
 #include "CppRestPetstoreClient/model/Pet.h"
 #include <vector>
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
@@ -25,6 +25,7 @@
 #include "CppRestPetstoreClient/model/Tag.h"
 #include "CppRestPetstoreClient/model/Category.h"
 #include <cpprest/details/basic_types.h>
+#include "CppRestPetstoreClient/Object.h"
 #include <vector>
 
 namespace org {
@@ -109,6 +110,11 @@ public:
     void unsetStatus();
     void setStatus(const StatusEnum value);
 
+    std::shared_ptr<Object> getMetadata() const;
+    bool metadataIsSet() const;
+    void unsetMetadata();
+    void setMetadata(const std::shared_ptr<Object>& value);
+
 
 protected:
     int64_t m_Id;
@@ -128,6 +134,9 @@ protected:
 
     StatusEnum m_Status;
     bool m_StatusIsSet;
+
+    std::shared_ptr<Object> m_Metadata;
+    bool m_MetadataIsSet;
 
 };
 

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Pet.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Pet.cpp
@@ -28,6 +28,7 @@ Pet::Pet()
     m_PhotoUrlsIsSet = false;
     m_TagsIsSet = false;
     m_StatusIsSet = false;
+    m_MetadataIsSet = false;
 }
 
 Pet::~Pet()
@@ -73,6 +74,11 @@ web::json::value Pet::toJson() const
         utility::string_t refVal = fromStatusEnum(m_Status);
         val[utility::conversions::to_string_t(_XPLATSTR("status"))] = ModelBase::toJson(refVal);
         
+    }
+    if(m_MetadataIsSet)
+    {   
+        
+        val[utility::conversions::to_string_t(_XPLATSTR("metadata"))] = ModelBase::toJson(m_Metadata);
     }
 
     return val;
@@ -148,6 +154,17 @@ bool Pet::fromJson(const web::json::value& val)
             
         }
     }
+    if(val.has_field(utility::conversions::to_string_t(_XPLATSTR("metadata"))))
+    {
+        const web::json::value& fieldValue = val.at(utility::conversions::to_string_t(_XPLATSTR("metadata")));
+        if(!fieldValue.is_null())
+        {
+            std::shared_ptr<Object> refVal_setMetadata;
+            ok &= ModelBase::fromJson(fieldValue, refVal_setMetadata);
+            setMetadata(refVal_setMetadata);
+            
+        }
+    }
     return ok;
 }
 
@@ -181,6 +198,10 @@ void Pet::toMultipart(std::shared_ptr<MultipartFormData> multipart, const utilit
     if(m_StatusIsSet)
     {
         multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("status")), fromStatusEnum(m_Status)));
+    }
+    if(m_MetadataIsSet)
+    {
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("metadata")), m_Metadata));
     }
 }
 
@@ -228,6 +249,12 @@ bool Pet::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const util
         utility::string_t refVal_setStatus;
         ok &= ModelBase::fromHttpContent(multipart->getContent(utility::conversions::to_string_t(_XPLATSTR("status"))), refVal_setStatus );
         setStatus(toStatusEnum(refVal_setStatus));
+    }
+    if(multipart->hasContent(utility::conversions::to_string_t(_XPLATSTR("metadata"))))
+    {
+        std::shared_ptr<Object> refVal_setMetadata;
+        ok &= ModelBase::fromHttpContent(multipart->getContent(utility::conversions::to_string_t(_XPLATSTR("metadata"))), refVal_setMetadata );
+        setMetadata(refVal_setMetadata);
     }
     return ok;
 }
@@ -390,6 +417,27 @@ bool Pet::statusIsSet() const
 void Pet::unsetStatus()
 {
     m_StatusIsSet = false;
+}
+std::shared_ptr<Object> Pet::getMetadata() const
+{
+    return m_Metadata;
+}
+
+
+void Pet::setMetadata(const std::shared_ptr<Object>& value)
+{
+    m_Metadata = value;
+    m_MetadataIsSet = true;
+}
+
+bool Pet::metadataIsSet() const
+{
+    return m_MetadataIsSet;
+}
+
+void Pet::unsetMetadata()
+{
+    m_MetadataIsSet = false;
 }
 
 }


### PR DESCRIPTION
This fixes serialization and usage of Objects by wrapping it in shared_ptr. These methods all rely on the shared_ptr, and without it methods like `toJson`, `fromString`, etc. will fail to compile.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
