### PR TITLE
[Java-Spring] add comment to EnumConverterConfiguration mustache file

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
@@ -12,6 +12,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "{{configPackage}}.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -6,6 +6,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -6,6 +6,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,6 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
+/**
+ * This class provides Spring Converter beans for the enum models in the OpenAPI specification.
+ *
+ * By default, Spring only converts primitive types to enums using Enum::valueOf, which can prevent
+ * correct conversion if the OpenAPI specification is using an `enumPropertyNaming` other than
+ * `original` or the specification has an integer enum.
+ */
 @Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 


### PR DESCRIPTION
This PR updates the mustache file used to create the EnumConverterConfiguration class for the Java Spring server generator, which is used when an OpenAPI spec contains an enum class.

The PR is a follow-up from code review feedback on [a similar PR](https://github.com/OpenAPITools/openapi-generator/pull/21579#discussion_r2217756798) in the Kotlin Spring server generator.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Java Spring: @cachescrubber (2022/02) @welshm (2022/02) @MelleD (2022/02) @atextor (2022/02) @manedev79 (2022/02) @javisst (2022/02) @borsch (2022/02) @banlevente (2022/02) @Zomzog (2022/09) @martin-mfg (2023/08)
Code review feedback: @wing328 