### PR TITLE
Markdown docs : No lowercase on anchors in README file

### DIFF
--- a/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
+++ b/modules/openapi-generator/src/main/resources/markdown-documentation/README.mustache
@@ -8,7 +8,7 @@ All URIs are relative to *{{{basePath}}}*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
-{{#apiInfo}}{{#apis}}{{#operations}}| {{#operation}}*{{classname}}* | [**{{operationId}}**](Apis/{{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{{summary}}}{{^summary}}{{{notes}}}{{/summary}} |
+{{#apiInfo}}{{#apis}}{{#operations}}| {{#operation}}*{{classname}}* | [**{{operationId}}**](Apis/{{apiDocPath}}{{classname}}.md#{{operationId}}) | **{{httpMethod}}** {{path}} | {{{summary}}}{{^summary}}{{{notes}}}{{/summary}} |
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 {{/generateApiDocs}}
 


### PR DESCRIPTION
The anchors in the API pages are not converted to lowercase.  To make the links work in the README page, the fragment should not be converted to lowercase either.