### PR TITLE
Replace periods with '_DOT_' in Python enum member names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1061,6 +1061,8 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
     }
 
     public String toEnumVariableName(String name, String datatype) {
+        name = name.replace(".", "_DOT_");
+
         if ("int".equals(datatype)) {
             return "NUMBER_" + name.replace("-", "MINUS_");
         }

--- a/modules/openapi-generator/src/test/resources/3_0/enum_float.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/enum_float.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: API description in Markdown.
+  version: 1.0.0
+paths:
+  /pony-sizes:
+    get:
+      summary: Returns all pony sizes.
+      description: Optional extended description in Markdown.
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PonySizes'
+components:
+  schemas:
+    PonySizes:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/Type'
+    Type:
+      type: float
+      enum:
+        - 2.0
+        - 1.0
+        - 0.5
+        - 0.25


### PR DESCRIPTION
This is relevant for enums whose values are floats since without this step the enum is syntactically invalid.

See: https://github.com/OpenAPITools/openapi-generator/issues/21322

## Demo

Sample output:

```py
class Type(int, Enum):
    """
    Type
    """

    """
    allowed enum values
    """
    NUMBER_2_DOT_0 = 2.0
    NUMBER_1_DOT_0 = 1.0
    NUMBER_0_DOT_5 = 0.5
    NUMBER_0_DOT_25 = 0.25
```

## Testing Instructions
- Check out this branch
- Run `./mvnw package` to rebuild
- Then run this command to test against a spec that would've previously resulted in a syntax error:
```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
    -i modules/openapi-generator/src/test/resources/3_0/enum_float.yaml \
    -g python \
    -o /tmp/out/python
```
- Then:
```
python -m py_compile /tmp/out/python/openapi_client/models/type.py
```
- Ensure there is no longer a syntax error (as there is on `master` and in the issue)

@cbornet @tomplus @krjakbrjak @fa0311 @multani

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Fixes https://github.com/OpenAPITools/openapi-generator/issues/21322