### PR TITLE
[go][client] Allow for unknown field if AdditionalProperties is true

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -548,7 +548,9 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 	var{{{classname}}} := _{{{classname}}}{}
 
 	decoder := json.NewDecoder(bytes.NewReader(data))
+{{#isAdditionalPropertiesTrue}}
 	decoder.DisallowUnknownFields()
+{{/isAdditionalPropertiesTrue}}
 	err = decoder.Decode(&var{{{classname}}})
 
 	if err != nil {


### PR DESCRIPTION


- Probable fix for https://github.com/OpenAPITools/openapi-generator/issues/21446
