### PR TITLE
[Python] Fix broken mypy checks

### DIFF
--- a/samples/openapi3/client/petstore/python/tests/test_deserialization.py
+++ b/samples/openapi3/client/petstore/python/tests/test_deserialization.py
@@ -297,7 +297,12 @@ class DeserializationTests(unittest.TestCase):
         json_str = '{"className": "Cat", "color": "red", "declawed": true}'
 
         deserialized = petstore_api.Animal.from_json(json_str)
-        self.assertTrue(isinstance(deserialized, petstore_api.Cat))
+
+        # the following is necessary for mypy as it does not handle isinstance() within self.assertTrue() well
+        if not isinstance(deserialized, petstore_api.Cat):
+            self.assertTrue(False)
+            return
+
         self.assertEqual(deserialized.class_name, "Cat")
         self.assertEqual(deserialized.declawed, True)
         self.assertEqual(deserialized.to_json(), '{"className": "Cat", "color": "red", "declawed": true}')


### PR DESCRIPTION
This fixes the mypy issues that are on the master branch.
It would seem that mypy does not handle the assertions of the unittest.TestCase class very well.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
