### PR TITLE
[scala][http4s] fix codegen for using reserved words in openapi

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sServerCodegen.java
@@ -807,12 +807,12 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
 
         if (_vendorExtensions.size() == 1) { // only `x-type`
             if ("String".equals(cp.getDataType())) {
-                return cp.baseName;
+                return cp.paramName;
             } else {
-                return cp.dataType + "Varr(" + cp.baseName + ")";
+                return cp.dataType + "Varr(" + cp.paramName + ")";
             }
         } else {
-            return cp.baseName + "Varr(" + cp.baseName + ")";
+            return cp.baseName + "Varr(" + cp.paramName + ")";
         }
     }
 
@@ -844,7 +844,7 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
         }
 
         vendorExtensions.putAll(refineProp(cp, imports));
-        return cp.baseName + "QueryParam(" + cp.baseName + ")";
+        return cp.baseName + "QueryParam(" + cp.paramName + ")";
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateArgs.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateArgs.mustache
@@ -1,21 +1,21 @@
 {{#pathParams}}
-      {{baseName}}: {{{vendorExtensions.x-type}}},
+      {{paramName}}: {{{vendorExtensions.x-type}}},
 {{/pathParams}}
 {{#queryParams}}
   {{#isArray}}
     {{#required}}
-      {{baseName}}: List[{{{items.vendorExtensions.x-type}}}],
+      {{paramName}}: List[{{{items.vendorExtensions.x-type}}}],
     {{/required}}
     {{^required}}
-      {{baseName}}: Option[List[{{{items.vendorExtensions.x-type}}}]],
+      {{paramName}}: Option[List[{{{items.vendorExtensions.x-type}}}]],
     {{/required}}
   {{/isArray}}
   {{^isArray}}
     {{#required}}
-      {{baseName}}: {{{vendorExtensions.x-type}}},
+      {{paramName}}: {{{vendorExtensions.x-type}}},
     {{/required}}
     {{^required}}
-      {{baseName}}: Option[{{{vendorExtensions.x-type}}}],
+      {{paramName}}: Option[{{{vendorExtensions.x-type}}}],
     {{/required}}
   {{/isArray}}
 {{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallGeneric.mustache
@@ -1,6 +1,6 @@
 {{^authName}}
-delegate.{{operationId}}.handle(req, {{#pathParams}}{{baseName}}, {{/pathParams}}{{#queryParams}}{{baseName}}, {{/queryParams}}responses)
+delegate.{{operationId}}.handle(req, {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
 {{/authName}}
 {{#authName}}
-delegate.{{operationId}}.handle_{{authName}}(auth, req, {{#pathParams}}{{baseName}}, {{/pathParams}}{{#queryParams}}{{baseName}}, {{/queryParams}}responses)
+delegate.{{operationId}}.handle_{{authName}}(auth, req, {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
 {{/authName}}

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallJson.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallJson.mustache
@@ -1,6 +1,6 @@
 {{^authName}}
-  delegate.{{operationId}}.handle(req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{baseName}}, {{/pathParams}}{{#queryParams}}{{baseName}}, {{/queryParams}}responses)
+  delegate.{{operationId}}.handle(req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
 {{/authName}}
 {{#authName}}
-  delegate.{{operationId}}.handle_{{authName}}(auth, req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{baseName}}, {{/pathParams}}{{#queryParams}}{{baseName}}, {{/queryParams}}responses)
+  delegate.{{operationId}}.handle_{{authName}}(auth, req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
 {{/authName}}


### PR DESCRIPTION
###

There is an example of correct openAPI specification:

```json
{
  "openapi": "3.0.0",
  "info": {
    "title": "Simple API",
    "description": "A simple API with GET and POST endpoints",
    "version": "1.0.0"
  },
  "servers": [
    {
      "url": "https://api.example.com/v1"
    }
  ],
  "paths": {
    "/users": {
      "get": {
        "summary": "Method with non-escaped parameter and escaped parameter",
        "parameters": [
          {
            "name": "id",
            "in": "query",
            "description": "Non-escaped parameter that should not be modified",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int64"
            }
          },
          {
            "name": "type",
            "in": "query",
            "description": "Escaped parameter that should be modified",
            "required": true,
            "schema": {
              "type": "string",
              "enum": [
                "active",
                "inactive",
                "pending"
              ]
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Successful response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/User"
                }
              }
            }
          }
        }
      }
    },
    "/users/{type}/{var}/{id}": {
      "get": {
        "summary": "Method with non-escaped parameter, escaped string parameter and escaped long parameter",
        "parameters": [
          {
            "name": "type",
            "in": "path",
            "required": true,
            "description": "Escaped string parameter that should be modified",
            "schema": {
              "type": "string",
              "enum": [
                "active",
                "inactive",
                "pending"
              ]
            }
          },
          {
            "name": "var",
            "in": "path",
            "required": true,
            "description": "Escaped long parameter that should be modified",
            "schema": {
              "type": "integer",
              "format": "int64"
            }
          },
          {
            "name": "id",
            "in": "path",
            "required": true,
            "description": "Non-escaped parameter that should not be modified",
            "schema": {
              "type": "integer",
              "format": "int64"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Successful response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/User"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "User": {
        "type": "object",
        "properties": {
          "result": {
            "type": "string",
            "enum": [
              "active",
              "inactive",
              "pending"
            ]
          }
        },
        "required": [
          "result"
        ]
      }
    }
  }
}
```

For given OpenAPI specification generated not compiled code because it uses reserved words. 
I [changed](https://github.com/OpenAPITools/openapi-generator/issues/3015#issuecomment-496275558) `baseName` to `paramName` to use escaped variables instead of reserved words for `scala-http4s-server`


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Hello! 👋
I'd love to get your eyes on this PR when you have a moment.
Thanks in advance!

@clasnake (2017/07), @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04) @fish86 (2023/06)
