### PR TITLE
Revert "[kotlin-client] Add support for integer enums in serialization for kotlin-client (#21248)"

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -43,45 +43,20 @@ import kotlinx.serialization.*
 {{#allowableValues}}{{#enumVars}}
     {{^multiplatform}}
     {{#moshi}}
-    {{#isString}}
     @Json(name = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
-    {{/isString}}
-    {{^isString}}
-    @Json(name = {{{value}}})
-    {{/isString}}
     {{/moshi}}
     {{#gson}}
-    {{#isString}}
     @SerializedName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
-    {{/isString}}
-    {{^isString}}
-    @SerializedName(value = {{{value}}})
-    {{/isString}}
     {{/gson}}
     {{#jackson}}
-    {{#isString}}
     @JsonProperty(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
-    {{/isString}}
-    {{^isString}}
-    @JsonProperty(value = {{{value}}}){{#enumUnknownDefaultCase}}{{#-last}} @JsonEnumDefaultValue{{/-last}}{{/enumUnknownDefaultCase}}
-    {{/isString}}
     {{/jackson}}
     {{#kotlinx_serialization}}
-    {{#isString}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
-    {{/isString}}
-    {{^isString}}
-    @SerialName(value = {{{value}}})
-    {{/isString}}
     {{/kotlinx_serialization}}
     {{/multiplatform}}
     {{#multiplatform}}
-    {{#isString}}
     @SerialName(value = {{#lambda.doublequote}}{{{value}}}{{/lambda.doublequote}})
-    {{/isString}}
-    {{^isString}}
-    @SerialName(value = {{{value}}})
-    {{/isString}}
     {{/multiplatform}}
     {{#isArray}}
     {{#isList}}


### PR DESCRIPTION
This reverts this PR https://github.com/OpenAPITools/openapi-generator/pull/21248 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)