### PR TITLE
Qualify rust trait template comments

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest-trait/api.mustache
@@ -26,11 +26,11 @@ pub trait {{{classname}}}: Send + Sync {
     /// {{{notes}}}
     {{/notes.empty}}
 {{#vendorExtensions.x-group-parameters}}
-    async fn {{{operationId}}}(&self, {{#allParams}}{{#-first}} params: {{{operationIdCamelCase}}}Params {{/-first}}{{/allParams}}{{! 
+    async fn {{{operationId}}}(&self, {{#allParams}}{{#-first}} params: {{{operationIdCamelCase}}}Params {{/-first}}{{/allParams}}{{!
     ### Function return type
     }}) -> Result<{{!
     ### Multi response support
-    }}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{! 
+    }}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{!
     ### Regular return type
     }}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{!
     ### Error Type
@@ -39,27 +39,27 @@ pub trait {{{classname}}}: Send + Sync {
 {{^vendorExtensions.x-group-parameters}}
     async fn {{{operationId}}}{{!
     ### Lifetimes
-    }}<{{#allParams}}'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}}{{^-last}}, {{/-last}}{{/allParams}}>{{! 
+    }}<{{#allParams}}'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}}{{^-last}}, {{/-last}}{{/allParams}}>{{!
     ### Function parameter names
-    }}(&self, {{#allParams}}{{{paramName}}}: {{! 
+    }}(&self, {{#allParams}}{{{paramName}}}: {{!
     ### Option Start
-    }}{{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{! 
+    }}{{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{!
     ### &str and Vec<&str>
-    }}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}} str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{! 
+    }}{{#isString}}{{#isArray}}Vec<{{/isArray}}{{^isUuid}}&'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}} str{{/isUuid}}{{#isArray}}>{{/isArray}}{{/isString}}{{!
     ### UUIDs
-    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{! 
+    }}{{#isUuid}}{{#isArray}}Vec<{{/isArray}}&str{{#isArray}}>{{/isArray}}{{/isUuid}}{{!
     ### Models and primative types
-    }}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{! 
+    }}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}models::{{/isContainer}}{{/isPrimitiveType}}{{{dataType}}}{{/isUuid}}{{/isString}}{{!
     ### Option End
-    }}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{! 
+    }}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{!
     ### Comma for next arguement
     }}{{^-last}}, {{/-last}}{{/allParams}}{{!
     ### Function return type
-    }}) -> Result<{{! 
+    }}) -> Result<{{!
     ### Multi response support
-    }}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{! 
+    }}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{!
     ### Regular return type
-    }}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{! 
+    }}{{^supportMultipleResponses}}{{^returnType}}(){{/returnType}}{{{returnType}}}{{/supportMultipleResponses}}{{!
     ### Error Type
     }}, Error<{{{operationIdCamelCase}}}Error>>;
 {{/vendorExtensions.x-group-parameters}}
@@ -83,7 +83,7 @@ impl {{classname}}Client {
 {{#vendorExtensions.x-group-parameters}}
 {{#allParams}}
 {{#-first}}
-/// struct for passing parameters to the method [`{{operationId}}`]
+/// struct for passing parameters to the method [`{{{classname}}}::{{operationId}}`]
 #[derive(Clone, Debug)]
 {{#useBonBuilder}}
 #[cfg_attr(feature = "bon", derive(::bon::Builder))]
@@ -149,7 +149,7 @@ impl {{classname}} for {{classname}}Client {
     ### Lifetimes
     }}<{{#allParams}}'{{#lambda.lifetimeName}}{{{paramName}}}{{/lambda.lifetimeName}}{{^-last}}, {{/-last}}{{/allParams}}>{{!
     ### Function parameter names
-    }}(&self, {{#allParams}}{{{paramName}}}: {{! 
+    }}(&self, {{#allParams}}{{{paramName}}}: {{!
     ### Option Start
     }}{{^required}}Option<{{/required}}{{#required}}{{#isNullable}}Option<{{/isNullable}}{{/required}}{{!
     ### &str and Vec<&str>
@@ -161,9 +161,9 @@ impl {{classname}} for {{classname}}Client {
     ### Option End
     }}{{^required}}>{{/required}}{{#required}}{{#isNullable}}>{{/isNullable}}{{/required}}{{!
     ### Comma for next arguement
-    }}{{^-last}}, {{/-last}}{{/allParams}}{{! 
+    }}{{^-last}}, {{/-last}}{{/allParams}}{{!
     ### Function return type
-    }}) -> Result<{{! 
+    }}) -> Result<{{!
     ### Multi response support
     }}{{#supportMultipleResponses}}ResponseContent<{{{operationIdCamelCase}}}Success>{{/supportMultipleResponses}}{{!
     ### Regular return type
@@ -516,7 +516,7 @@ impl {{classname}} for {{classname}}Client {
 {{#supportMultipleResponses}}
 {{#operations}}
 {{#operation}}
-/// struct for typed successes of method [`{{operationId}}`]
+/// struct for typed successes of method [`{{{classname}}}::{{operationId}}`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum {{{operationIdCamelCase}}}Success {
@@ -536,7 +536,7 @@ pub enum {{{operationIdCamelCase}}}Success {
 {{/supportMultipleResponses}}
 {{#operations}}
 {{#operation}}
-/// struct for typed errors of method [`{{operationId}}`]
+/// struct for typed errors of method [`{{{classname}}}::{{operationId}}`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum {{{operationIdCamelCase}}}Error {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/fake_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/fake_api.rs
@@ -82,7 +82,7 @@ impl FakeApi for FakeApiClient {
 
 }
 
-/// struct for typed errors of method [`test_nullable_required_param`]
+/// struct for typed errors of method [`FakeApi::test_nullable_required_param`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TestNullableRequiredParamError {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/pet_api.rs
@@ -511,7 +511,7 @@ impl PetApi for PetApiClient {
 
 }
 
-/// struct for typed errors of method [`add_pet`]
+/// struct for typed errors of method [`PetApi::add_pet`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AddPetError {
@@ -519,7 +519,7 @@ pub enum AddPetError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`delete_pet`]
+/// struct for typed errors of method [`PetApi::delete_pet`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeletePetError {
@@ -527,7 +527,7 @@ pub enum DeletePetError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`find_pets_by_status`]
+/// struct for typed errors of method [`PetApi::find_pets_by_status`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FindPetsByStatusError {
@@ -535,7 +535,7 @@ pub enum FindPetsByStatusError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`find_pets_by_tags`]
+/// struct for typed errors of method [`PetApi::find_pets_by_tags`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FindPetsByTagsError {
@@ -543,7 +543,7 @@ pub enum FindPetsByTagsError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`get_pet_by_id`]
+/// struct for typed errors of method [`PetApi::get_pet_by_id`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetPetByIdError {
@@ -552,7 +552,7 @@ pub enum GetPetByIdError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`pets_explode_post`]
+/// struct for typed errors of method [`PetApi::pets_explode_post`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PetsExplodePostError {
@@ -560,7 +560,7 @@ pub enum PetsExplodePostError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`pets_post`]
+/// struct for typed errors of method [`PetApi::pets_post`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PetsPostError {
@@ -568,7 +568,7 @@ pub enum PetsPostError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`update_pet`]
+/// struct for typed errors of method [`PetApi::update_pet`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UpdatePetError {
@@ -578,7 +578,7 @@ pub enum UpdatePetError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`update_pet_with_form`]
+/// struct for typed errors of method [`PetApi::update_pet_with_form`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UpdatePetWithFormError {
@@ -586,7 +586,7 @@ pub enum UpdatePetWithFormError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`upload_file`]
+/// struct for typed errors of method [`PetApi::upload_file`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UploadFileError {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/store_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/store_api.rs
@@ -209,7 +209,7 @@ impl StoreApi for StoreApiClient {
 
 }
 
-/// struct for typed errors of method [`delete_order`]
+/// struct for typed errors of method [`StoreApi::delete_order`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeleteOrderError {
@@ -218,14 +218,14 @@ pub enum DeleteOrderError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`get_inventory`]
+/// struct for typed errors of method [`StoreApi::get_inventory`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetInventoryError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`get_order_by_id`]
+/// struct for typed errors of method [`StoreApi::get_order_by_id`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetOrderByIdError {
@@ -234,7 +234,7 @@ pub enum GetOrderByIdError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`place_order`]
+/// struct for typed errors of method [`StoreApi::place_order`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PlaceOrderError {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/testing_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/testing_api.rs
@@ -167,21 +167,21 @@ impl TestingApi for TestingApiClient {
 
 }
 
-/// struct for typed errors of method [`tests_all_of_with_one_model_get`]
+/// struct for typed errors of method [`TestingApi::tests_all_of_with_one_model_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TestsAllOfWithOneModelGetError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`tests_file_response_get`]
+/// struct for typed errors of method [`TestingApi::tests_file_response_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TestsFileResponseGetError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`tests_type_testing_get`]
+/// struct for typed errors of method [`TestingApi::tests_type_testing_get`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TestsTypeTestingGetError {

--- a/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/user_api.rs
+++ b/samples/client/petstore/rust/reqwest-trait/petstore/src/apis/user_api.rs
@@ -368,7 +368,7 @@ impl UserApi for UserApiClient {
 
 }
 
-/// struct for typed errors of method [`create_user`]
+/// struct for typed errors of method [`UserApi::create_user`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CreateUserError {
@@ -376,7 +376,7 @@ pub enum CreateUserError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`create_users_with_array_input`]
+/// struct for typed errors of method [`UserApi::create_users_with_array_input`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CreateUsersWithArrayInputError {
@@ -384,7 +384,7 @@ pub enum CreateUsersWithArrayInputError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`create_users_with_list_input`]
+/// struct for typed errors of method [`UserApi::create_users_with_list_input`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CreateUsersWithListInputError {
@@ -392,7 +392,7 @@ pub enum CreateUsersWithListInputError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`delete_user`]
+/// struct for typed errors of method [`UserApi::delete_user`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeleteUserError {
@@ -401,7 +401,7 @@ pub enum DeleteUserError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`get_user_by_name`]
+/// struct for typed errors of method [`UserApi::get_user_by_name`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetUserByNameError {
@@ -410,7 +410,7 @@ pub enum GetUserByNameError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`login_user`]
+/// struct for typed errors of method [`UserApi::login_user`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LoginUserError {
@@ -418,7 +418,7 @@ pub enum LoginUserError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`logout_user`]
+/// struct for typed errors of method [`UserApi::logout_user`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LogoutUserError {
@@ -426,7 +426,7 @@ pub enum LogoutUserError {
     UnknownValue(serde_json::Value),
 }
 
-/// struct for typed errors of method [`update_user`]
+/// struct for typed errors of method [`UserApi::update_user`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum UpdateUserError {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

The doc links for parameter and error structs in the `reqwest-trait` template were copied over from the `reqwest` template, but they are not valid as-is, as these functions are now part of a trait and not standalone functions. This means for them to work correctly in IDEs and docs you need to qualify them with the trait name.

For example, VSCode, shows the link with a different color and displays a preview of the function, plus clicking on the name would navigate to the function.
With this change:
![image](https://github.com/user-attachments/assets/9722726b-82ab-47d4-aca6-13db4b2d204b)
 
Without this change:
![image](https://github.com/user-attachments/assets/d9549335-37d2-47b8-82e8-21f6af2a180e)

I've also removed the trailing whitespace from the template file, let me know if you prefer that to be reverted and split into a separate PR.

Tagging openapi-generator Rust committee, like the checklist mentions: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
