### PR TITLE
[req] Allow models and apis list properties to span multi-lines and i…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -626,6 +626,17 @@ public class DefaultGenerator implements Generator {
         }
     }
 
+    private Set<String> getPropertyAsSet(String propertyName) {
+        String propertyRaw = GlobalSettings.getProperty(propertyName);
+        if (propertyRaw == null || propertyRaw.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        return Arrays.stream(propertyRaw.split(","))
+            .map(String::trim)
+            .collect(Collectors.toSet());
+    }
+
     private Set<String> modelKeys() {
         final Map<String, Schema> schemas = ModelUtils.getSchemas(this.openAPI);
         if (schemas == null) {
@@ -633,12 +644,7 @@ public class DefaultGenerator implements Generator {
             return Collections.emptySet();
         }
 
-        String modelNames = GlobalSettings.getProperty("models");
-        Set<String> modelsToGenerate = null;
-        if (modelNames != null && !modelNames.isEmpty()) {
-            modelsToGenerate = new HashSet<>(Arrays.asList(modelNames.split(",")));
-        }
-
+        Set<String> modelsToGenerate = getPropertyAsSet(CodegenConstants.MODELS);
         Set<String> modelKeys = schemas.keySet();
         if (modelsToGenerate != null && !modelsToGenerate.isEmpty()) {
             Set<String> updatedKeys = new HashSet<>();
@@ -661,11 +667,7 @@ public class DefaultGenerator implements Generator {
             return;
         }
         Map<String, List<CodegenOperation>> paths = processPaths(this.openAPI.getPaths());
-        Set<String> apisToGenerate = null;
-        String apiNames = GlobalSettings.getProperty(CodegenConstants.APIS);
-        if (apiNames != null && !apiNames.isEmpty()) {
-            apisToGenerate = new HashSet<>(Arrays.asList(apiNames.split(",")));
-        }
+        Set<String> apisToGenerate = getPropertyAsSet(CodegenConstants.APIS);
         if (apisToGenerate != null && !apisToGenerate.isEmpty()) {
             Map<String, List<CodegenOperation>> updatedPaths = new TreeMap<>();
             for (String m : paths.keySet()) {
@@ -827,11 +829,7 @@ public class DefaultGenerator implements Generator {
             return;
         }
         Map<String, List<CodegenOperation>> webhooks = processWebhooks(this.openAPI.getWebhooks());
-        Set<String> webhooksToGenerate = null;
-        String webhookNames = GlobalSettings.getProperty(CodegenConstants.WEBHOOKS);
-        if (webhookNames != null && !webhookNames.isEmpty()) {
-            webhooksToGenerate = new HashSet<>(Arrays.asList(webhookNames.split(",")));
-        }
+        Set<String> webhooksToGenerate = getPropertyAsSet(CodegenConstants.WEBHOOKS);
         if (webhooksToGenerate != null && !webhooksToGenerate.isEmpty()) {
             Map<String, List<CodegenOperation>> Webhooks = new TreeMap<>();
             for (String m : webhooks.keySet()) {
@@ -1064,12 +1062,7 @@ public class DefaultGenerator implements Generator {
             return;
         }
 
-        Set<String> supportingFilesToGenerate = null;
-        String supportingFiles = GlobalSettings.getProperty(CodegenConstants.SUPPORTING_FILES);
-        if (supportingFiles != null && !supportingFiles.isEmpty()) {
-            supportingFilesToGenerate = new HashSet<>(Arrays.asList(supportingFiles.split(",")));
-        }
-
+        Set<String> supportingFilesToGenerate = getPropertyAsSet(CodegenConstants.SUPPORTING_FILES);
         for (SupportingFile support : config.supportingFiles()) {
             try {
                 String outputFolder = config.outputFolder();

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -626,6 +626,11 @@ public class DefaultGenerator implements Generator {
         }
     }
 
+    /**
+     * this method splits the specified property by commas, trims any results for spaces and
+     * newlines, and returns them as a Set of Strings. the method will return an empty
+     * set if the specified property has not been set or is an empty string.
+     */
     private Set<String> getPropertyAsSet(String propertyName) {
         String propertyRaw = GlobalSettings.getProperty(propertyName);
         if (propertyRaw == null || propertyRaw.isEmpty()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -993,13 +993,13 @@ public class DefaultGeneratorTest {
             generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
             generator.setGeneratorPropertyDefault(CodegenConstants.API_TESTS, "false");
 
-            List<String> filesToGenerate = Arrays.asList(
+            List<String> supportingFilesToGenerate = Arrays.asList(
                 "pom.xml",
                 ".travis.yml",
                 ".gitignore",
                 "git_push.sh"
             );
-            GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, String.join(multiLineSeparator, filesToGenerate));
+            GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, String.join(multiLineSeparator, supportingFilesToGenerate));
 
             List<String> apisToGenerate = Arrays.asList(
                 "Pet",
@@ -1017,21 +1017,24 @@ public class DefaultGeneratorTest {
 
             List<File> files = generator.opts(clientOptInput).generate();
 
-            Assert.assertEquals(files.size(), 5 + modelsToGenerate.size() + apisToGenerate.size());
+            Assert.assertEquals(
+                files.size(),
+                // version file + files specified by properties
+                1 + supportingFilesToGenerate.size() + modelsToGenerate.size() + apisToGenerate.size()
+            );
 
-            TestUtils.ensureContainsFile(files, output, "pom.xml");
-            TestUtils.ensureContainsFile(files, output, ".travis.yml");
-            TestUtils.ensureContainsFile(files, output, ".gitignore");
-            TestUtils.ensureContainsFile(files, output, "git_push.sh");
             TestUtils.ensureContainsFile(files, output, ".openapi-generator/VERSION");
+            for(String supportingFile : supportingFilesToGenerate) {
+                TestUtils.ensureContainsFile(files, output, supportingFile);
+            }
 
             for(String apiFile : apisToGenerate) {
                 String filename = "src/main/java/org/openapitools/client/api/" + apiFile + "Api.java";
                 TestUtils.ensureContainsFile(files, output, filename);
             }
 
-            for(String apiFile : modelsToGenerate) {
-                String filename = "src/main/java/org/openapitools/client/model/" + apiFile + ".java";
+            for(String modelFile : modelsToGenerate) {
+                String filename = "src/main/java/org/openapitools/client/model/" + modelFile + ".java";
                 TestUtils.ensureContainsFile(files, output, filename);
             }
         } finally {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -809,11 +809,11 @@ public class DefaultGeneratorTest {
     public void testGenerateRecursiveDependentModelsBackwardCompatibilityIssue18444() throws IOException {
         Path target = Files.createTempDirectory("test");
         File output = target.toFile();
-        String oldModelsProp = GlobalSettings.getProperty("models");
+        String oldModelsProp = GlobalSettings.getProperty(CodegenConstants.MODELS);
 
         try {
             DefaultGenerator generator = generatorGenerateRecursiveDependentModelsBackwardCompatibility("false");
-            GlobalSettings.setProperty("models", "RQ1,RS1");
+            GlobalSettings.setProperty(CodegenConstants.MODELS, "RQ1,RS1");
             ClientOptInput clientOptInput = createOptInputIssue18444(target);
             List<File> files = generator.opts(clientOptInput).generate();
             Assert.assertEquals(files.size(), 17);
@@ -853,9 +853,9 @@ public class DefaultGeneratorTest {
         } finally {
             output.deleteOnExit();
             if (oldModelsProp != null) {
-                GlobalSettings.setProperty("models", oldModelsProp);
+                GlobalSettings.setProperty(CodegenConstants.MODELS, oldModelsProp);
             } else {
-                GlobalSettings.clearProperty("models");
+                GlobalSettings.clearProperty(CodegenConstants.MODELS);
             }
         }
     }
@@ -864,11 +864,11 @@ public class DefaultGeneratorTest {
     public void testGenerateRecursiveDependentModelsIssue18444() throws IOException {
         Path target = Files.createTempDirectory("test");
         File output = target.toFile();
-        String oldModelsProp = GlobalSettings.getProperty("models");
+        String oldModelsProp = GlobalSettings.getProperty(CodegenConstants.MODELS);
 
         try {
             DefaultGenerator generator = generatorGenerateRecursiveDependentModelsBackwardCompatibility("true");
-            GlobalSettings.setProperty("models", "RQ1,RS1");
+            GlobalSettings.setProperty(CodegenConstants.MODELS, "RQ1,RS1");
             ClientOptInput clientOptInput = createOptInputIssue18444(target);
             List<File> files = generator.opts(clientOptInput).generate();
             Assert.assertEquals(files.size(), 21);
@@ -908,9 +908,9 @@ public class DefaultGeneratorTest {
         } finally {
             output.deleteOnExit();
             if (oldModelsProp != null) {
-                GlobalSettings.setProperty("models", oldModelsProp);
+                GlobalSettings.setProperty(CodegenConstants.MODELS, oldModelsProp);
             } else {
-                GlobalSettings.clearProperty("models");
+                GlobalSettings.clearProperty(CodegenConstants.MODELS);
             }
         }
     }
@@ -919,11 +919,11 @@ public class DefaultGeneratorTest {
     public void testGenerateRecursiveDependentModelsIssue19220() throws IOException {
         Path target = Files.createTempDirectory("test");
         File output = target.toFile();
-        String oldModelsProp = GlobalSettings.getProperty("models");
+        String oldModelsProp = GlobalSettings.getProperty(CodegenConstants.MODELS);
 
         try {
             DefaultGenerator generator = generatorGenerateRecursiveDependentModelsBackwardCompatibility("true");
-            GlobalSettings.setProperty("models", "RQ1,RS1");
+            GlobalSettings.setProperty(CodegenConstants.MODELS, "RQ1,RS1");
             ClientOptInput clientOptInput = createOptInputIssue19220(target);
             List<File> files = generator.opts(clientOptInput).generate();
             Assert.assertEquals(files.size(), 21);
@@ -963,11 +963,81 @@ public class DefaultGeneratorTest {
         } finally {
             output.deleteOnExit();
             if (oldModelsProp != null) {
-                GlobalSettings.setProperty("models", oldModelsProp);
+                GlobalSettings.setProperty(CodegenConstants.MODELS, oldModelsProp);
             } else {
-                GlobalSettings.clearProperty("models");
+                GlobalSettings.clearProperty(CodegenConstants.MODELS);
             }
         }
     }
 
+    @Test
+    public void testGenerateMultiLinePropertiesIssue19628() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        File output = target.toFile();
+        String multiLineSeparator = ",\n    ";
+        try {
+            final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setInputSpec("src/test/resources/3_1/java/petstore.yaml")
+                .setOutputDir(target.toAbsolutePath().toString());
+
+            final ClientOptInput clientOptInput = configurator.toClientOptInput();
+            DefaultGenerator generator = new DefaultGenerator(true);
+
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+            generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "true");
+            generator.setGeneratorPropertyDefault(CodegenConstants.API_DOCS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+            generator.setGeneratorPropertyDefault(CodegenConstants.API_TESTS, "false");
+
+            List<String> filesToGenerate = Arrays.asList(
+                "pom.xml",
+                ".travis.yml",
+                ".gitignore",
+                "git_push.sh"
+            );
+            GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, String.join(multiLineSeparator, filesToGenerate));
+
+            List<String> apisToGenerate = Arrays.asList(
+                "Pet",
+                "User"
+            );
+            GlobalSettings.setProperty(CodegenConstants.APIS, String.join(multiLineSeparator, apisToGenerate));
+
+            List<String> modelsToGenerate = Arrays.asList(
+                "Category",
+                "Pet",
+                "Tag",
+                "User"
+            );
+            GlobalSettings.setProperty(CodegenConstants.MODELS, String.join(multiLineSeparator, modelsToGenerate));
+
+            List<File> files = generator.opts(clientOptInput).generate();
+
+            Assert.assertEquals(files.size(), 5 + modelsToGenerate.size() + apisToGenerate.size());
+
+            TestUtils.ensureContainsFile(files, output, "pom.xml");
+            TestUtils.ensureContainsFile(files, output, ".travis.yml");
+            TestUtils.ensureContainsFile(files, output, ".gitignore");
+            TestUtils.ensureContainsFile(files, output, "git_push.sh");
+            TestUtils.ensureContainsFile(files, output, ".openapi-generator/VERSION");
+
+            for(String apiFile : apisToGenerate) {
+                String filename = "src/main/java/org/openapitools/client/api/" + apiFile + "Api.java";
+                TestUtils.ensureContainsFile(files, output, filename);
+            }
+
+            for(String apiFile : modelsToGenerate) {
+                String filename = "src/main/java/org/openapitools/client/model/" + apiFile + ".java";
+                TestUtils.ensureContainsFile(files, output, filename);
+            }
+        } finally {
+            GlobalSettings.reset();
+            output.deleteOnExit();
+        }
+
+    }
 }


### PR DESCRIPTION
fix [Issue 19628](https://github.com/OpenAPITools/openapi-generator/issues/19628)

For consideration, this code change to `DefaultGenerator.java` allows API, MODELS, SUPPORTED_FILES & WEBHOOKS properties to include white space and newlines which are trimmed after splitting.  This allows users to specify longer lists of models using maven without having to worry about extra spaces or newlines.

I opted to change `DefaultGenerator` instead of modifying the `CodeGenMojo` in the maven plugin since MODELS or APIS can be specified in either in `modelsToGenerate` or in the `globalProperties`/`models` setting.  Doing so in DefaultGenerator allows for either method to span multi-lines.  See the maven plugin [README](https://github.com/OpenAPITools/openapi-generator/blob/3ef45f1b4d505c9479e40db87a59e9b8a458714b/modules/openapi-generator-maven-plugin/README.md?plain=1#L134) for an example of specifying MODELS via `globalProperties` or `modelsToGenerate`.

I've added a unit test in `DefaultGeneratorTest` that should cover all the properties except for `WEBHOOKS`.  If there are some modifications I can make to the unit test to support multiple `WEBHOOKS` in the OpenAPI spec, let me know and I can add them.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @wing328
