### PR TITLE
fix(ruby-client): fix incorrect Date parsing in OneOf

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_anyof_module.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_anyof_module.mustache
@@ -56,7 +56,7 @@
         when 'Time'
           return Time.parse(data)
         when 'Date'
-          return Date.parse(data)
+          return Date.iso8601(data)
         when 'String'
           return data if data.instance_of?(String)
         when 'Object' # "type: object"

--- a/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/partial_oneof_module.mustache
@@ -98,7 +98,7 @@
         when 'Time'
           return Time.parse(data)
         when 'Date'
-          return Date.parse(data)
+          return Date.iso8601(data)
         when 'String'
           return data if data.instance_of?(String)
         when 'Object' # "type: object"

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/mammal_anyof.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/mammal_anyof.rb
@@ -64,7 +64,7 @@ module Petstore
         when 'Time'
           return Time.parse(data)
         when 'Date'
-          return Date.parse(data)
+          return Date.iso8601(data)
         when 'String'
           return data if data.instance_of?(String)
         when 'Object' # "type: object"

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/mammal_without_discriminator.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/mammal_without_discriminator.rb
@@ -65,7 +65,7 @@ module Petstore
         when 'Time'
           return Time.parse(data)
         when 'Date'
-          return Date.parse(data)
+          return Date.iso8601(data)
         when 'String'
           return data if data.instance_of?(String)
         when 'Object' # "type: object"

--- a/samples/client/petstore/ruby/lib/petstore/models/mammal_anyof.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mammal_anyof.rb
@@ -64,7 +64,7 @@ module Petstore
         when 'Time'
           return Time.parse(data)
         when 'Date'
-          return Date.parse(data)
+          return Date.iso8601(data)
         when 'String'
           return data if data.instance_of?(String)
         when 'Object' # "type: object"

--- a/samples/client/petstore/ruby/lib/petstore/models/mammal_without_discriminator.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mammal_without_discriminator.rb
@@ -65,7 +65,7 @@ module Petstore
         when 'Time'
           return Time.parse(data)
         when 'Date'
-          return Date.parse(data)
+          return Date.iso8601(data)
         when 'String'
           return data if data.instance_of?(String)
         when 'Object' # "type: object"


### PR DESCRIPTION
Changes Date.parse to Date.iso8601 to fix incorrect type coercion in OneOf contexts. Previously, arbitrary strings matching Date.parse's lenient pattern (e.g., "ABC1") were incorrectly coerced to dates (2025-06-01), when they should have remained as strings.

For example:
- "ABC1" was parsed as Date(2025-06-01) instead of remaining "ABC1"
- This occurred because Date.parse treats the first char as month ('A'=1) and remaining digits as day

The fix ensures only ISO8601 formatted strings (e.g. "2025-06-02") are parsed as dates, improving type safety and preventing unexpected coercion of string values.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
