### PR TITLE
Add Maven CLI usage to documentation

### DIFF
--- a/docs/generators/cli.md
+++ b/docs/generators/cli.md
@@ -1,0 +1,11 @@
+# Gradle users:
+./gradlew openapiGenerate \
+  -DgeneratorName=java \
+  -DinputSpec=path/to/your-api.yaml \
+  -DoutputDir=generated-code/java
+
+# Maven users:
+mvn openapi-generator:generate \
+  -DgeneratorName=java \
+  -DinputSpec=path/to/your-api.yaml \
+  -DoutputDir=generated-code/java

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -366,3 +366,12 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |XML|✓|OAS2,OAS3
 |PROTOBUF|✗|ToolingExtension
 |Custom|✗|OAS2,OAS3
+### Using the CLI with Maven
+
+You can also use the OpenAPI Generator from the command line with Maven:
+
+```bash
+mvn openapi-generator:generate \
+  -DgeneratorName=java \
+  -DinputSpec=path/to/your-api.yaml \
+  -DoutputDir=generated-code/java


### PR DESCRIPTION
Added instructions for using the OpenAPI Generator CLI with Maven to improve usability for Maven users.