### PR TITLE
[rust-axum] Prevent multiple declarations of the same operation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -429,6 +429,14 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         String underscoredOperationId = underscore(op.operationId);
+        ArrayList<MethodOperation> pathMethods = pathMethodOpMap.get(path);
+
+        // Prevent multiple declarations of the same operation
+        if (pathMethods != null && pathMethods.stream().anyMatch(pathMethod ->
+                pathMethod.operationID.equals(underscoredOperationId))) {
+            return op;
+        }
+
         op.vendorExtensions.put("x-operation-id", underscoredOperationId);
         op.vendorExtensions.put("x-uppercase-operation-id", underscoredOperationId.toUpperCase(Locale.ROOT));
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustAxumServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustAxumServerCodegenTest.java
@@ -1,0 +1,32 @@
+package org.openapitools.codegen.rust;
+
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.openapitools.codegen.TestUtils.linearize;
+
+public class RustAxumServerCodegenTest {
+    @Test
+    public void testPreventDuplicateOperationDeclaration() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("rust-axum")
+                .setInputSpec("src/test/resources/3_1/issue_21144.yaml")
+                .setSkipOverwrite(false)
+                .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        Path outputPath = Path.of(target.toString(), "/src/server/mod.rs");
+        String routerSpec = linearize("Router::new() " +
+                ".route(\"/api/test\", " +
+                "delete(test_delete::<I, A, E, C>).post(test_post::<I, A, E, C>) ) " +
+                ".with_state(api_impl)");
+        TestUtils.assertFileExists(outputPath);
+        TestUtils.assertFileContains(outputPath, routerSpec);
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustAxumServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustAxumServerCodegenTest.java
@@ -5,9 +5,11 @@ import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.openapitools.codegen.TestUtils.linearize;
 
@@ -20,7 +22,8 @@ public class RustAxumServerCodegenTest {
                 .setInputSpec("src/test/resources/3_1/issue_21144.yaml")
                 .setSkipOverwrite(false)
                 .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
-        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
         Path outputPath = Path.of(target.toString(), "/src/server/mod.rs");
         String routerSpec = linearize("Router::new() " +
                 ".route(\"/api/test\", " +

--- a/modules/openapi-generator/src/test/resources/3_1/issue_21144.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_21144.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: "test"
+  version: "0.1.1"
+  description: "test"
+paths:
+  /api/test:
+    delete:
+      operationId: "test_delete"
+      description: "Delete method"
+      responses:
+        204:
+          description: "delete"
+      security:
+        - apiKey: []
+    post:
+      tags:
+        - firsttag
+        - secondtag
+        - thirdtag
+      operationId: "test_post"
+      description: "Post method"
+      responses:
+        201:
+          description: "post"
+      security:
+        - apiKey: []
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: X-API-Key
+      in: header


### PR DESCRIPTION
If tags are defined for an operation, the router path will be duplicated per tag. If a security schema is defined as well, the code will no longer compile because there will be duplicate operations with and without a claims parameter. Since there doesn't appear to be a benefit to specifying the same operation multiple times, this skips adding an operation if it already exists.

Fixes #21144 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
