### PR TITLE
[Typescript]: add deprecated tags

### DIFF
--- a/bin/configs/typescript-echo-api.yaml
+++ b/bin/configs/typescript-echo-api.yaml
@@ -1,6 +1,6 @@
 generatorName: typescript
 outputDir: samples/client/echo_api/typescript/build
-inputSpec: modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+inputSpec: modules/openapi-generator/src/test/resources/3_0/typescript/echo_api.yaml
 templateDir: modules/openapi-generator/src/main/resources/typescript
 additionalProperties:
   artifactId: echo-api-typescript

--- a/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/api/api.mustache
@@ -32,6 +32,10 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
 
     {{#operation}}
     /**
+    {{#isDeprecated}}
+     * @deprecated
+     *
+    {{/isDeprecated}}
      {{#notes}}
      * {{&notes}}
      {{/notes}}
@@ -39,7 +43,7 @@ export class {{classname}}RequestFactory extends BaseAPIRequestFactory {
      * {{&summary}}
      {{/summary}}
      {{#allParams}}
-     * @param {{paramName}} {{description}}
+     * @param {{paramName}} {{description}}{{#isDeprecated}} (@deprecated){{/isDeprecated}}
      {{/allParams}}
      */
     public async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}_options?: Configuration): Promise<RequestContext> {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.testng.Assert.*;
 
@@ -175,6 +177,21 @@ public class TestUtils {
         } catch (IOException e) {
             fail("Unable to evaluate file " + path);
         }
+    }
+
+    /**
+     * Count occurrences of the given text
+     * @param content content of the file
+     * @param text text to find
+     * @return
+     */
+    public static int countOccurrences(String content, String text) {
+        Matcher matcher = Pattern.compile(text).matcher(content);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
     }
 
     public static String linearize(String target) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -177,31 +177,6 @@ public class TestUtils {
         }
     }
 
-    /**
-     * Verify line is found at given lineNumber
-     * @param path
-     * @param lineNumber
-     * @param line
-     */
-    public static void assertFileContains(Path path, int lineNumber, String line) {
-        try {
-            List<String> linesInFile = Files.readAllLines(path);
-            int index = lineNumber - 1;
-
-            assertTrue(index >= 0 && index < linesInFile.size(),
-                    "Invalid line number: " + lineNumber);
-
-            String targetLine = linearize(linesInFile.get(index));
-            String expectedLine = linearize(line);
-
-            assertTrue(targetLine.contains(expectedLine),
-                    "Expected line [" + expectedLine + "] not found at line number " + lineNumber);
-
-        } catch (IOException e) {
-            fail("Unable to evaluate file " + path);
-        }
-    }
-
     public static String linearize(String target) {
         return target.replaceAll("\r?\n", "").replaceAll("\\s+", "\\s");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/TestUtils.java
@@ -177,6 +177,31 @@ public class TestUtils {
         }
     }
 
+    /**
+     * Verify line is found at given lineNumber
+     * @param path
+     * @param lineNumber
+     * @param line
+     */
+    public static void assertFileContains(Path path, int lineNumber, String line) {
+        try {
+            List<String> linesInFile = Files.readAllLines(path);
+            int index = lineNumber - 1;
+
+            assertTrue(index >= 0 && index < linesInFile.size(),
+                    "Invalid line number: " + lineNumber);
+
+            String targetLine = linearize(linesInFile.get(index));
+            String expectedLine = linearize(line);
+
+            assertTrue(targetLine.contains(expectedLine),
+                    "Expected line [" + expectedLine + "] not found at line number " + lineNumber);
+
+        } catch (IOException e) {
+            fail("Unable to evaluate file " + path);
+        }
+    }
+
     public static String linearize(String target) {
         return target.replaceAll("\r?\n", "").replaceAll("\\s+", "\\s");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -210,4 +210,31 @@ public class TypeScriptClientCodegenTest {
                 "}"
         );
     }
+
+    @Test
+    public void testOrderParameters() throws Exception {
+        final File output = Files.createTempDirectory("typescriptnodeclient_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript")
+                .setInputSpec("src/test/resources/3_0/typescript/deprecated-operation.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(clientOptInput).generate();
+        files.forEach(File::deleteOnExit);
+
+        // deprecated operation
+        TestUtils.assertFileContains(
+                Paths.get(output + "/apis/DefaultApi.ts"),
+                "* @deprecated"
+        );
+        // deprecated parameter
+        TestUtils.assertFileContains(
+                Paths.get(output + "/apis/DefaultApi.ts"),
+                "* @param name name of pet  (@deprecated)"
+        );
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -15,10 +15,13 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Test(groups = {TypeScriptGroups.TYPESCRIPT})
 public class TypeScriptClientCodegenTest {
@@ -227,10 +230,15 @@ public class TypeScriptClientCodegenTest {
         files.forEach(File::deleteOnExit);
 
         // verify operation is deprecated
+        Path file = Paths.get(output + "/apis/DefaultApi.ts");
         TestUtils.assertFileContains(
-                Paths.get(output + "/apis/DefaultApi.ts"),
+                file,
                 "* @deprecated"
         );
+
+        String content = Files.readString(file);
+        assertEquals(1, TestUtils.countOccurrences(content, "@deprecated"));
+
     }
 
     @Test
@@ -249,9 +257,14 @@ public class TypeScriptClientCodegenTest {
         files.forEach(File::deleteOnExit);
 
         // verify parameter is deprecated parameter
+        Path file = Paths.get(output + "/apis/DefaultApi.ts");
         TestUtils.assertFileContains(
-                Paths.get(output + "/apis/DefaultApi.ts"),
+                file,
                 "* @param name name of pet  (@deprecated)"
         );
+
+        String content = Files.readString(file);
+        assertEquals(1, TestUtils.countOccurrences(content, "@deprecated"));
+
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -229,7 +229,6 @@ public class TypeScriptClientCodegenTest {
         // verify operation is deprecated
         TestUtils.assertFileContains(
                 Paths.get(output + "/apis/DefaultApi.ts"),
-                18,
                 "* @deprecated"
         );
     }
@@ -252,7 +251,6 @@ public class TypeScriptClientCodegenTest {
         // verify parameter is deprecated parameter
         TestUtils.assertFileContains(
                 Paths.get(output + "/apis/DefaultApi.ts"),
-                20,
                 "* @param name name of pet  (@deprecated)"
         );
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -229,6 +229,7 @@ public class TypeScriptClientCodegenTest {
         // verify operation is deprecated
         TestUtils.assertFileContains(
                 Paths.get(output + "/apis/DefaultApi.ts"),
+                18,
                 "* @deprecated"
         );
     }
@@ -251,6 +252,7 @@ public class TypeScriptClientCodegenTest {
         // verify parameter is deprecated parameter
         TestUtils.assertFileContains(
                 Paths.get(output + "/apis/DefaultApi.ts"),
+                20,
                 "* @param name name of pet  (@deprecated)"
         );
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/TypeScriptClientCodegenTest.java
@@ -212,7 +212,7 @@ public class TypeScriptClientCodegenTest {
     }
 
     @Test
-    public void testOrderParameters() throws Exception {
+    public void testDeprecatedOperation() throws Exception {
         final File output = Files.createTempDirectory("typescriptnodeclient_").toFile();
         output.deleteOnExit();
 
@@ -226,12 +226,29 @@ public class TypeScriptClientCodegenTest {
         final List<File> files = generator.opts(clientOptInput).generate();
         files.forEach(File::deleteOnExit);
 
-        // deprecated operation
+        // verify operation is deprecated
         TestUtils.assertFileContains(
                 Paths.get(output + "/apis/DefaultApi.ts"),
                 "* @deprecated"
         );
-        // deprecated parameter
+    }
+
+    @Test
+    public void testDeprecatedParameter() throws Exception {
+        final File output = Files.createTempDirectory("typescriptnodeclient_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript")
+                .setInputSpec("src/test/resources/3_0/typescript/deprecated-parameter.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        final DefaultGenerator generator = new DefaultGenerator();
+        final List<File> files = generator.opts(clientOptInput).generate();
+        files.forEach(File::deleteOnExit);
+
+        // verify parameter is deprecated parameter
         TestUtils.assertFileContains(
                 Paths.get(output + "/apis/DefaultApi.ts"),
                 "* @param name name of pet  (@deprecated)"

--- a/modules/openapi-generator/src/test/resources/3_0/typescript/deprecated-operation.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript/deprecated-operation.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  description: test order parameters
+  version: 1.0.0
+  title: Test order parameters
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /pets:
+    get:
+      tags:
+        - default
+      summary: Finds Pets
+      deprecated: true
+      description: Find all pets
+      operationId: findPets
+      parameters:
+        - name: type
+          in: query
+          description: type of pet
+          style: form
+          explode: false
+          schema:
+            type: string
+            default: available
+        - name: name
+          in: query
+          deprecated: true
+          description: name of pet
+          required: true
+          schema:
+            type: string
+        - name: age
+          in: query
+          description: age of pet
+          schema:
+            type: number
+            format: int32
+      responses:
+        '200':
+          description: successful operation
+        '400':
+          description: Invalid status value

--- a/modules/openapi-generator/src/test/resources/3_0/typescript/deprecated-parameter.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript/deprecated-parameter.yaml
@@ -12,7 +12,6 @@ paths:
       tags:
         - default
       summary: Finds Pets
-      deprecated: true
       description: Find all pets
       operationId: findPets
       parameters:
@@ -26,6 +25,7 @@ paths:
             default: available
         - name: name
           in: query
+          deprecated: true
           description: name of pet
           required: true
           schema:

--- a/modules/openapi-generator/src/test/resources/3_0/typescript/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript/echo_api.yaml
@@ -1,0 +1,918 @@
+#
+# Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: Echo Server API
+  description: Echo Server API
+  contact:
+    email: team@openapitools.org
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 0.1.0
+servers:
+  - url: http://localhost:3000/
+paths:
+  # Path usually starts with parameter type such as path, query, header, form
+  # For body/form parameters, path starts with "/echo" so the echo server
+  # will respond with the same body in the HTTP request.
+  #
+  # path parameter tests
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
+    get:
+      tags:
+        - path 
+      summary: Test path parameter(s)
+      description: Test path parameter(s)
+      operationId: tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}
+      parameters:
+      - in: path 
+        name: path_string
+        required: true
+        schema:
+          type: string
+      - in: path 
+        name: path_integer
+        required: true
+        schema:
+          type: integer 
+      - in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          type: string
+          enum:
+          - success
+          - failure
+          - unclassified
+      - in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # form parameter tests
+  /form/integer/boolean/string:
+    post:
+      tags:
+        - form
+      summary: Test form parameter(s)
+      description: Test form parameter(s)
+      operationId: test/form/integer/boolean/string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                integer_form:
+                  type: integer
+                boolean_form:
+                  type: boolean
+                string_form:
+                  type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # form parameter tests for oneOf schema
+  /form/oneof:
+    post:
+      tags:
+        - form
+      summary: Test form parameter(s) for oneOf schema
+      description: Test form parameter(s) for oneOf schema
+      operationId: test/form/oneof
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              oneOf:
+                - type: object
+                  properties:
+                    form1:
+                      type: string
+                    form2:
+                      type: integer
+                - type: object
+                  properties:
+                    form3:
+                      type: string
+                    form4:
+                      type: boolean
+                - $ref: '#/components/schemas/Tag'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /form/object/multipart: 
+    post:
+      tags:
+        - form
+      summary: Test form parameter(s) for multipart schema
+      description: Test form parameter(s) for multipart schema
+      operationId: test/form/object/multipart
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - marker
+              properties:
+                marker:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # header parameter tests
+  /header/integer/boolean/string/enums:
+    get:
+      tags:
+        - header
+      summary: Test header parameter(s)
+      description: Test header parameter(s)
+      operationId: test/header/integer/boolean/string/enums
+      parameters:
+      - in: header
+        name: integer_header
+        style: form #default
+        explode: true #default
+        schema:
+          type: integer
+      - in: header
+        name: boolean_header
+        style: form #default
+        explode: true #default
+        schema:
+          type: boolean
+      - in: header
+        name: string_header
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+      - in: header
+        name: enum_nonref_string_header
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+          enum:
+          - success
+          - failure
+          - unclassified
+      - in: header
+        name: enum_ref_string_header
+        style: form #default
+        explode: true #default
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # query parameter tests
+  /query/enum_ref_string:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/enum_ref_string
+      parameters:
+      - in: query
+        name: enum_nonref_string_query
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+          enum:
+          - success
+          - failure
+          - unclassified
+      - in: query
+        name: enum_ref_string_query
+        style: form #default
+        explode: true #default
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/datetime/date/string:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/datetime/date/string
+      parameters:
+      - in: query
+        name: datetime_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: date_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: string_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/integer/boolean/string:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/integer/boolean/string
+      parameters:
+      - in: query
+        name: integer_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: integer
+      - in: query
+        name: boolean_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: boolean
+      - in: query
+        name: string_query 
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_form/explode_true/array_string:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_form/explode_true/array_string
+      parameters:
+      - in: query
+        name: query_object
+        style: form #default
+        explode: true #default
+        schema:
+          type: object
+          properties:
+            values:
+                type: array
+                items:
+                    type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_form/explode_false/array_integer:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_form/explode_false/array_integer
+      parameters:
+        - in: query
+          name: query_object
+          style: form #default
+          explode: false
+          schema:
+            type: array
+            items:
+              type: integer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_form/explode_false/array_string:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_form/explode_false/array_string
+      parameters:
+        - in: query
+          name: query_object
+          style: form #default
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_form/explode_true/object:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_form/explode_true/object
+      parameters:
+      - in: query
+        name: query_object
+        style: form #default
+        explode: true #default
+        schema:
+          $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_form/explode_true/object/allOf:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_form/explode_true/object/allOf
+      parameters:
+      - in: query
+        name: query_object
+        style: form #default
+        explode: true #default
+        schema:
+          $ref: '#/components/schemas/DataQuery'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_deepObject/explode_true/object:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_deepObject/explode_true/object
+      parameters:
+      - in: query
+        name: query_object
+        style: deepObject
+        explode: true #default
+        schema:
+          $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_deepObject/explode_true/object/allOf:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_deepObject/explode_true/object/allOf
+      parameters:
+      - in: query
+        name: query_object
+        style: deepObject
+        explode: true #default
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/Bird'
+          - $ref: '#/components/schemas/Category'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # body parameter tests
+  /body/application/octetstream/binary:
+    post:
+      tags:
+        - body
+      summary: Test body parameter(s)
+      description: Test body parameter(s)
+      operationId: test/body/application/octetstream/binary
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /echo/body/Pet:
+    post:
+      tags:
+        - body
+      summary: Test body parameter(s)
+      description: Test body parameter(s)
+      operationId: test/echo/body/Pet
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+  /echo/body/allOf/Pet:
+    post:
+      tags:
+        - body
+      summary: Test body parameter(s)
+      description: Test body parameter(s)
+      operationId: test/echo/body/allOf/Pet
+      requestBody:
+        $ref: '#/components/requestBodies/AllOfPet'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+  /echo/body/Pet/response_string:
+    post:
+      tags:
+        - body
+      summary: Test empty response body
+      description: Test empty response body
+      operationId: test/echo/body/Pet/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /echo/body/Tag/response_string:
+    post:
+      tags:
+        - body
+      summary: Test empty json (request body)
+      description: Test empty json (request body)
+      operationId: test/echo/body/Tag/response_string
+      requestBody:
+        $ref: '#/components/requestBodies/Tag'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /echo/body/FreeFormObject/response_string:
+    post:
+      tags:
+        - body
+      summary: Test free form object
+      description: Test free form object
+      operationId: test/echo/body/FreeFormObject/response_string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Free form object
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /echo/body/string_enum:
+    post:
+      tags:
+        - body
+      summary: Test string enum response body
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+  /binary/gif:
+    post:
+      tags:
+        - body
+      summary: Test binary (gif) response body
+      description: Test binary (gif) response body
+      operationId: test/binary/gif
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            image/gif:
+              schema:
+                type: string
+                format: binary
+  # Single binary in multipart mime test
+  /body/application/octetstream/single_binary:
+    post:
+      tags:
+        - body
+      summary: Test single binary in multipart mime
+      description: Test single binary in multipart mime
+      operationId: test/body/multipart/formdata/single_binary
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                my-file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # Array of binary in multipart mime tests
+  /body/application/octetstream/array_of_binary:
+    post:
+      tags:
+        - body
+      summary: Test array of binary in multipart mime
+      description: Test array of binary in multipart mime
+      operationId: test/body/multipart/formdata/array_of_binary
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+                - files
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # To test http basic auth
+  /auth/http/basic:
+    post:
+      tags:
+        - auth
+      security:
+        - http_auth: []
+      summary: To test HTTP basic authentication
+      description: To test HTTP basic authentication
+      operationId: test/auth/http/basic
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  # To test http bearer auth
+  /auth/http/bearer:
+    post:
+      tags:
+        - auth
+      security:
+        - http_bearer_auth: []
+      summary: To test HTTP bearer authentication
+      description: To test HTTP bearer authentication
+      operationId: test/auth/http/bearer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /test/deprecated:
+    get:
+      tags:
+        - query
+      deprecated: true
+      summary: Test deprecation
+      operationId: deprecated-test
+      parameters:
+        - name: name
+          in: query
+          deprecated: true
+          description: name of pet
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  securitySchemes:
+    http_auth:
+      type: http
+      scheme: basic
+    http_bearer_auth:
+      type: http
+      scheme: bearer
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+    AllOfPet:
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+    Tag:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Tag'
+      description: Tag object
+  schemas:
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+      xml:
+        name: category
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: tag
+    Pet:
+      required:
+        - name
+        - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          $ref: '#/components/schemas/Category'
+        photoUrls:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: photoUrl
+        tags:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: pet
+    StringEnumRef:
+      type: string
+      enum:
+      - success
+      - failure
+      - unclassified
+    DefaultValue:
+      type: object
+      description: to test the default value of properties
+      properties:
+        array_string_enum_ref_default:
+          type: array
+          items:
+            $ref: '#/components/schemas/StringEnumRef'
+          default:
+            - success
+            - failure
+        array_string_enum_default:
+          type: array
+          items:
+            type: string
+            enum:
+            - success
+            - failure
+            - unclassified
+          default:
+            - success
+            - failure
+        array_string_default:
+          type: array
+          items:
+            type: string
+          default:
+            - failure
+            - skipped
+        array_integer_default:
+          type: array
+          items:
+            type: integer 
+          default:
+            - 1 
+            - 3
+        array_string:
+          type: array
+          items:
+            type: string
+        array_string_nullable:
+          nullable: true
+          type: array
+          items:
+            type: string
+        array_string_extension_nullable:
+          x-nullable: true
+          type: array
+          items:
+            type: string
+        string_nullable:
+          type: string
+          nullable: true
+    Bird:
+      type: object
+      properties:
+        size:
+          type: string
+        color:
+          type: string
+    Query:
+      type: object
+      x-parent: true
+      properties:
+        id:
+          type: integer
+          description: Query
+          format: int64
+        outcomes:
+          type: array
+          items:
+            type: string
+            enum:
+            - SUCCESS
+            - FAILURE
+            - SKIPPED
+          default:
+            - SUCCESS
+            - FAILURE
+    DataQuery:
+      allOf:
+      - type: object
+        properties:
+          suffix:
+            type: string
+            description: test suffix
+          text:
+            type: string
+            description: Some text containing white spaces
+            example: "Some text"
+          date:
+            type: string
+            format: date-time
+            description: A date
+      - $ref: '#/components/schemas/Query'
+    NumberPropertiesOnly:
+      type: object
+      properties:
+        number:
+          type: number
+        float:
+          type: number
+          format: float
+        double:
+          type: number
+          format: double
+          minimum: 0.8
+          maximum: 50.2

--- a/samples/client/echo_api/typescript/build/QueryApi.md
+++ b/samples/client/echo_api/typescript/build/QueryApi.md
@@ -4,6 +4,7 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**deprecatedTest**](QueryApi.md#deprecatedTest) | **GET** /test/deprecated | Test deprecation
 [**testEnumRefString**](QueryApi.md#testEnumRefString) | **GET** /query/enum_ref_string | Test query parameter(s)
 [**testQueryDatetimeDateString**](QueryApi.md#testQueryDatetimeDateString) | **GET** /query/datetime/date/string | Test query parameter(s)
 [**testQueryIntegerBooleanString**](QueryApi.md#testQueryIntegerBooleanString) | **GET** /query/integer/boolean/string | Test query parameter(s)
@@ -15,6 +16,58 @@ Method | HTTP request | Description
 [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
 
+
+# **deprecatedTest**
+> string deprecatedTest()
+
+
+### Example
+
+
+```typescript
+import { createConfiguration, QueryApi } from '';
+import type { QueryApiDeprecatedTestRequest } from '';
+
+const configuration = createConfiguration();
+const apiInstance = new QueryApi(configuration);
+
+const request: QueryApiDeprecatedTestRequest = {
+    // name of pet (optional)
+  name: "name_example",
+};
+
+const data = await apiInstance.deprecatedTest(request);
+console.log('API called successfully. Returned data:', data);
+```
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **name** | [**string**] | name of pet | (optional) defaults to undefined
+
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](README.md#documentation-for-api-endpoints) [[Back to Model list]](README.md#documentation-for-models) [[Back to README]](README.md)
 
 # **testEnumRefString**
 > string testEnumRefString()

--- a/samples/client/echo_api/typescript/build/apis/QueryApi.ts
+++ b/samples/client/echo_api/typescript/build/apis/QueryApi.ts
@@ -22,6 +22,38 @@ import { TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter } from '..
 export class QueryApiRequestFactory extends BaseAPIRequestFactory {
 
     /**
+     * @deprecated
+     *
+     * Test deprecation
+     * @param name name of pet (@deprecated)
+     */
+    public async deprecatedTest(name?: string, _options?: Configuration): Promise<RequestContext> {
+        let _config = _options || this.configuration;
+
+
+        // Path Params
+        const localVarPath = '/test/deprecated';
+
+        // Make Request Context
+        const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
+        requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (name !== undefined) {
+            requestContext.setQueryParam("name", ObjectSerializer.serialize(name, "string", ""));
+        }
+
+
+        
+        const defaultAuth: SecurityAuthentication | undefined = _config?.authMethods?.default
+        if (defaultAuth?.applySecurityAuthentication) {
+            await defaultAuth?.applySecurityAuthentication(requestContext);
+        }
+
+        return requestContext;
+    }
+
+    /**
      * Test query parameter(s)
      * Test query parameter(s)
      * @param enumNonrefStringQuery 
@@ -384,6 +416,35 @@ export class QueryApiRequestFactory extends BaseAPIRequestFactory {
 }
 
 export class QueryApiResponseProcessor {
+
+    /**
+     * Unwraps the actual response sent by the server from the response context and deserializes the response content
+     * to the expected objects
+     *
+     * @params response Response returned by the server for a request to deprecatedTest
+     * @throws ApiException if the response code was not in [200, 299]
+     */
+     public async deprecatedTestWithHttpInfo(response: ResponseContext): Promise<HttpInfo<string >> {
+        const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
+        if (isCodeInRange("200", response.httpStatusCode)) {
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "string", ""
+            ) as string;
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+        }
+
+        // Work around for missing responses in specification, e.g. for petstore.yaml
+        if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
+            const body: string = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "string", ""
+            ) as string;
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+        }
+
+        throw new ApiException<string | Buffer | undefined>(response.httpStatusCode, "Unknown API Status Code!", await response.getBodyAsAny(), response.headers);
+    }
 
     /**
      * Unwraps the actual response sent by the server from the response context and deserializes the response content

--- a/samples/client/echo_api/typescript/build/types/ObjectParamAPI.ts
+++ b/samples/client/echo_api/typescript/build/types/ObjectParamAPI.ts
@@ -624,6 +624,16 @@ export class ObjectPathApi {
 import { ObservableQueryApi } from "./ObservableAPI";
 import { QueryApiRequestFactory, QueryApiResponseProcessor} from "../apis/QueryApi";
 
+export interface QueryApiDeprecatedTestRequest {
+    /**
+     * name of pet
+     * Defaults to: undefined
+     * @type string
+     * @memberof QueryApideprecatedTest
+     */
+    name?: string
+}
+
 export interface QueryApiTestEnumRefStringRequest {
     /**
      * 
@@ -764,6 +774,22 @@ export class ObjectQueryApi {
 
     public constructor(configuration: Configuration, requestFactory?: QueryApiRequestFactory, responseProcessor?: QueryApiResponseProcessor) {
         this.api = new ObservableQueryApi(configuration, requestFactory, responseProcessor);
+    }
+
+    /**
+     * Test deprecation
+     * @param param the request object
+     */
+    public deprecatedTestWithHttpInfo(param: QueryApiDeprecatedTestRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<string>> {
+        return this.api.deprecatedTestWithHttpInfo(param.name,  options).toPromise();
+    }
+
+    /**
+     * Test deprecation
+     * @param param the request object
+     */
+    public deprecatedTest(param: QueryApiDeprecatedTestRequest = {}, options?: ConfigurationOptions): Promise<string> {
+        return this.api.deprecatedTest(param.name,  options).toPromise();
     }
 
     /**

--- a/samples/client/echo_api/typescript/build/types/PromiseAPI.ts
+++ b/samples/client/echo_api/typescript/build/types/PromiseAPI.ts
@@ -520,6 +520,26 @@ export class PromiseQueryApi {
     }
 
     /**
+     * Test deprecation
+     * @param [name] name of pet
+     */
+    public deprecatedTestWithHttpInfo(name?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<string>> {
+        const observableOptions = wrapOptions(_options);
+        const result = this.api.deprecatedTestWithHttpInfo(name, observableOptions);
+        return result.toPromise();
+    }
+
+    /**
+     * Test deprecation
+     * @param [name] name of pet
+     */
+    public deprecatedTest(name?: string, _options?: PromiseConfigurationOptions): Promise<string> {
+        const observableOptions = wrapOptions(_options);
+        const result = this.api.deprecatedTest(name, observableOptions);
+        return result.toPromise();
+    }
+
+    /**
      * Test query parameter(s)
      * Test query parameter(s)
      * @param [enumNonrefStringQuery]

--- a/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/apis/PetApi.ts
@@ -112,7 +112,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -152,6 +152,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/apis/PetApi.ts
@@ -114,7 +114,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -154,6 +154,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/apis/PetApi.ts
@@ -112,7 +112,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -152,6 +152,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/apis/PetApi.ts
@@ -112,7 +112,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -152,6 +152,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/apis/PetApi.ts
@@ -114,7 +114,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -154,6 +154,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/apis/PetApi.ts
@@ -108,7 +108,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -144,6 +144,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/apis/PetApi.ts
@@ -112,7 +112,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -152,6 +152,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/apis/PetApi.ts
@@ -114,7 +114,7 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * Multiple status values can be provided with comma separated strings
      * Finds Pets by status
-     * @param status Status values that need to be considered for filter
+     * @param status Status values that need to be considered for filter (@deprecated)
      */
     public async findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -154,6 +154,8 @@ export class PetApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * @deprecated
+     *
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
      * @param tags Tags to filter by


### PR DESCRIPTION
PR to add `@deprecation` tags when endpoints or parameters are deprecated

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
