### PR TITLE
Add Maven CLI usage example to Java generator documentation

### DIFF
--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -368,3 +368,10 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |XML|✓|OAS2,OAS3
 |PROTOBUF|✗|ToolingExtension
 |Custom|✗|OAS2,OAS3
+
+## 🔧 Example: Using Maven CLI to view generator version
+
+To check which version of the OpenAPI Generator Maven plugin is configured in your project, use:
+
+```bash
+mvn openapi-generator:version


### PR DESCRIPTION
This PR improves the documentation for the Java generator by adding an example that shows how to check the plugin version using the Maven CLI. This addition helps users quickly verify which version of the OpenAPI Generator is configured in their project.

Let me know if any changes are needed — happy to update.

TY