### PR TITLE
[ Go] Add `strictResponseDecoding` option to Go-server generator (default = true)

### DIFF
--- a/docs/generators/go-server.md
+++ b/docs/generators/go-server.md
@@ -29,6 +29,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |router|Specify the router which should be used.|<dl><dt>**mux**</dt><dd>mux</dd><dt>**chi**</dt><dd>chi</dd></dl>|mux|
 |serverPort|The network port the generated server binds to| |8080|
 |sourceFolder|source folder for generated code| |go|
+|strictResponseDecoding| Generated server rejects extra JSON fields | |true|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -35,24 +35,27 @@ import java.util.*;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 public class GoServerCodegen extends AbstractGoCodegen {
-
+    public static final String STRICT_RESPONSE_DECODING = "strictResponseDecoding";
+    protected boolean strictResponseDecoding = true;
     /**
      * Name of additional property for switching routers
      */
     private static final String ROUTER_SWITCH = "router";
+    
+    
 
     /**
      * Description of additional property for switching routers
      */
     private static final String ROUTER_SWITCH_DESC = "Specify the router which should be used.";
-
+    
     /**
      * List of available routers
      */
     private static final String[] ROUTERS = {"mux", "chi"};
-
+    
     private final Logger LOGGER = LoggerFactory.getLogger(GoServerCodegen.class);
-
+    
     @Setter protected String packageVersion = "1.0.0";
     @Setter protected int serverPort = 8080;
     protected String projectName = "openapi-server";
@@ -92,6 +95,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
         // set the output folder here
         outputFolder = "generated-code/go";
 
+        cliOptions.add(new CliOption(STRICT_RESPONSE_DECODING, "If true, server JSON decoders call DisallowUnknownFields").defaultValue("true"));
         cliOptions.add(new CliOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC)
                 .defaultValue(sourceFolder));
 
@@ -132,6 +136,9 @@ public class GoServerCodegen extends AbstractGoCodegen {
         optOutputAsLibrary.setType("bool");
         optOutputAsLibrary.defaultValue(outputAsLibrary.toString());
         cliOptions.add(optOutputAsLibrary);
+
+        cliOptions.add(new CliOption(STRICT_RESPONSE_DECODING, "If true, responses are decoded with DisallowUnknownFields (strict); " + "if false, unknown JSON fields are ignored (permissive)").defaultValue("true"));
+
         /*
          * Models.  You can write model files using the modelTemplateFiles map.
          * if you want to create one template for file, you can do so here.
@@ -192,6 +199,9 @@ public class GoServerCodegen extends AbstractGoCodegen {
          * Additional Properties.  These values can be passed to the templates and
          * are available in models, apis, and supporting files
          */
+        if (additionalProperties.containsKey(STRICT_RESPONSE_DECODING)){
+            strictResponseDecoding = Boolean.parseBoolean(additionalProperties.get(STRICT_RESPONSE_DECODING).toString());
+        }
         if (additionalProperties.containsKey(CodegenConstants.PACKAGE_NAME)) {
             setPackageName((String) additionalProperties.get(CodegenConstants.PACKAGE_NAME));
         } else {
@@ -268,6 +278,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
             routers.put(router, router.equals(propRouter));
         }
         additionalProperties.put("routers", routers);
+        additionalProperties.put("strictResponseDecoding", strictResponseDecoding);
 
         modelPackage = packageName;
         apiPackage = packageName;

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -612,9 +612,9 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{#isBodyParam}}
 	var {{paramName}}Param {{dataType}}
 	d := json.NewDecoder(r.Body)
-	{{^isAdditionalPropertiesTrue}}
+	{{#strictResponseDecoding}}
 	d.DisallowUnknownFields()
-	{{/isAdditionalPropertiesTrue}}
+	{{/strictResponseDecoding}}
 	if err := d.Decode(&{{paramName}}Param); err != nil {{^required}}&& !errors.Is(err, io.EOF) {{/required}}{
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return


### PR DESCRIPTION
**Summary**

This PR introduces a new generator property, `strictResponseDecoding`, to the **go-server** generator. When enabled (the new default), every JSON decoder in generated handlers will call `DisallowUnknownFields()`, causing the server to reject any incoming payloads that contain fields not defined in the spec. Users can disable strict mode and allow extra fields by passing `--additional-properties strictResponseDecoding=false`.

---

**Changes**

1. **Codegen configuration**

   * **File:** `GoServerCodegen.java`
   * **What’s changed:**

     * Added a `STRICT_RESPONSE_DECODING` CLI option (default: `true`).
     * Exposed `strictResponseDecoding` boolean in `additionalProperties` for use in templates.

2. **Template guard**

   * **File:** `server.mustache`
   * **What’s changed:**

     * Wrapped the call to `decoder.DisallowUnknownFields()` in a `{{#strictResponseDecoding}}…{{/strictResponseDecoding}}` block.

3. **Documentation**

   * **File:** Go-server README (`modules/openapi-generator/README.md`)
   * **What’s changed:**

     * Documented the new `--additional-properties=strictResponseDecoding={true|false}` flag, its default behavior, and usage example.

---

**Impact**

* **Backward compatibility:**

  * Default behavior is now “strict” (reject unknown fields). Users relying on permissive parsing must explicitly opt out.
* **Client generation:**

  * No impact; this change applies only to the go-server generator.

---



**Usage Example**

```bash
# Strict mode (default):
openapi-generator generate \
  -i api.yaml \
  -g go-server

# Permissive mode:
openapi-generator generate \
  -i api.yaml \
  -g go-server \
  --additional-properties strictResponseDecoding=false
```

---

**Checklist**

* [x] Added CLI option in `GoServerCodegen.java`
* [x] Updated `server.mustache` template
* [x] Updated Go-server README with documentation

@antihax  @grokify  @kemokemo @jirikuncar @ph4r5h4d  @lwj5 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
