### PR TITLE
[BUG][Kotlin] Fixed primitive type check for array of array

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -292,6 +292,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
             }
             {{/required}}
             {{#items.isPrimitiveType}}
+            {{^items.isArray}}
             // ensure the items in json array are primitive
             if (jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] != null) {
               for (i in 0 until jsonObj.getAsJsonArray("{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}").size()) {
@@ -300,6 +301,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
                 }
               }
             }
+            {{/items.isArray}}
             {{/items.isPrimitiveType}}
             {{/items.isModel}}
             {{/isArray}}


### PR DESCRIPTION
## Description
Upon [PR #21315](https://github.com/OpenAPITools/openapi-generator/pull/21315), a feature was included, so that code is generated of to check that in a list of primitive types, the items in that list are in fact a primitive. Now I discovered an edge case:

### Current behavior:
A list of a list currently also generate the code, which then leads to false assertions.

### Excpected behavior:
The code added in the PR is not being generated for a list of a list.

I do not really understand why a list is considered a primitive type here, but I simply had to add another if statement to check for such a case.

@dr4ke616 @karismann @Zomzog @andrewemery @4brunu @stefankoppier @e5l