### PR TITLE
fix: Use correct constructor for ApiException in PSR-18 PHP library

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -301,9 +301,8 @@ use function sprintf;
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -806,9 +805,9 @@ use function sprintf;
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -65,7 +65,6 @@ use function sprintf;
     /**
      * @var PluginClient
      */
-                    (string) $response->getBody()
     protected $httpAsyncClient;
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -65,6 +65,7 @@ use function sprintf;
     /**
      * @var PluginClient
      */
+                    (string) $response->getBody()
     protected $httpAsyncClient;
 
     /**
@@ -805,7 +806,7 @@ use function sprintf;
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-			request,
+			$request,
                         $response,
                         $exception
                     );

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -251,9 +251,8 @@ class AnotherFakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -514,9 +513,9 @@ class AnotherFakeApi
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -245,9 +245,8 @@ class DefaultApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -489,9 +488,9 @@ class DefaultApi
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -245,9 +245,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -486,9 +485,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -785,9 +783,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1256,9 +1253,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1498,9 +1494,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1740,9 +1735,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1982,9 +1976,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2224,9 +2217,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2489,9 +2481,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2763,9 +2754,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -3025,9 +3015,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -3296,9 +3285,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -3562,9 +3550,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -4933,9 +4920,8 @@ class FakeApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -7349,9 +7335,9 @@ class FakeApi
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -251,9 +251,8 @@ class FakeClassnameTags123Api
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -519,9 +518,9 @@ class FakeClassnameTags123Api
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -717,9 +717,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -978,9 +977,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1240,9 +1238,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1984,9 +1981,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2266,9 +2262,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2566,9 +2561,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2883,9 +2877,8 @@ class PetApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -3164,9 +3157,9 @@ class PetApi
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -460,9 +460,8 @@ class StoreApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -706,9 +705,8 @@ class StoreApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -971,9 +969,8 @@ class StoreApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1234,9 +1231,9 @@ class StoreApi
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -1089,9 +1089,8 @@ class UserApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -1349,9 +1348,8 @@ class UserApi
                         $statusCode,
                         (string) $request->getUri()
                     ),
-                    $statusCode,
-                    $response->getHeaders(),
-                    (string) $response->getBody()
+                    $request,
+                    $response
                 );
             }
 
@@ -2057,9 +2055,9 @@ class UserApi
                             'Error JSON decoding server response (%s)',
                             $request->getUri()
                         ),
-                        $response->getStatusCode(),
-                        $response->getHeaders(),
-                        $content
+			request,
+                        $response,
+                        $exception
                     );
                 }
             }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The PSR-18 version of the `api.mustache` template uses the wrong constructor for `ApiException` in two places. It uses the constructor of the normal PHP generated (non-PSR18).


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Mentions:
- @jebentier
- @dkarlovi 
- @mandrean
-  @jfastnacht 
- @ybelenko 
- @renepardon
