### PR TITLE
Type check of array element only when array is not empty. fix #21276

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -81,7 +81,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     {{^isPrimitiveType}}
                     {{#isArray}}
                         List<?> list = (List<?>) value.getActualInstance();
-                        if (list.get(0) instanceof {{{items.dataType}}}) {
+                        if (!list.isEmpty() && list.get(0) instanceof {{{items.dataType}}}) {
                             JsonArray array = adapter{{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}}.toJsonTree(({{{dataType}}})value.getActualInstance()).getAsJsonArray();
                             elementAdapter.write(out, array);
                             return;
@@ -252,7 +252,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         if (instance instanceof {{#isArray}}List<?>{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}) {
         {{#isArray}}
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof {{{items.dataType}}}) {
+            if (!list.isEmpty() && list.get(0) instanceof {{{items.dataType}}}) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
@@ -94,7 +94,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     {{^isPrimitiveType}}
                     {{#isArray}}
                         List<?> list = (List<?>) value.getActualInstance();
-                        if (list.get(0) instanceof {{{items.dataType}}}) {
+                        if (!list.isEmpty() && list.get(0) instanceof {{{items.dataType}}}) {
                             JsonArray array = adapter{{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}}.toJsonTree(({{{dataType}}})value.getActualInstance()).getAsJsonArray();
                             elementAdapter.write(out, array);
                             return;
@@ -330,7 +330,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         if (instance instanceof {{#isArray}}List<?>{{/isArray}}{{#isMap}}Map<?, ?>{{/isMap}}{{^isMap}}{{^isArray}}{{{dataType}}}{{/isArray}}{{/isMap}}) {
         {{#isArray}}
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof {{{items.dataType}}}) {
+            if (!list.isEmpty() && list.get(0) instanceof {{{items.dataType}}}) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/anyof_class.mustache
@@ -110,7 +110,7 @@ import java.io.IOException
                     if (value.actualInstance is {{#isArray}}List<*>{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}) {
                     {{#isArray}}
                         val list = value.actualInstance as List<Any>
-                        if (list.get(0) is {{{items.dataType}}}) {
+                        if (!list.isEmpty() && list.get(0) is {{{items.dataType}}}) {
                             val array = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonArray()
                             elementAdapter.write(out, array)
                             return

--- a/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/oneof_class.mustache
@@ -110,7 +110,7 @@ import java.io.IOException
                     if (value.actualInstance is {{#isArray}}List<*>{{/isArray}}{{^isArray}}{{{dataType}}}{{/isArray}}) {
                     {{#isArray}}
                         val list = value.actualInstance as List<Any>
-                        if (list.get(0) is {{{items.dataType}}}) {
+                        if (!list.isEmpty() && list.get(0) is {{{items.dataType}}}) {
                             val array = adapter{{#sanitizeGeneric}}{{{dataType}}}{{/sanitizeGeneric}}.toJsonTree(value.actualInstance as {{{dataType}}}?).getAsJsonArray()
                             elementAdapter.write(out, array)
                             return

--- a/samples/client/others/java/okhttp-gson-oneOf-array/src/main/java/org/openapitools/client/model/MyExampleGet200Response.java
+++ b/samples/client/others/java/okhttp-gson-oneOf-array/src/main/java/org/openapitools/client/model/MyExampleGet200Response.java
@@ -89,7 +89,7 @@ public class MyExampleGet200Response extends AbstractOpenApiSchema {
                     // check if the actual instance is of the type `List<@Valid OneOf1>`
                     if (value.getActualInstance() instanceof List<?>) {
                         List<?> list = (List<?>) value.getActualInstance();
-                        if (list.get(0) instanceof OneOf1) {
+                        if (!list.isEmpty() && list.get(0) instanceof OneOf1) {
                             JsonArray array = adapterListOneOf1.toJsonTree((List<@Valid OneOf1>)value.getActualInstance()).getAsJsonArray();
                             elementAdapter.write(out, array);
                             return;
@@ -191,7 +191,7 @@ public class MyExampleGet200Response extends AbstractOpenApiSchema {
     public void setActualInstance(Object instance) {
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof OneOf1) {
+            if (!list.isEmpty() && list.get(0) instanceof OneOf1) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/RefToRefParameterAnyofRefToAnyofParameter.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/RefToRefParameterAnyofRefToAnyofParameter.java
@@ -187,7 +187,7 @@ public class RefToRefParameterAnyofRefToAnyofParameter extends AbstractOpenApiSc
 
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof String) {
+            if (!list.isEmpty() && list.get(0) instanceof String) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayAnyOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayAnyOf.java
@@ -182,7 +182,7 @@ public class ArrayAnyOf extends AbstractOpenApiSchema {
 
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof String) {
+            if (!list.isEmpty() && list.get(0) instanceof String) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOneOf.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/ArrayOneOf.java
@@ -187,7 +187,7 @@ public class ArrayOneOf extends AbstractOpenApiSchema {
 
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof String) {
+            if (!list.isEmpty() && list.get(0) instanceof String) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeAnyOfWIthSameErasureGet200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeAnyOfWIthSameErasureGet200Response.java
@@ -157,7 +157,7 @@ public class FakeAnyOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
     public void setActualInstance(Object instance) {
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof String) {
+            if (!list.isEmpty() && list.get(0) instanceof String) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeOneOfWIthSameErasureGet200Response.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/FakeOneOfWIthSameErasureGet200Response.java
@@ -163,7 +163,7 @@ public class FakeOneOfWIthSameErasureGet200Response extends AbstractOpenApiSchem
     public void setActualInstance(Object instance) {
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof String) {
+            if (!list.isEmpty() && list.get(0) instanceof String) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Value.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/model/Value.java
@@ -86,7 +86,7 @@ public class Value extends AbstractOpenApiSchema {
                     // check if the actual instance is of the type `List<Scalar>`
                     if (value.getActualInstance() instanceof List<?>) {
                         List<?> list = (List<?>) value.getActualInstance();
-                        if (list.get(0) instanceof Scalar) {
+                        if (!list.isEmpty() && list.get(0) instanceof Scalar) {
                             JsonArray array = adapterListScalar.toJsonTree((List<Scalar>)value.getActualInstance()).getAsJsonArray();
                             elementAdapter.write(out, array);
                             return;
@@ -187,7 +187,7 @@ public class Value extends AbstractOpenApiSchema {
 
         if (instance instanceof List<?>) {
             List<?> list = (List<?>) instance;
-            if (list.get(0) instanceof Scalar) {
+            if (!list.isEmpty() && list.get(0) instanceof Scalar) {
                 super.setActualInstance(instance);
                 return;
             }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiAnyOfUserOrPetOrArrayString.kt
@@ -74,7 +74,7 @@ data class ApiAnyOfUserOrPetOrArrayString(var actualInstance: Any? = null) {
                     // check if the actual instance is of the type `kotlin.collections.List<kotlin.String>`
                     if (value.actualInstance is List<*>) {
                         val list = value.actualInstance as List<Any>
-                        if (list.get(0) is kotlin.String) {
+                        if (!list.isEmpty() && list.get(0) is kotlin.String) {
                             val array = adapterkotlincollectionsListkotlinString.toJsonTree(value.actualInstance as kotlin.collections.List<kotlin.String>?).getAsJsonArray()
                             elementAdapter.write(out, array)
                             return

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPetOrArrayString.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiUserOrPetOrArrayString.kt
@@ -74,7 +74,7 @@ data class ApiUserOrPetOrArrayString(var actualInstance: Any? = null) {
                     // check if the actual instance is of the type `kotlin.collections.List<kotlin.String>`
                     if (value.actualInstance is List<*>) {
                         val list = value.actualInstance as List<Any>
-                        if (list.get(0) is kotlin.String) {
+                        if (!list.isEmpty() && list.get(0) is kotlin.String) {
                             val array = adapterkotlincollectionsListkotlinString.toJsonTree(value.actualInstance as kotlin.collections.List<kotlin.String>?).getAsJsonArray()
                             elementAdapter.write(out, array)
                             return


### PR DESCRIPTION
Not checking type of the first element of list when list is empty. Such a check would only produce IndexOutOfBoundsException.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
