### PR TITLE
[kotlin] Fix compile error in enum properties with "" values(#18660)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -85,14 +85,14 @@ import kotlinx.serialization.*
     {{/multiplatform}}
     {{#isArray}}
     {{#isList}}
-    {{&name}}(listOf({{{value}}})){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{#name}}{{^isEmpty}}{{&name}}{{/isEmpty}}{{#isEmpty}}_{{/isEmpty}}{{/name}}(listOf({{{value}}})){{^-last}},{{/-last}}{{#-last}};{{/-last}}
     {{/isList}}
     {{^isList}}
-    {{&name}}(arrayOf({{{value}}})){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{#name}}{{^isEmpty}}{{&name}}{{/isEmpty}}{{#isEmpty}}_{{/isEmpty}}{{/name}}(arrayOf({{{value}}})){{^-last}},{{/-last}}{{#-last}};{{/-last}}
     {{/isList}}
     {{/isArray}}
     {{^isArray}}
-    {{&name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+    {{#name}}{{^isEmpty}}{{&name}}{{/isEmpty}}{{#isEmpty}}_{{/isEmpty}}{{/name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
     {{/isArray}}
 {{/enumVars}}{{/allowableValues}}
     /**


### PR DESCRIPTION
This PR solves the problem described in #18660.

I made this fix locally and on my openapi the issue was fixed and no new issues were found.

For testing you can use the code from the Issue or use this:
```Json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Simple",
    "version": "0.0.1"
  },
  "paths": {},
  "components": {
    "schemas": {
      "TestEnum": {
        "type": "string",
        "enum": [
          "",
          "1",
          "2"
        ],
        "title": "TestEnum"
      },
      "TestItem": {
        "properties": {
          "test": {
            "type": "integer",
            "title": "test"
          },
          "testEmum": {
            "$ref": "#/components/schemas/TestEnum",
            "default": ""
          }
        },
        "type": "object",
        "required": [
          "test"
        ],
        "title": "TestItem"
      }
    }
  },
  "tags": []
}
```


@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)