### PR TITLE
[Typescript Fetch] Fix missing closing bracket in date handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -291,7 +291,7 @@ export class {{classname}} extends runtime.BaseAPI {
         {{^isDateTimeType}}
         {{#isDateType}}
         if (requestParameters['{{paramName}}'] instanceof Date) {
-            urlPath = urlPath.replace(`{${"{{baseName}}"}}`, encodeURIComponent(requestParameters['{{paramName}}'].toISOString().substring(0,10));
+            urlPath = urlPath.replace(`{${"{{baseName}}"}}`, encodeURIComponent(requestParameters['{{paramName}}'].toISOString().substring(0,10)));
         } else {
             urlPath = urlPath.replace(`{${"{{baseName}}"}}`, encodeURIComponent(String(requestParameters['{{paramName}}'])));
         }


### PR DESCRIPTION
#19313 added handling date params for typescript-fetch. Unfortunately there is a missing closing bracket breaking builds. 

### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo (2019/11) @amakhrov @davidgamero @mkusaka @joscha

Sorry if I did this wrong ^ 😬

There should probably be tests for this. Can someone give me some pointers there?