### PR TITLE
[gradle-plugin] add treatWarningsAsErrors option to openApiValidate in gradle plugin

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/OpenApiGeneratorPlugin.kt
@@ -85,6 +85,7 @@ class OpenApiGeneratorPlugin : Plugin<Project> {
 
                     inputSpec.set(validate.inputSpec)
                     recommend.set(validate.recommend)
+                    treatWarningsAsErrors.set(validate.treatWarningsAsErrors)
                 }
 
                 register("openApiGenerate", GenerateTask::class.java).configure {

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorValidateExtension.kt
@@ -34,4 +34,9 @@ open class OpenApiGeneratorValidateExtension(project: Project) {
      * Whether to offer recommendations related to the validated specification document.
      */
     val recommend = project.objects.property<Boolean>().convention(true)
+
+    /**
+     * Whether to treat warnings as errors and fail the task.
+     */
+    val treatWarningsAsErrors = project.objects.property<Boolean>().convention(false)
 }


### PR DESCRIPTION
This PR adds a new treatWarningsAsErrors setting to the validation task.
If set to true, the task will fail when warnings are found—helpful for keeping specs clean and catching issues early.

By default, it's off to keep things backward-compatible :)