### PR TITLE
replace deprecated 'typings' field with standard 'types' in package.json

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/package.mustache
@@ -15,7 +15,7 @@
 {{/packageAsSourceOnlyLibrary}}
 {{^packageAsSourceOnlyLibrary}}
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
 {{#supportsES6}}
   "module": "./dist/esm/index.js",
   "sideEffects": false,

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
   },
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "module": "./dist/esm/index.js",
   "sideEffects": false,
   "scripts": {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
   },
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build"

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
   },
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "module": "./dist/esm/index.js",
   "sideEffects": false,
   "scripts": {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
   },
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build"

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/package.json
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/GIT_USER_ID/GIT_REPO_ID.git"
   },
   "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build"


### PR DESCRIPTION
### Description

Replaces deprecated `"typings"` field with `"types"` in `package.json`.

Without this fix, some IDEs (e.g., VS Code) fail to resolve type definitions correctly when using this package, due to `"typings"` being ignored in favor of the standard `"types"` field.
