### PR TITLE
FIX #21407 - use referenced string enum schema in requestBody if available

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -397,6 +397,9 @@ public class CodegenConstants {
     public static final String REMOVE_ENUM_VALUE_PREFIX = "removeEnumValuePrefix";
     public static final String REMOVE_ENUM_VALUE_PREFIX_DESC = "Remove the common prefix of enum values";
 
+    public static final String USE_STRING_ENUM_SCHEMA_REF_FOR_REQUEST_BODY = "useStringEnumSchemaRefForRequestBody";
+    public static final String USE_STRING_ENUM_SCHEMA_REF_FOR_REQUEST_BODY_DESC = "A boolean flag that controls how the parameter type for a referenced string enum in a request body is generated. When set to true, the generator will use the referenced schema instead of a plain String type";
+
     public static final String SKIP_ONEOF_ANYOF_GETTER = "skipOneOfAnyOfGetter";
     public static final String SKIP_ONEOF_ANYOF_GETTER_DESC = "Skip the generation of getter for sub-schemas in oneOf/anyOf models.";
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7794,8 +7794,13 @@ public class DefaultCodegen implements CodegenConfig {
         }
     }
 
-    protected void updateRequestBodyForString(CodegenParameter codegenParameter, Schema schema, Set<String> imports, String bodyParameterName) {
-        updateRequestBodyForPrimitiveType(codegenParameter, schema, bodyParameterName, imports);
+    protected void updateRequestBodyForString(CodegenParameter codegenParameter, Schema schema, String name, Set<String> imports, String bodyParameterName) {
+        if (convertPropertyToBoolean(CodegenConstants.USE_STRING_ENUM_SCHEMA_REF_FOR_REQUEST_BODY) && !StringUtils.isEmpty(name)) {
+            addBodyModelSchema(codegenParameter, name, schema, imports, bodyParameterName, false);
+        } else {
+            updateRequestBodyForPrimitiveType(codegenParameter, schema, bodyParameterName, imports);
+        }
+
         if (ModelUtils.isByteArraySchema(schema)) {
             codegenParameter.setIsString(false);
             codegenParameter.isByteArray = true;
@@ -7996,7 +8001,7 @@ public class DefaultCodegen implements CodegenConfig {
             // swagger v2 only, type file
             codegenParameter.isFile = true;
         } else if (ModelUtils.isStringSchema(schema)) {
-            updateRequestBodyForString(codegenParameter, schema, imports, bodyParameterName);
+            updateRequestBodyForString(codegenParameter, schema, name, imports, bodyParameterName);
         } else if (ModelUtils.isNumberSchema(schema)) {
             updateRequestBodyForPrimitiveType(codegenParameter, schema, bodyParameterName, imports);
             codegenParameter.isNumeric = Boolean.TRUE;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -48,6 +48,7 @@ import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.SemVer;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
@@ -5014,5 +5015,50 @@ public class DefaultCodegenTest {
 
         // When & Then
         assertThat(codegenOperation.getHasSingleParam()).isTrue();
+    }
+
+    @DataProvider(name = "testRequestBodyWithStringEnumSchemaData")
+    private Object[][] testRequestBodyWithStringEnumSchemaData() {
+        return new Object[][]{
+                {false, "String"},
+                {true, "Letter"}
+        };
+    }
+
+    @Test(dataProvider = "testRequestBodyWithStringEnumSchemaData")
+    public void testRequestBodyWithStringEnumSchema(boolean useStringEnumSchemaRefForRequestBody, String expectedDataType) {
+        // Given
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_21407.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.additionalProperties().put(CodegenConstants.USE_STRING_ENUM_SCHEMA_REF_FOR_REQUEST_BODY, useStringEnumSchemaRefForRequestBody);
+        String path = "/v1/resource-class/send-using-schema";
+
+        // When
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+
+        // Then
+        assertThat(codegenOperation.bodyParam).satisfies(bodyParam -> {
+            assertThat(bodyParam).isNotNull();
+            assertThat(bodyParam.getDataType()).isEqualTo(expectedDataType);
+        });
+    }
+
+    @Test
+    public void testRequestBodyWithStringSchema() {
+        // Given
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_21407.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        String path = "/v1/resource-class/send-using-string";
+
+        // When
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "POST", openAPI.getPaths().get(path).getPost(), null);
+
+        // Then
+        assertThat(codegenOperation.bodyParam).satisfies(bodyParam -> {
+            assertThat(bodyParam).isNotNull();
+            assertThat(bodyParam.getDataType()).isEqualTo("String");
+        });
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/issue_21407.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_21407.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.1
+info:
+  title: sample spec
+  description: "Sample spec"
+  version: 0.0.1
+tags:
+- name: ResourceClass
+paths:
+  /v1/resource-class/send-using-schema:
+    post:
+      tags:
+      - ResourceClass
+      description: Add @Operation annotation to provide a description
+      operationId: send-using-schema
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Letter"
+      responses:
+        "200":
+          description: OK - the request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Letter"
+  /v1/resource-class/send-using-string:
+    post:
+      tags:
+        - ResourceClass
+      description: Add @Operation annotation to provide a description
+      operationId: send-using-string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "204":
+          description: "No Content - the request has been successfully processed,\
+            \ but there is no additional content."
+components:
+  schemas:
+    Letter:
+      type: string
+      enum:
+      - A
+      - B


### PR DESCRIPTION
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Description

The core of this change is to treat a referenced string enum schema as a model rather than a primitive.

To achieve this, the `updateRequestBodyForString` method has been updated to accept the schema's component name. When this name is present, we delegate processing to `addBodyModelSchema`. This mirrors the existing logic that is already present in `updateRequestBodyForObject`, resulting in the proper enum type in the generated API.

The behavior for primitive or inline strings remains unchanged.

#### Breaking change
Since this modifies the generated method signatures, the new behavior is introduced behind a feature flag named `useStringEnumSchemaRefForRequestBody` to ensure back compatibility with existing clients.