### PR TITLE
python: Read proxies from environment + no_proxy support

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -413,6 +413,9 @@ conf = {{{packageName}}}.Configuration(
         self.proxy: Optional[str] = None
         """Proxy URL
         """
+        self.no_proxy: Optional[str] = None
+        """Hosts for which to bypass the proxy
+        """
         self.proxy_headers = None
         """Proxy headers
         """

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -6,6 +6,8 @@ import io
 import json
 import re
 import ssl
+from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 
 import urllib3
 
@@ -89,14 +91,23 @@ class RESTClientObject:
         # https pool manager
         self.pool_manager: urllib3.PoolManager
 
-        if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+        parsed = urlparse(configuration.host)
+        proxy = getproxies().get(parsed.scheme) if configuration.proxy is None else configuration.proxy
+        if proxy:
+            if configuration.no_proxy is not None:
+                if _proxy_bypass(parsed.netloc, configuration.no_proxy):
+                    proxy = None
+            elif proxy_bypass(parsed.netloc):
+                proxy = None
+
+        if proxy:
+            if is_socks_proxy_url(proxy):
                 from urllib3.contrib.socks import SOCKSProxyManager
-                pool_args["proxy_url"] = configuration.proxy
+                pool_args["proxy_url"] = proxy
                 pool_args["headers"] = configuration.proxy_headers
                 self.pool_manager = SOCKSProxyManager(**pool_args)
             else:
-                pool_args["proxy_url"] = configuration.proxy
+                pool_args["proxy_url"] = proxy
                 pool_args["proxy_headers"] = configuration.proxy_headers
                 self.pool_manager = urllib3.ProxyManager(**pool_args)
         else:
@@ -246,3 +257,27 @@ class RESTClientObject:
             raise ApiException(status=0, reason=msg)
 
         return RESTResponse(r)
+
+# Adapted from urllib.request.proxy_bypass_environment
+def _proxy_bypass(netloc: str, no_proxy: str):
+    if no_proxy == '*':
+        return True
+
+    host = netloc.lower()
+    if match := re.match(r'(.*):([0-9]*)', host):
+        hostonly, _port = match.groups()
+    else:
+        hostonly = host
+
+    for name in no_proxy.split(','):
+        name = name.strip()
+        if name:
+            name = name.lstrip('.')
+            name = name.lower()
+            if hostonly == name or host == name:
+                return True
+            name = '.' + name
+            if hostonly.endswith(name) or host.endswith(name):
+                return True
+
+    return False

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/configuration.py
@@ -309,6 +309,9 @@ conf = openapi_client.Configuration(
         self.proxy: Optional[str] = None
         """Proxy URL
         """
+        self.no_proxy: Optional[str] = None
+        """Hosts for which to bypass the proxy
+        """
         self.proxy_headers = None
         """Proxy headers
         """

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -309,6 +309,9 @@ conf = openapi_client.Configuration(
         self.proxy: Optional[str] = None
         """Proxy URL
         """
+        self.no_proxy: Optional[str] = None
+        """Hosts for which to bypass the proxy
+        """
         self.proxy_headers = None
         """Proxy headers
         """

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -375,6 +375,9 @@ conf = petstore_api.Configuration(
         self.proxy: Optional[str] = None
         """Proxy URL
         """
+        self.no_proxy: Optional[str] = None
+        """Hosts for which to bypass the proxy
+        """
         self.proxy_headers = None
         """Proxy headers
         """

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -379,6 +379,9 @@ conf = petstore_api.Configuration(
         self.proxy: Optional[str] = None
         """Proxy URL
         """
+        self.no_proxy: Optional[str] = None
+        """Hosts for which to bypass the proxy
+        """
         self.proxy_headers = None
         """Proxy headers
         """

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -16,6 +16,8 @@ import io
 import json
 import re
 import ssl
+from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 
 import urllib3
 
@@ -99,14 +101,23 @@ class RESTClientObject:
         # https pool manager
         self.pool_manager: urllib3.PoolManager
 
-        if configuration.proxy:
-            if is_socks_proxy_url(configuration.proxy):
+        parsed = urlparse(configuration.host)
+        proxy = getproxies().get(parsed.scheme) if configuration.proxy is None else configuration.proxy
+        if proxy:
+            if configuration.no_proxy is not None:
+                if _proxy_bypass(parsed.netloc, configuration.no_proxy):
+                    proxy = None
+            elif proxy_bypass(parsed.netloc):
+                proxy = None
+
+        if proxy:
+            if is_socks_proxy_url(proxy):
                 from urllib3.contrib.socks import SOCKSProxyManager
-                pool_args["proxy_url"] = configuration.proxy
+                pool_args["proxy_url"] = proxy
                 pool_args["headers"] = configuration.proxy_headers
                 self.pool_manager = SOCKSProxyManager(**pool_args)
             else:
-                pool_args["proxy_url"] = configuration.proxy
+                pool_args["proxy_url"] = proxy
                 pool_args["proxy_headers"] = configuration.proxy_headers
                 self.pool_manager = urllib3.ProxyManager(**pool_args)
         else:
@@ -256,3 +267,27 @@ class RESTClientObject:
             raise ApiException(status=0, reason=msg)
 
         return RESTResponse(r)
+
+# Adapted from urllib.request.proxy_bypass_environment
+def _proxy_bypass(netloc: str, no_proxy: str):
+    if no_proxy == '*':
+        return True
+
+    host = netloc.lower()
+    if match := re.match(r'(.*):([0-9]*)', host):
+        hostonly, _port = match.groups()
+    else:
+        hostonly = host
+
+    for name in no_proxy.split(','):
+        name = name.strip()
+        if name:
+            name = name.lstrip('.')
+            name = name.lower()
+            if hostonly == name or host == name:
+                return True
+            name = '.' + name
+            if hostonly.endswith(name) or host.endswith(name):
+                return True
+
+    return False


### PR DESCRIPTION
Partially reapplies https://github.com/OpenAPITools/openapi-generator/pull/10648, which was lost in https://github.com/OpenAPITools/openapi-generator/commit/01ed5975e1bfeee3a31efc89a603e9eb37e8ebe0 (I suspect unintentionally so).

Fixes https://github.com/OpenAPITools/openapi-generator/issues/6786. Partially fixes https://github.com/OpenAPITools/openapi-generator/issues/20226.

@cbornet @tomplus @krjakbrjak @fa0311 @multani

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
