### PR TITLE
[csharp][generichost] Removed duplicate service registration

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HostConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HostConfiguration.mustache
@@ -80,8 +80,7 @@ namespace {{packageName}}.{{clientPackage}}
 
             {{/useSourceGeneration}}
             _services.AddSingleton<IApiFactory, ApiFactory>();{{#apiInfo}}{{#apis}}
-            _services.AddSingleton<{{classname}}Events>();
-            _services.AddTransient<{{interfacePrefix}}{{classname}}, {{classname}}>();{{/apis}}{{/apiInfo}}
+            _services.AddSingleton<{{classname}}Events>();{{/apis}}{{/apiInfo}}
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -49,7 +49,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -47,11 +47,8 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<APIKEYSApiEvents>();
-            _services.AddTransient<IAPIKEYSApi, APIKEYSApi>();
             _services.AddSingleton<APIKeysApiEvents>();
-            _services.AddTransient<IAPIKeysApi, APIKeysApi>();
             _services.AddSingleton<ApiKeysApiEvents>();
-            _services.AddTransient<IApiKeysApi, ApiKeysApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -202,19 +202,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -154,19 +154,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -44,7 +44,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -202,19 +202,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -154,19 +154,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -44,7 +44,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -204,19 +204,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -158,19 +158,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -156,19 +156,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -266,19 +266,12 @@ namespace Org.OpenAPITools.Client
 
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -204,19 +204,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -158,19 +158,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -50,7 +50,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -156,19 +156,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -266,19 +266,12 @@ namespace Org.OpenAPITools.Client
 
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -46,7 +46,6 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -154,19 +154,12 @@ namespace Org.OpenAPITools.Client
             _services.AddSingleton(jsonSerializerOptionsProvider);
             _services.AddSingleton<IApiFactory, ApiFactory>();
             _services.AddSingleton<AnotherFakeApiEvents>();
-            _services.AddTransient<IAnotherFakeApi, AnotherFakeApi>();
             _services.AddSingleton<DefaultApiEvents>();
-            _services.AddTransient<IDefaultApi, DefaultApi>();
             _services.AddSingleton<FakeApiEvents>();
-            _services.AddTransient<IFakeApi, FakeApi>();
             _services.AddSingleton<FakeClassnameTags123ApiEvents>();
-            _services.AddTransient<IFakeClassnameTags123Api, FakeClassnameTags123Api>();
             _services.AddSingleton<PetApiEvents>();
-            _services.AddTransient<IPetApi, PetApi>();
             _services.AddSingleton<StoreApiEvents>();
-            _services.AddTransient<IStoreApi, StoreApi>();
             _services.AddSingleton<UserApiEvents>();
-            _services.AddTransient<IUserApi, UserApi>();
         }
 
         /// <summary>


### PR DESCRIPTION
Registering the typed HttpClient implicitly registers our api classes as transient, which means we were registering these classes twice.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
