### PR TITLE
Bugfix for remote specs with params

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskDslTest.kt
@@ -34,6 +34,7 @@ class GenerateTaskDslTest : TestBase() {
     @Test
     fun `openApiGenerate should create an expected file structure from URL config`() {
         val specUrl = "https://raw.githubusercontent.com/OpenAPITools/openapi-generator/b6b8c0db872fb4a418ae496e89c7e656e14be165/modules/openapi-generator-gradle-plugin/src/test/resources/specs/petstore-v3.0.yaml"
+        val urlParams ="?meaningless=params&amp;so=it&amp;results=in&amp;illegal=filenames&amp;on=windows"
         // Arrange
         val buildContents = """
          plugins {
@@ -41,7 +42,7 @@ class GenerateTaskDslTest : TestBase() {
         }
         openApiGenerate {
             generatorName = "kotlin"
-            remoteInputSpec = "$specUrl"
+            remoteInputSpec = "$specUrl$urlParams"
             outputDir = file("build/kotlin").absolutePath
             apiPackage = "org.openapitools.example.api"
             invokerPackage = "org.openapitools.example.invoker"

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -1066,7 +1066,7 @@ public class CodeGenMojo extends AbstractMojo {
         String name = inputSpecFile.getName();
 
         URL url = inputSpecRemoteUrl();
-        if (inputSpecFile.exists() && url != null) {
+        if (url != null) {
             String[] segments = url.getPath().split("/");
             name = Files.getNameWithoutExtension(segments[segments.length - 1]);
         }

--- a/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
+++ b/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
@@ -68,6 +68,10 @@ public class CodeGenMojoTest extends BaseTestCase {
         testCommonConfiguration("jar");
     }
 
+    public void testCommonConfigurationWithRemoteInputSpec() throws Exception {
+        testCommonConfiguration("remote");
+    }
+
     @SuppressWarnings("unchecked")
     private void testCommonConfiguration(String profile) throws Exception {
         CodeGenMojo mojo = loadMojo(newTempFolder(), "src/test/resources/default", profile);

--- a/modules/openapi-generator-maven-plugin/src/test/resources/default/pom.xml
+++ b/modules/openapi-generator-maven-plugin/src/test/resources/default/pom.xml
@@ -55,6 +55,12 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>remote</id>
+            <properties>
+                <inputSpec>https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml?meaningless=params&amp;so=it&amp;results=in&amp;illegal=filenames&amp;on=windows</inputSpec>
+            </properties>
+        </profile>
     </profiles>
     <build>
         <finalName>common-maven</finalName>


### PR DESCRIPTION
Fixes #19724 
[BUG] openapi-generator-maven-plugin 7.7.0 or 7.8.0 on Windows

The issue was originally introduced in PR #18576
### The Issue
Due to the changed If statement in [CodeGenMojo.java](https://github.com/OpenAPITools/openapi-generator/compare/master...Hobbesgoblin:openapi-generator:bugfix-for-remote-specs-with-params?expand=1#diff-233dcd5306a0a0c4760a7b5bd4b2e58ef35d90b2cb370f1bb8ce1c6b0c723687) the code in the block would never be entered for remote URLs, resulting in any parameters being part of the hashFileName.
The result of this was that the special characters would make the code generation fail on Windows (as the hashfile would never be saved, resulting in a `FileNotFoundException`) as well as leaking potentially sensitve inrformation, like parameter submitted access tokens, in the log (via the thrown expcetion on the filename in windows) or the filename of the hashfile on systems where the filename was still legal.

### My changes
I reverted the condition to its previous state. This fixes the issue without breaking the loading of specs from jar files, for which it was added in the first place.

I added new or changed existing tests for this testcase with against a file in the repo, with some useless parameters, as currently github seems to ignore paramters for raw.githubusercontent.com URLs.

The change in the Gradle Plugin test is just for completeness.
The issue does not appear in the gradle plugin.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
