### PR TITLE
[Bug][typescript-fetch] Fix missing close parenthesis in oneOf models.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -87,37 +87,37 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         if (json.every(item => typeof item === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
             return json;
         }
-     }
+    }
     {{/isNumeric}}
     {{#isString}}
     if (Array.isArray(json)) {
         if (json.every(item => typeof item === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
             return json;
         }
-     }
+    }
     {{/isString}}
     {{/items}}
     {{/isArray}}
     {{^isArray}}
     {{#isDateType}}
-    if(!(isNaN(new Date(json).getTime()))) {
+    if (!(isNaN(new Date(json).getTime()))) {
         return {{^required}}json == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json == null ? null : {{/isNullable}}{{/required}}new Date(json));
     }
     {{/isDateType}}
     {{^isDateType}}
     {{#isDateTimeType}}
-    if(!(isNaN(new Date(json).getTime()))) {
+    if (!(isNaN(new Date(json).getTime()))) {
         return {{^required}}json == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json == null ? null : {{/isNullable}}{{/required}}new Date(json));
     }
     {{/isDateTimeType}}
     {{/isDateType}}
     {{#isNumeric}}
-    if(typeof json === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}json === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+    if (typeof json === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}json === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
         return json;
     }
     {{/isNumeric}}
     {{#isString}}
-    if(typeof json === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}json === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+    if (typeof json === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}json === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
         return json;
     }
     {{/isString}}
@@ -189,14 +189,14 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     {{/isDateTimeType}}
     {{#isNumeric}}
     if (Array.isArray(value)) {
-        if (value.every(item => typeof item === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+        if (value.every(item => typeof item === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
             return value;
         }
     }
     {{/isNumeric}}
     {{#isString}}
     if (Array.isArray(value)) {
-        if (value.every(item => typeof item === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+        if (value.every(item => typeof item === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
             return value;
         }
     }
@@ -205,22 +205,22 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     {{/isArray}}
     {{^isArray}}
     {{#isDateType}}
-    if(value instanceof Date) {
+    if (value instanceof Date) {
         return ((value{{#isNullable}} as any{{/isNullable}}){{^required}}{{#isNullable}}?{{/isNullable}}{{/required}}.toISOString().substring(0,10));
-     }
+    }
     {{/isDateType}}
     {{#isDateTimeType}}
-    if(value instanceof Date) {
+    if (value instanceof Date) {
         return {{^required}}{{#isNullable}}value === null ? null : {{/isNullable}}{{^isNullable}}value == null ? undefined : {{/isNullable}}{{/required}}((value{{#isNullable}} as any{{/isNullable}}){{^required}}{{#isNullable}}?{{/isNullable}}{{/required}}.toISOString());
     }
     {{/isDateTimeType}}
     {{#isNumeric}}
-    if(typeof value === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+    if (typeof value === 'number'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
         return value;
     }
     {{/isNumeric}}
     {{#isString}}
-    if(typeof value === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+    if (typeof value === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
         return value;
     }
     {{/isString}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -356,19 +356,21 @@ public class TypeScriptFetchClientCodegenTest {
 
         Path exampleModelPath = Paths.get(outputPath + "/models/MyCustomSpeed.ts");
         //FromJSON
-        TestUtils.assertFileContains(exampleModelPath, "typeof json === 'number'");
-        TestUtils.assertFileContains(exampleModelPath, "typeof json === 'string'");
-        TestUtils.assertFileContains(exampleModelPath, "json === 'fixed-value-a' || json === 'fixed-value-b' || json === 'fixed-value-c'");
-        TestUtils.assertFileContains(exampleModelPath, "isNaN(new Date(json).getTime())");
-        TestUtils.assertFileContains(exampleModelPath, "json.every(item => typeof item === 'number'");
-        TestUtils.assertFileContains(exampleModelPath, "json.every(item => typeof item === 'string' && (item === 'oneof-array-enum-a' || item === 'oneof-array-enum-b' || item === 'oneof-array-enum-c')");
+        TestUtils.assertFileContains(exampleModelPath, "(typeof json !== 'object')");
+        TestUtils.assertFileContains(exampleModelPath, "(instanceOfMyNumericValue(json))");
+        TestUtils.assertFileContains(exampleModelPath, "(typeof json === 'number' && (json === 10 || json === 20 || json === 30))");
+        TestUtils.assertFileContains(exampleModelPath, "(typeof json === 'string' && (json === 'fixed-value-a' || json === 'fixed-value-b' || json === 'fixed-value-c'))");
+        TestUtils.assertFileContains(exampleModelPath, "(isNaN(new Date(json).getTime())");
+        TestUtils.assertFileContains(exampleModelPath, "(json.every(item => typeof item === 'number'))");
+        TestUtils.assertFileContains(exampleModelPath, "(json.every(item => typeof item === 'string' && (item === 'oneof-array-enum-a' || item === 'oneof-array-enum-b' || item === 'oneof-array-enum-c')))");
         //ToJSON
-        TestUtils.assertFileContains(exampleModelPath, "typeof value === 'number'");
-        TestUtils.assertFileContains(exampleModelPath, "typeof value === 'string'");
-        TestUtils.assertFileContains(exampleModelPath, "value === 'fixed-value-a' || value === 'fixed-value-b' || value === 'fixed-value-c'");
-        TestUtils.assertFileContains(exampleModelPath, "value instanceof Date");
-        TestUtils.assertFileContains(exampleModelPath, "value.every(item => typeof item === 'number'");
-        TestUtils.assertFileContains(exampleModelPath, "value.every(item => typeof item === 'string' && (item === 'oneof-array-enum-a' || item === 'oneof-array-enum-b' || item === 'oneof-array-enum-c')");
+        TestUtils.assertFileContains(exampleModelPath, "(typeof value !== 'object')");
+        TestUtils.assertFileContains(exampleModelPath, "(instanceOfMyNumericValue(value))");
+        TestUtils.assertFileContains(exampleModelPath, "(typeof value === 'number' && (value === 10 || value === 20 || value === 30))");
+        TestUtils.assertFileContains(exampleModelPath, "(typeof value === 'string' && (value === 'fixed-value-a' || value === 'fixed-value-b' || value === 'fixed-value-c'))");
+        TestUtils.assertFileContains(exampleModelPath, "(value instanceof Date)");
+        TestUtils.assertFileContains(exampleModelPath, "(value.every(item => typeof item === 'number'))");
+        TestUtils.assertFileContains(exampleModelPath, "(value.every(item => typeof item === 'string' && (item === 'oneof-array-enum-a' || item === 'oneof-array-enum-b' || item === 'oneof-array-enum-c')))");
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchModelTest.java
@@ -47,7 +47,7 @@ import static io.swagger.codegen.utils.ModelUtils.updateCodegenPropertyEnum;
 @SuppressWarnings("static-method")
 public class TypeScriptFetchModelTest {
 
-    @Test(description = "convert a simple TypeScript Angular model")
+    @Test(description = "convert a simple TypeScript Fetch model")
     public void simpleModelTest() {
         final Schema model = new Schema()
                 .description("a sample model")

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestArrayResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestArrayResponse.ts
@@ -57,7 +57,7 @@ export function TestArrayResponseFromJSONTyped(json: any, ignoreDiscriminator: b
         if (json.every(item => typeof item === 'string')) {
             return json;
         }
-     }
+    }
     return {} as any;
 }
 
@@ -81,7 +81,7 @@ export function TestArrayResponseToJSONTyped(value?: TestArrayResponse | null, i
         return value;
     }
     if (Array.isArray(value)) {
-        if (value.every(item => typeof item === 'string') {
+        if (value.every(item => typeof item === 'string')) {
             return value;
         }
     }

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestResponse.ts
@@ -51,7 +51,7 @@ export function TestResponseFromJSONTyped(json: any, ignoreDiscriminator: boolea
     if (instanceOfTestB(json)) {
         return TestBFromJSONTyped(json, true);
     }
-    if(typeof json === 'string') {
+    if (typeof json === 'string') {
         return json;
     }
     return {} as any;
@@ -74,7 +74,7 @@ export function TestResponseToJSONTyped(value?: TestResponse | null, ignoreDiscr
     if (instanceOfTestB(value)) {
         return TestBToJSON(value as TestB);
     }
-    if(typeof value === 'string') {
+    if (typeof value === 'string') {
         return value;
     }
     return {};


### PR DESCRIPTION
Fixes #21639 

PR https://github.com/OpenAPITools/openapi-generator/pull/21464 provided some changes to add serialization & deserialization logic for primitive and enum types used by the ToJSONTypes & FromJSONTyped methods of 'oneOf' models.

There are a couple of cases where the if-statements used in the ToJSONTyped methods generated by the template are missing closing parentheses, such as when serializing an Array<number>, Array<string>.

This PR fixes these cases and modifies the unit test for Issue 21295 to check for the correct number of closing parenthesis. 

Just as a side note, having the unit test check for string literals is probably not a great long term strategy as the approach is brittle; changes in formatting which are technically correct can break these tests.  It would probably be better to have a tool like [assertj](https://joel-costigliola.github.io/assertj/) (which is used for the Java generation tests) or to use some sort of typescript linting tools to check the output of each test. I took a look at using typescript-eslint, but it seems that that tooling is dependent on running with npm. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Typescript: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
PR #21464 - @DavidGrath