### PR TITLE
Removed try/catch to enable framework error handling to pick up error

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-laravel/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-laravel/api_controller.mustache
@@ -87,13 +87,8 @@ class {{controllerName}} extends Controller
         {{/isPathParam}}
 
         {{/allParams}}
-        try {
-            $apiResult = $this->api->{{operationId}}({{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
-        } catch (\Exception $exception) {
-            // This shouldn't happen
-            report($exception);
-            return response()->json(['error' => $exception->getMessage()], 500);
-        }
+
+        $apiResult = $this->api->{{operationId}}({{#allParams}}${{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
 
         {{#responses}}
         {{#isArray}}


### PR DESCRIPTION
@ybelenko Mentioning you here as I needed to mention the relevant tech committee. as per the PR description template

I have removed the try/catch block from the controller logic in the php-laravel server generator. The reason for that is because the try/catch block is not extendable and returns a nonstandard and non-customizable response.

By removing the try/catch block we allow Laravel to pick up and handle the error. We also allow users of the generator to add their custom generator logic.

This should fix #21109 . Got no response so am now trying this route.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
