### PR TITLE
[Scala sttp] Fix header serialization for Optional values

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp/paramCreation.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/paramCreation.mustache
@@ -1,1 +1,1 @@
-"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}.toString
+"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}{{#required}}.toString{{/required}}{{^required}}.map(_.toString()).getOrElse(null){{/required}}

--- a/modules/openapi-generator/src/main/resources/scala-sttp/paramCreation.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/paramCreation.mustache
@@ -1,1 +1,1 @@
-"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}{{#required}}.toString{{/required}}{{^required}}.map(_.toString()).getOrElse(null){{/required}}
+"{{baseName}}", {{#isContainer}}ArrayValues({{{paramName}}}{{#collectionFormat}}, {{collectionFormat.toUpperCase}}{{/collectionFormat}}){{/isContainer}}{{^isContainer}}{{{paramName}}}{{/isContainer}}{{#required}}.toString{{/required}}{{^required}}.map(_.toString()){{/required}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
@@ -139,11 +139,11 @@ public class SttpCodegenTest {
         Path path = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/api/DefaultApi.scala");
         assertFileContains(path, ".method(Method.GET, uri\"$baseUrl/ping\")\n");
         assertFileContains(path, "xOptionalHeader: Option[String] = None");
-        assertFileContains(path, ".header(\"X-Optional-Header\", xOptionalHeader.map(_.toString()).getOrElse(null))");
+        assertFileContains(path, ".header(\"X-Optional-Header\", xOptionalHeader.map(_.toString()))");
         assertFileContains(path, "xRequiredHeader: String");
         assertFileContains(path, ".header(\"X-Required-Header\", xRequiredHeader.toString)");
         assertFileContains(path, "xOptionalSchemaHeader: Option[UUID] = None");
-        assertFileContains(path, ".header(\"X-Optional-Schema-Header\", xOptionalSchemaHeader.map(_.toString()).getOrElse(null))");
+        assertFileContains(path, ".header(\"X-Optional-Schema-Header\", xOptionalSchemaHeader.map(_.toString()))");
         assertFileContains(path, "xRequiredSchemaHeader: UUID");
         assertFileContains(path, ".header(\"X-Required-Schema-Header\", xRequiredSchemaHeader.toString)");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
@@ -110,4 +110,38 @@ public class SttpCodegenTest {
         assertFileContains(path, ".cookie(\"apikey\", apiKeyCookie)");
     }
 
+    @Test
+    public void headerSerialization() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        String outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/bugs/issue_21602.yaml", null, new ParseOptions()).getOpenAPI();
+
+        ScalaSttpClientCodegen codegen = new ScalaSttpClientCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true");
+
+        ClientOptInput input = new ClientOptInput();
+        input.openAPI(openAPI);
+        input.config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.opts(input).generate();
+
+        Path path = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/api/DefaultApi.scala");
+        assertFileContains(path, ".method(Method.GET, uri\"$baseUrl/ping\")\n");
+        assertFileContains(path, ".header(\"X-Optional-Header\", xOptionalHeader.map(_.toString()).getOrElse(null))");
+        assertFileContains(path, ".header(\"X-Required-Header\", xRequiredHeader.toString)");
+        assertFileContains(path, ".header(\"X-Optional-Schema-Header\", xOptionalSchemaHeader.map(_.toString()).getOrElse(null))");
+        assertFileContains(path, ".header(\"X-Required-Schema-Header\", xRequiredSchemaHeader.toString)");
+    }
+
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/scala/SttpCodegenTest.java
@@ -138,9 +138,13 @@ public class SttpCodegenTest {
 
         Path path = Paths.get(outputPath + "/src/main/scala/org/openapitools/client/api/DefaultApi.scala");
         assertFileContains(path, ".method(Method.GET, uri\"$baseUrl/ping\")\n");
+        assertFileContains(path, "xOptionalHeader: Option[String] = None");
         assertFileContains(path, ".header(\"X-Optional-Header\", xOptionalHeader.map(_.toString()).getOrElse(null))");
+        assertFileContains(path, "xRequiredHeader: String");
         assertFileContains(path, ".header(\"X-Required-Header\", xRequiredHeader.toString)");
+        assertFileContains(path, "xOptionalSchemaHeader: Option[UUID] = None");
         assertFileContains(path, ".header(\"X-Optional-Schema-Header\", xOptionalSchemaHeader.map(_.toString()).getOrElse(null))");
+        assertFileContains(path, "xRequiredSchemaHeader: UUID");
         assertFileContains(path, ".header(\"X-Required-Schema-Header\", xRequiredSchemaHeader.toString)");
     }
 

--- a/modules/openapi-generator/src/test/resources/bugs/issue_21602.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_21602.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.0"
+info:
+  title: Optional Header Test
+  version: 1.0.0
+paths:
+  /ping:
+    get:
+      summary: Ping with optional header
+      operationId: getPing
+      parameters:
+        - name: X-Optional-Header
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: X-Required-Header
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: X-Optional-Schema-Header
+          in: header
+          required: false
+          schema:
+            $ref: '#/components/schemas/UUID'
+        - name: X-Required-Schema-Header
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/UUID'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: string
+components:
+  schemas:
+    UUID:
+      type: object
+      properties:
+        uuid:
+          type: string

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -55,7 +55,7 @@ class PetApi(baseUrl: String) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
-      .header("api_key", apiKey.toString)
+      .header("api_key", apiKey.map(_.toString()).getOrElse(null))
       .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**

--- a/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp-circe/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -55,7 +55,7 @@ class PetApi(baseUrl: String) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
-      .header("api_key", apiKey.map(_.toString()).getOrElse(null))
+      .header("api_key", apiKey.map(_.toString()))
       .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -55,7 +55,7 @@ class PetApi(baseUrl: String) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
-      .header("api_key", apiKey.toString)
+      .header("api_key", apiKey.map(_.toString()).getOrElse(null))
       .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -55,7 +55,7 @@ class PetApi(baseUrl: String) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
-      .header("api_key", apiKey.map(_.toString()).getOrElse(null))
+      .header("api_key", apiKey.map(_.toString()))
       .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fixes #21602

Marked as a draft while attempting to find a proper solution for how to handle required header parameters that are complex (i.e., the header contains a `ref` rather than a `string`).

```
paths:
  /ping:
    get:
      summary: Ping with required header
      operationId: getPing
      parameters:
        - name: X-Required-Schema-Header
          in: header
          required: true
          schema:
            $ref: '#/components/schemas/UUID'
components:
  schemas:
    UUID:
      type: object
      properties:
        uuid:
          type: string
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
