### PR TITLE
[scala][http4s] fix escaping of reserved words for correct model dese…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaHttp4sServerCodegen.java
@@ -16,10 +16,14 @@
 
 package org.openapitools.codegen.languages;
 
+import com.google.common.collect.ImmutableMap;
+import com.samskivert.mustache.Escapers;
+import com.samskivert.mustache.Mustache;
 import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.model.*;
+import org.openapitools.codegen.templating.mustache.EscapeKeywordLambda;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,7 +144,7 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
         additionalProperties.put("infoEmail", "team@openapitools.org");
         additionalProperties.put("licenseInfo", "Apache 2.0");
         additionalProperties.put("licenseUrl", "http://apache.org/licenses/LICENSE-2.0.html");
-
+        additionalProperties.put("fnEscapeBacktick", new EscapeBacktickLambda());
 
         languageSpecificPrimitives = new HashSet<>(
                 Arrays.asList(
@@ -557,7 +561,12 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
 
     @Override
     public String escapeReservedWord(String name) {
-        return "_" + name;
+        if (this.reservedWordsMappings().containsKey(name)) {
+            return this.reservedWordsMappings().get(name);
+        }
+        // Reserved words will be further escaped at the mustache compiler level.
+        // Scala escaping done here (via `, without compiler escaping) would otherwise be HTML encoded.
+        return "`" + name + "`";
     }
 
     @Override
@@ -807,12 +816,12 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
 
         if (_vendorExtensions.size() == 1) { // only `x-type`
             if ("String".equals(cp.getDataType())) {
-                return cp.paramName;
+                return escapeReservedWordUnapply(cp.baseName);
             } else {
-                return cp.dataType + "Varr(" + cp.paramName + ")";
+                return cp.dataType + "Varr(" + escapeReservedWordUnapply(cp.baseName) + ")";
             }
         } else {
-            return cp.baseName + "Varr(" + cp.paramName + ")";
+            return cp.baseName + "Varr(" + escapeReservedWordUnapply(cp.baseName) + ")";
         }
     }
 
@@ -844,11 +853,34 @@ public class ScalaHttp4sServerCodegen extends DefaultCodegen implements CodegenC
         }
 
         vendorExtensions.putAll(refineProp(cp, imports));
-        return cp.baseName + "QueryParam(" + cp.paramName + ")";
+        return cp.baseName + "QueryParam(" + escapeReservedWordUnapply(cp.baseName) + ")";
     }
 
     @Override
     public GeneratorLanguage generatorLanguage() {
         return GeneratorLanguage.SCALA;
+    }
+
+    @Override
+    protected ImmutableMap.Builder<String, Mustache.Lambda> addMustacheLambdas() {
+        return super.addMustacheLambdas()
+                .put("escapeReservedWordUnapply", new EscapeKeywordLambda(this::escapeReservedWordUnapply));
+    }
+
+    private String escapeReservedWordUnapply(String value) {
+        // The unapply method doesn’t allow you to work with reserved variables via backticks;
+        // in such cases you should use the variable via a placeholder instead.
+        return isReservedWord(value) ? "_" + value : value;
+    }
+
+    private static class EscapeBacktickLambda extends AbstractScalaCodegen.CustomLambda {
+        @Override
+        public String formatFragment(String fragment) {
+            if (fragment.startsWith("`") && fragment.endsWith("`")) {
+                String unescaped = fragment.substring(1, fragment.length() - 1);
+                return "`" + Escapers.HTML.escape(unescaped) + "`";
+            }
+            return Escapers.HTML.escape(fragment);
+        }
     }
 }

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateArgs.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateArgs.mustache
@@ -1,21 +1,21 @@
 {{#pathParams}}
-      {{paramName}}: {{{vendorExtensions.x-type}}},
+      {{#fnEscapeBacktick}}{{{paramName}}}{{/fnEscapeBacktick}}: {{{vendorExtensions.x-type}}},
 {{/pathParams}}
 {{#queryParams}}
   {{#isArray}}
     {{#required}}
-      {{paramName}}: List[{{{items.vendorExtensions.x-type}}}],
+      {{#fnEscapeBacktick}}{{{paramName}}}{{/fnEscapeBacktick}}: List[{{{items.vendorExtensions.x-type}}}],
     {{/required}}
     {{^required}}
-      {{paramName}}: Option[List[{{{items.vendorExtensions.x-type}}}]],
+      {{#fnEscapeBacktick}}{{{paramName}}}{{/fnEscapeBacktick}}: Option[List[{{{items.vendorExtensions.x-type}}}]],
     {{/required}}
   {{/isArray}}
   {{^isArray}}
     {{#required}}
-      {{paramName}}: {{{vendorExtensions.x-type}}},
+      {{#fnEscapeBacktick}}{{{paramName}}}{{/fnEscapeBacktick}}: {{{vendorExtensions.x-type}}},
     {{/required}}
     {{^required}}
-      {{paramName}}: Option[{{{vendorExtensions.x-type}}}],
+      {{#fnEscapeBacktick}}{{{paramName}}}{{/fnEscapeBacktick}}: Option[{{{vendorExtensions.x-type}}}],
     {{/required}}
   {{/isArray}}
 {{/queryParams}}

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallGeneric.mustache
@@ -1,6 +1,6 @@
 {{^authName}}
-delegate.{{operationId}}.handle(req, {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
+delegate.{{operationId}}.handle(req, {{#pathParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/pathParams}}{{#queryParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/queryParams}}responses)
 {{/authName}}
 {{#authName}}
-delegate.{{operationId}}.handle_{{authName}}(auth, req, {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
+delegate.{{operationId}}.handle_{{authName}}(auth, req, {{#pathParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/pathParams}}{{#queryParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/queryParams}}responses)
 {{/authName}}

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallJson.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/delegateCallJson.mustache
@@ -1,6 +1,6 @@
 {{^authName}}
-  delegate.{{operationId}}.handle(req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
+  delegate.{{operationId}}.handle(req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/pathParams}}{{#queryParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/queryParams}}responses)
 {{/authName}}
 {{#authName}}
-  delegate.{{operationId}}.handle_{{authName}}(auth, req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{paramName}}, {{/pathParams}}{{#queryParams}}{{paramName}}, {{/queryParams}}responses)
+  delegate.{{operationId}}.handle_{{authName}}(auth, req, req.asJsonDecode[{{{bodyParam.dataType}}}] , {{#pathParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/pathParams}}{{#queryParams}}{{#lambda.escapeReservedWordUnapply}}{{baseName}}{{/lambda.escapeReservedWordUnapply}}, {{/queryParams}}responses)
 {{/authName}}

--- a/modules/openapi-generator/src/main/resources/scala-http4s-server/types.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s-server/types.mustache
@@ -23,7 +23,7 @@ import {{modelPackage}}.{{classname}}.{{classname}}
 /**
 * {{{description}}}
 {{#vars}}
-* @param {{name}} {{{description}}}
+* @param {{#fnEscapeBacktick}}{{{name}}}{{/fnEscapeBacktick}} {{{description}}}
 {{/vars}}
 */
 {{#vendorExtensions.x-isSealedTrait}}
@@ -104,7 +104,7 @@ object {{classname}} extends Enumeration {
 {{#vendorExtensions.x-another}}
 case class {{classname}}(
 {{#vars}}
-  {{name}}: {{^required}}Option[{{{vendorExtensions.x-type}}}]{{/required}}{{#required}}{{{vendorExtensions.x-type}}}{{/required}}{{^-last}},{{/-last}}
+  {{#fnEscapeBacktick}}{{{name}}}{{/fnEscapeBacktick}}: {{^required}}Option[{{{vendorExtensions.x-type}}}]{{/required}}{{#required}}{{{vendorExtensions.x-type}}}{{/required}}{{^-last}},{{/-last}}
 {{/vars}}
 ){{#vendorExtensions.x-extends}} extends {{.}}{{/vendorExtensions.x-extends}}{{#vendorExtensions.x-extendsWith}} with {{.}}{{/vendorExtensions.x-extendsWith}}
 object {{classname}} {

--- a/samples/server/petstore/scala-http4s-server/src/main/scala/org/openapitools/apis/FakeApi.scala
+++ b/samples/server/petstore/scala-http4s-server/src/main/scala/org/openapitools/apis/FakeApi.scala
@@ -57,8 +57,8 @@ trait FakeApiDelegate[F[_]] {
 
     def handle(
       req: Request[F],
-      _type: String,
-      _var: Option[String],
+      `type`: String,
+      `var`: Option[String],
       responses: reservedWordsResponses[F]
     ): F[Response[F]]
 

--- a/samples/server/petstore/scala-http4s-server/src/main/scala/org/openapitools/models/types.scala
+++ b/samples/server/petstore/scala-http4s-server/src/main/scala/org/openapitools/models/types.scala
@@ -15,13 +15,13 @@ import java.time.ZonedDateTime
 /**
 * Describes the result of uploading an image resource
 * @param code 
-* @param _type 
+* @param `type` 
 * @param message 
 */
 
 case class ApiResponse(
   code: Option[Int],
-  _type: Option[String],
+  `type`: Option[String],
   message: Option[String]
 )
 object ApiResponse {


### PR DESCRIPTION
###

There is an example of correct openAPI specification:

```json
{
  "openapi": "3.0.0",
  "info": {
    "title": "Simple API",
    "description": "A simple API with GET and POST endpoints",
    "version": "1.0.0"
  },
  "servers": [
    {
      "url": "https://api.example.com/v1"
    }
  ],
  "paths": {
    "/users": {
      "get": {
        "summary": "Method that has models with a reserved word",
        "parameters": [
          {
            "name": "typeName",
            "in": "query",
            "description": "param",
            "required": true,
            "schema": {
              "type": "string",
              "enum": [
                "active",
                "inactive",
                "pending"
              ]
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Successful response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/User"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "User": {
        "type": "object",
        "properties": {
          "type": {
            "type": "string",
            "enum": [
              "active",
              "inactive",
              "pending"
            ]
          }
        },
        "required": [
          "type"
        ]
      }
    }
  }
}
```

JSON response is generated for this OpenAPI specification:

```json
{"_type":"active"}
```

This is incorrect since we specified that the field should be named `type`, not `_type`.
I changed the escaping of reserved words to standard Scala backticks notation so that the JSON decoder could properly map the domain to JSON.

```json
{"type":"active"}
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Hello! 👋
I'd love to get your eyes on this PR when you have a moment.
Thanks in advance!

@clasnake (2017/07), @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04) @fish86 (2023/06)
