### PR TITLE
[csharp] Handle nested maps recursively

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -751,33 +751,6 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
     protected void patchPropertyIsInherited(CodegenModel model, CodegenProperty property) {
     }
 
-    protected void patchProperty(Map<String, CodegenModel> enumRefs, CodegenModel model, CodegenProperty property) {
-        if (enumRefs.containsKey(property.dataType)) {
-            // Handle any enum properties referred to by $ref.
-            // This is different in C# than most other generators, because enums in C# are compiled to integral types,
-            // while enums in many other languages are true objects.
-            CodegenModel refModel = enumRefs.get(property.dataType);
-            property.allowableValues = refModel.allowableValues;
-            property.isEnum = true;
-
-            // We do these after updateCodegenPropertyEnum to avoid generalities that don't mesh with C#.
-            property.isPrimitiveType = true;
-        }
-
-        this.patchPropertyIsInherited(model, property);
-
-        patchPropertyVendorExtensions(property);
-
-        property.name = patchPropertyName(model, property.name, null);
-
-        patchNestedMaps(property);
-
-        // HOTFIX: https://github.com/OpenAPITools/openapi-generator/issues/14944
-        if (property.datatypeWithEnum.equals("decimal")) {
-            property.isDecimal = true;
-        }
-    }
-
     private void patchNestedMaps(CodegenProperty property) {
         // Process nested types before making any replacements to ensure we have the correct inner type
         if (property.items != null) {
@@ -806,6 +779,33 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen {
             if (!originalType.equals(property.datatypeWithEnum)) {
                 property.dataType = property.datatypeWithEnum;
             }
+        }
+    }
+
+    protected void patchProperty(Map<String, CodegenModel> enumRefs, CodegenModel model, CodegenProperty property) {
+        if (enumRefs.containsKey(property.dataType)) {
+            // Handle any enum properties referred to by $ref.
+            // This is different in C# than most other generators, because enums in C# are compiled to integral types,
+            // while enums in many other languages are true objects.
+            CodegenModel refModel = enumRefs.get(property.dataType);
+            property.allowableValues = refModel.allowableValues;
+            property.isEnum = true;
+
+            // We do these after updateCodegenPropertyEnum to avoid generalities that don't mesh with C#.
+            property.isPrimitiveType = true;
+        }
+
+        this.patchPropertyIsInherited(model, property);
+
+        patchPropertyVendorExtensions(property);
+
+        property.name = patchPropertyName(model, property.name, null);
+
+        patchNestedMaps(property);
+
+        // HOTFIX: https://github.com/OpenAPITools/openapi-generator/issues/14944
+        if (property.datatypeWithEnum.equals("decimal")) {
+            property.isDecimal = true;
         }
     }
 


### PR DESCRIPTION
Converts existing code into recursive code to better handle nested maps. First of a few PRs to fix issues pointed out by https://github.com/OpenAPITools/openapi-generator/issues/21585 I don't think sample changes are necessary since its only making existing code recursive.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
