### PR TITLE
[BUG][CSHARP] Support equatable on generichost

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/ImplementsIEquatable.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/ImplementsIEquatable.mustache
@@ -1,1 +1,1 @@
-{{#equatable}}{{#readOnlyVars}}{{#-first}}IEquatable<{{classname}}{{nrt?}}>  {{/-first}}{{/readOnlyVars}}{{/equatable}}
+{{#equatable}}IEquatable<{{classname}}{{nrt?}}>  {{/equatable}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -311,7 +311,7 @@
             if (input == null)
                 return false;
 
-            return {{#parent}}base.Equals(input) && {{/parent}}{{#readOnlyVars}}{{^isInherited}}{{^isContainer}}
+            return {{#parent}}base.Equals(input) && {{/parent}}{{#allVars}}{{^isInherited}}{{^isContainer}}
                 (
                     {{name}} == input.{{name}} ||
                     {{^vendorExtensions.x-is-value-type}}
@@ -327,7 +327,7 @@
                     {{^vendorExtensions.x-is-value-type}}{{name}} != null &&
                     input.{{name}} != null &&
                     {{/vendorExtensions.x-is-value-type}}{{name}}.SequenceEqual(input.{{name}})
-                ){{^-last}} && {{/-last}}{{/isContainer}}{{/isInherited}}{{/readOnlyVars}}{{^readOnlyVars}}{{#parent}}base.Equals(input){{/parent}}{{^parent}}false{{/parent}}{{/readOnlyVars}}{{^isAdditionalPropertiesTrue}};{{/isAdditionalPropertiesTrue}}
+                ){{^-last}} && {{/-last}}{{/isContainer}}{{/isInherited}}{{/allVars}}{{^allVars}}{{#parent}}base.Equals(input){{/parent}}{{^parent}}false{{/parent}}{{/allVars}}{{^isAdditionalPropertiesTrue}};{{/isAdditionalPropertiesTrue}}
                 {{#isAdditionalPropertiesTrue}}
                 {{^parentModel}}
                 && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
@@ -350,14 +350,14 @@
                 {{^parent}}
                 int hashCode = 41;
                 {{/parent}}
-                {{#readOnlyVars}}
+                {{#allVars}}
                 {{#required}}
                 {{^isNullable}}
                 hashCode = (hashCode * 59) + {{name}}.GetHashCode();
                 {{/isNullable}}
                 {{/required}}
-                {{/readOnlyVars}}
-                {{#readOnlyVars}}
+                {{/allVars}}
+                {{#allVars}}
                 {{#lambda.copy}}
                 if ({{name}} != null)
                     hashCode = (hashCode * 59) + {{name}}.GetHashCode();
@@ -371,7 +371,7 @@
                 {{#lambda.pasteOnce}}
                 {{/lambda.pasteOnce}}
                 {{/required}}
-                {{/readOnlyVars}}
+                {{/allVars}}
                 {{#isAdditionalPropertiesTrue}}
                 {{^parentModel}}
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -1,7 +1,7 @@
     /// <summary>
     /// {{description}}{{^description}}{{classname}}{{/description}}
     /// </summary>
-    {{>visibility}} partial class {{classname}}{{#lambda.firstDot}}{{#parent}} : .{{/parent}}{{#validatable}} : .{{/validatable}}{{#equatable}}{{#readOnlyVars}}{{#-first}} : .{{/-first}}{{/readOnlyVars}}{{/equatable}}{{/lambda.firstDot}}{{#lambda.joinWithComma}}{{#parent}}{{{.}}}  {{/parent}}{{>ImplementsIEquatable}}{{#validatable}}IValidatableObject  {{/validatable}}{{/lambda.joinWithComma}}
+    {{>visibility}} partial class {{classname}}{{#lambda.firstDot}}{{#parent}} : .{{/parent}}{{#validatable}} : .{{/validatable}}{{#equatable}} : {{/equatable}}{{/lambda.firstDot}}{{#lambda.joinWithComma}}{{#parent}}{{{.}}}  {{/parent}}{{>ImplementsIEquatable}}{{#validatable}}IValidatableObject  {{/validatable}}{{/lambda.joinWithComma}}
     {
         {{#composedSchemas.oneOf}}
         {{^vendorExtensions.x-duplicated-data-type}}
@@ -281,8 +281,6 @@
             return sb.ToString();
         }
         {{#equatable}}
-        {{#readOnlyVars}}
-        {{#-first}}
 
         /// <summary>
         /// Returns true if objects are equal
@@ -383,8 +381,6 @@
                 return hashCode;
             }
         }
-        {{/-first}}
-        {{/readOnlyVars}}
         {{/equatable}}
 {{#validatable}}
 {{^parentModel}}

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of an adult
     /// </summary>
-    public partial class Adult : Person, IValidatableObject
+    public partial class Adult : Person, IEquatable<Adult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
@@ -69,6 +69,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Children: ").Append(Children).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Adult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Adult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Adult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Adult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Children != null)
+                    hashCode = (hashCode * 59) + Children.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of a child
     /// </summary>
-    public partial class Child : Person, IValidatableObject
+    public partial class Child : Person, IEquatable<Child>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
@@ -85,6 +85,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Child).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Child instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Child to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Child input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Age != null)
+                    hashCode = (hashCode * 59) + Age.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                if (BoosterSeat != null)
+                    hashCode = (hashCode * 59) + BoosterSeat.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Person
     /// </summary>
-    public partial class Person : IValidatableObject
+    public partial class Person : IEquatable<Person>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
@@ -97,6 +97,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Person).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Person instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Person to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Person input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -100,6 +100,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -26,7 +26,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -72,6 +72,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return this.Equals(input as Apple);
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Kind == input.Kind ||
+                    (Kind != null &&
+                    Kind.Equals(input.Kind))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -26,7 +26,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -72,6 +72,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return this.Equals(input as Banana);
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Count == input.Count ||
+                    Count.Equals(input.Count)
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -26,7 +26,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -99,6 +99,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return this.Equals(input as Fruit);
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Color == input.Color ||
+                    (Color != null &&
+                    Color.Equals(input.Color))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -194,6 +194,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -140,6 +140,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -611,6 +611,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -74,6 +74,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -96,6 +96,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -127,6 +127,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -221,6 +221,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -678,6 +678,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -187,6 +187,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -236,6 +236,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -222,6 +222,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1689,6 +1689,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -140,6 +140,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -162,6 +162,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -139,6 +139,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of an adult
     /// </summary>
-    public partial class Adult : Person, IValidatableObject
+    public partial class Adult : Person, IEquatable<Adult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
@@ -69,6 +69,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Children: ").Append(Children).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Adult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Adult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Adult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Adult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Children != null)
+                    hashCode = (hashCode * 59) + Children.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of a child
     /// </summary>
-    public partial class Child : Person, IValidatableObject
+    public partial class Child : Person, IEquatable<Child>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
@@ -85,6 +85,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Child).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Child instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Child to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Child input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Age != null)
+                    hashCode = (hashCode * 59) + Age.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                if (BoosterSeat != null)
+                    hashCode = (hashCode * 59) + BoosterSeat.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Person
     /// </summary>
-    public partial class Person : IValidatableObject
+    public partial class Person : IEquatable<Person>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
@@ -97,6 +97,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Person).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Person instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Person to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Person input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -100,6 +100,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -26,7 +26,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -72,6 +72,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return this.Equals(input as Apple);
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Kind == input.Kind ||
+                    (Kind != null &&
+                    Kind.Equals(input.Kind))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -26,7 +26,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -72,6 +72,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return this.Equals(input as Banana);
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Count == input.Count ||
+                    Count.Equals(input.Count)
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -26,7 +26,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -99,6 +99,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return this.Equals(input as Fruit);
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Color == input.Color ||
+                    (Color != null &&
+                    Color.Equals(input.Color))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -194,6 +194,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -140,6 +140,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -611,6 +611,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -74,6 +74,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -96,6 +96,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -127,6 +127,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -221,6 +221,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -678,6 +678,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -187,6 +187,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -236,6 +236,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -222,6 +222,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1689,6 +1689,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -140,6 +140,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -162,6 +162,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -139,6 +139,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of an adult
     /// </summary>
-    public partial class Adult : Person, IValidatableObject
+    public partial class Adult : Person, IEquatable<Adult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
@@ -71,6 +71,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Children: ").Append(Children).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Adult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Adult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Adult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Adult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Children != null)
+                    hashCode = (hashCode * 59) + Children.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of a child
     /// </summary>
-    public partial class Child : Person, IValidatableObject
+    public partial class Child : Person, IEquatable<Child?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
@@ -87,6 +87,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Child).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Child instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Child to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Child? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Age != null)
+                    hashCode = (hashCode * 59) + Age.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                if (BoosterSeat != null)
+                    hashCode = (hashCode * 59) + BoosterSeat.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Person
     /// </summary>
-    public partial class Person : IValidatableObject
+    public partial class Person : IEquatable<Person?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
@@ -99,6 +99,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Person).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Person instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Person to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Person? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -102,6 +102,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -74,6 +74,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return this.Equals(input as Apple);
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Kind == input.Kind ||
+                    (Kind != null &&
+                    Kind.Equals(input.Kind))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -74,6 +74,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return this.Equals(input as Banana);
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Count == input.Count ||
+                    Count.Equals(input.Count)
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -101,6 +101,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return this.Equals(input as Fruit);
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Color == input.Color ||
+                    (Color != null &&
+                    Color.Equals(input.Color))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -194,6 +194,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -140,6 +140,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -611,6 +611,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -74,6 +74,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -188,6 +188,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -83,6 +83,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -156,6 +156,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -70,6 +70,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -84,6 +84,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -129,6 +129,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -122,6 +122,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -63,6 +63,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -63,6 +63,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -70,6 +70,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -123,6 +123,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -67,6 +67,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -223,6 +223,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -680,6 +680,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -446,6 +446,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -91,6 +91,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -73,6 +73,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -95,6 +95,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -67,6 +67,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -70,6 +70,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -95,6 +95,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -189,6 +189,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -128,6 +128,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -125,6 +125,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -123,6 +123,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -147,6 +147,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -251,6 +251,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -126,6 +126,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -65,6 +65,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -238,6 +238,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -53,6 +53,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -224,6 +224,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -110,6 +110,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -125,6 +125,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1691,6 +1691,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -110,6 +110,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -109,6 +109,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -142,6 +142,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -109,6 +109,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -95,6 +95,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -256,6 +256,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -100,6 +100,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -164,6 +164,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -141,6 +141,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -98,6 +98,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -127,6 +127,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -221,6 +221,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -678,6 +678,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -187,6 +187,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -236,6 +236,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -222,6 +222,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1689,6 +1689,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -140,6 +140,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -162,6 +162,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -139,6 +139,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -189,6 +189,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -84,6 +84,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -78,6 +78,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -78,6 +78,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -157,6 +157,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -71,6 +71,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -85,6 +85,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -130,6 +130,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -123,6 +123,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -64,6 +64,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -64,6 +64,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -71,6 +71,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -224,6 +224,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -681,6 +681,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -447,6 +447,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -92,6 +92,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -74,6 +74,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -96,6 +96,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -71,6 +71,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -96,6 +96,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -190,6 +190,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -129,6 +129,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -148,6 +148,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -252,6 +252,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -127,6 +127,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -66,6 +66,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -239,6 +239,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -54,6 +54,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -225,6 +225,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -111,6 +111,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -126,6 +126,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1692,6 +1692,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -111,6 +111,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -110,6 +110,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -143,6 +143,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -110,6 +110,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -96,6 +96,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -257,6 +257,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -101,6 +101,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -165,6 +165,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -142,6 +142,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Adult.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of an adult
     /// </summary>
-    public partial class Adult : Person, IValidatableObject
+    public partial class Adult : Person, IEquatable<Adult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Adult" /> class.
@@ -71,6 +71,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Children: ").Append(Children).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Adult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Adult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Adult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Adult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Children != null)
+                    hashCode = (hashCode * 59) + Children.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Child.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// A representation of a child
     /// </summary>
-    public partial class Child : Person, IValidatableObject
+    public partial class Child : Person, IEquatable<Child?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Child" /> class.
@@ -87,6 +87,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  BoosterSeat: ").Append(BoosterSeat).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Child).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Child instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Child to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Child? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                if (Age != null)
+                    hashCode = (hashCode * 59) + Age.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                if (BoosterSeat != null)
+                    hashCode = (hashCode * 59) + BoosterSeat.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Model/Person.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Person
     /// </summary>
-    public partial class Person : IValidatableObject
+    public partial class Person : IEquatable<Person?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Person" /> class.
@@ -99,6 +99,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Person).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Person instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Person to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Person? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -102,6 +102,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Apple.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -74,6 +74,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return this.Equals(input as Apple);
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Kind == input.Kind ||
+                    (Kind != null &&
+                    Kind.Equals(input.Kind))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Banana.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -74,6 +74,52 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return this.Equals(input as Banana);
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Count == input.Count ||
+                    Count.Equals(input.Count)
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Model/Fruit.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -101,6 +101,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return this.Equals(input as Fruit);
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            if (input == null)
+                return false;
+
+            return 
+                (
+                    Color == input.Color ||
+                    (Color != null &&
+                    Color.Equals(input.Color))
+                )
+                && (AdditionalProperties.Count == input.AdditionalProperties.Count && !AdditionalProperties.Except(input.AdditionalProperties).Any());
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -194,6 +194,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -140,6 +140,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -611,6 +611,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -74,6 +74,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Activity.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -188,6 +188,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Animal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -83,6 +83,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Apple.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Banana.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -156,6 +156,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Cat.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -70,6 +70,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Category.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -84,6 +84,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -129,6 +129,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -122,6 +122,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -63,6 +63,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -63,6 +63,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Dog.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -70,6 +70,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Drawing.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -123,6 +123,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -67,6 +67,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -223,6 +223,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -680,6 +680,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/File.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Foo.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -446,6 +446,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Fruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -91,6 +91,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -73,6 +73,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -95,6 +95,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -67,6 +67,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -70,6 +70,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/List.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Mammal.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -95,6 +95,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MapTest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -189,6 +189,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -128,6 +128,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -125,6 +125,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -123,6 +123,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Name.cs
@@ -147,6 +147,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -251,6 +251,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -126,6 +126,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -65,6 +65,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Order.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -238,6 +238,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -53,6 +53,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pet.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -224,6 +224,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Pig.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -110,6 +110,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -125,6 +125,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1691,6 +1691,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Result.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -110,6 +110,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Return.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -109,6 +109,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Shape.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -80,6 +80,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -77,6 +77,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Tag.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -91,6 +91,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -142,6 +142,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TestResult.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -109,6 +109,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Triangle.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -95,6 +95,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/User.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -256,6 +256,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Whale.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -100,6 +100,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/Zebra.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -164,6 +164,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -141,6 +141,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Apple.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Kind != null)
+                    hashCode = (hashCode * 59) + Kind.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Banana.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Count != null)
+                    hashCode = (hashCode * 59) + Count.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Model/Fruit.cs
@@ -29,7 +29,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -98,6 +98,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -127,6 +127,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -221,6 +221,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -678,6 +678,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -187,6 +187,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -236,6 +236,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -222,6 +222,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1689,6 +1689,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -140,6 +140,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -162,6 +162,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -139,6 +139,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Activity.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -189,6 +189,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Animal.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -84,6 +84,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Apple.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -78,6 +78,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Banana.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -78,6 +78,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -157,6 +157,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Cat.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -71,6 +71,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Category.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -85,6 +85,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -130,6 +130,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -123,6 +123,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -64,6 +64,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -64,6 +64,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Dog.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -71,6 +71,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Drawing.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -224,6 +224,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -681,6 +681,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/File.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Foo.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -447,6 +447,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Fruit.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -92,6 +92,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -74,6 +74,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -96,6 +96,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -71,6 +71,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/List.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Mammal.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -96,6 +96,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MapTest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -190,6 +190,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -129,6 +129,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Name.cs
@@ -148,6 +148,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -252,6 +252,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -77,6 +77,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -127,6 +127,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -66,6 +66,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Order.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -239,6 +239,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -54,6 +54,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pet.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -225,6 +225,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Pig.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -111,6 +111,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -126,6 +126,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1692,6 +1692,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Result.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -111,6 +111,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Return.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -110,6 +110,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Shape.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -81,6 +81,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -78,6 +78,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Tag.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -92,6 +92,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -143,6 +143,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -76,6 +76,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TestResult.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -110,6 +110,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Triangle.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -96,6 +96,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -69,6 +69,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/User.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -257,6 +257,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Whale.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -101,6 +101,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/Zebra.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -165,6 +165,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -30,7 +30,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass?>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -142,6 +142,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass? input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Activity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// test map of maps
     /// </summary>
-    public partial class Activity : IValidatableObject
+    public partial class Activity : IEquatable<Activity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Activity" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Activity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Activity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Activity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Activity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ActivityOutputs != null)
+                    hashCode = (hashCode * 59) + ActivityOutputs.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ActivityOutputElementRepresentation
     /// </summary>
-    public partial class ActivityOutputElementRepresentation : IValidatableObject
+    public partial class ActivityOutputElementRepresentation : IEquatable<ActivityOutputElementRepresentation>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivityOutputElementRepresentation" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ActivityOutputElementRepresentation).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ActivityOutputElementRepresentation instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ActivityOutputElementRepresentation to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ActivityOutputElementRepresentation input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Prop1 != null)
+                    hashCode = (hashCode * 59) + Prop1.GetHashCode();
+
+                if (Prop2 != null)
+                    hashCode = (hashCode * 59) + Prop2.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AdditionalPropertiesClass
     /// </summary>
-    public partial class AdditionalPropertiesClass : IValidatableObject
+    public partial class AdditionalPropertiesClass : IEquatable<AdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AdditionalPropertiesClass" /> class.
@@ -186,6 +186,65 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Anytype1 != null)
+                    hashCode = (hashCode * 59) + Anytype1.GetHashCode();
+
+                if (EmptyMap != null)
+                    hashCode = (hashCode * 59) + EmptyMap.GetHashCode();
+
+                if (MapOfMapProperty != null)
+                    hashCode = (hashCode * 59) + MapOfMapProperty.GetHashCode();
+
+                if (MapProperty != null)
+                    hashCode = (hashCode * 59) + MapProperty.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype1 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype1.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype2 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype2.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesAnytype3 != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesAnytype3.GetHashCode();
+
+                if (MapWithUndeclaredPropertiesString != null)
+                    hashCode = (hashCode * 59) + MapWithUndeclaredPropertiesString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Animal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Animal
     /// </summary>
-    public partial class Animal : IValidatableObject
+    public partial class Animal : IEquatable<Animal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Animal" /> class.
@@ -81,6 +81,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Animal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Animal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Animal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Animal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ApiResponse
     /// </summary>
-    public partial class ApiResponse : IValidatableObject
+    public partial class ApiResponse : IEquatable<ApiResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiResponse" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ApiResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ApiResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ApiResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ApiResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Message != null)
+                    hashCode = (hashCode * 59) + Message.GetHashCode();
+
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Apple.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Apple
     /// </summary>
-    public partial class Apple : IValidatableObject
+    public partial class Apple : IEquatable<Apple>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Apple" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Apple).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Apple instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Apple to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Apple input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ColorCode != null)
+                    hashCode = (hashCode * 59) + ColorCode.GetHashCode();
+
+                if (Cultivar != null)
+                    hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+
+                if (Origin != null)
+                    hashCode = (hashCode * 59) + Origin.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// AppleReq
     /// </summary>
-    public partial class AppleReq : IValidatableObject
+    public partial class AppleReq : IEquatable<AppleReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AppleReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Mealy: ").Append(Mealy).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as AppleReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if AppleReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of AppleReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(AppleReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Cultivar.GetHashCode();
+                if (Mealy != null)
+                    hashCode = (hashCode * 59) + Mealy.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfArrayOfNumberOnly : IEquatable<ArrayOfArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayOfNumberOnly
     /// </summary>
-    public partial class ArrayOfNumberOnly : IValidatableObject
+    public partial class ArrayOfNumberOnly : IEquatable<ArrayOfNumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayOfNumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayOfNumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayOfNumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayOfNumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayNumber != null)
+                    hashCode = (hashCode * 59) + ArrayNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ArrayTest
     /// </summary>
-    public partial class ArrayTest : IValidatableObject
+    public partial class ArrayTest : IEquatable<ArrayTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ArrayTest" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ArrayTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ArrayTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ArrayTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ArrayTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayArrayOfInteger != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfInteger.GetHashCode();
+
+                if (ArrayArrayOfModel != null)
+                    hashCode = (hashCode * 59) + ArrayArrayOfModel.GetHashCode();
+
+                if (ArrayOfString != null)
+                    hashCode = (hashCode * 59) + ArrayOfString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Banana.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Banana
     /// </summary>
-    public partial class Banana : IValidatableObject
+    public partial class Banana : IEquatable<Banana>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Banana" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Banana).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Banana instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Banana to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Banana input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (LengthCm != null)
+                    hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BananaReq
     /// </summary>
-    public partial class BananaReq : IValidatableObject
+    public partial class BananaReq : IEquatable<BananaReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BananaReq" /> class.
@@ -75,6 +75,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Sweet: ").Append(Sweet).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BananaReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BananaReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BananaReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BananaReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + LengthCm.GetHashCode();
+                if (Sweet != null)
+                    hashCode = (hashCode * 59) + Sweet.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/BasquePig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// BasquePig
     /// </summary>
-    public partial class BasquePig : IValidatableObject
+    public partial class BasquePig : IEquatable<BasquePig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BasquePig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as BasquePig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if BasquePig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of BasquePig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(BasquePig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Capitalization
     /// </summary>
-    public partial class Capitalization : IValidatableObject
+    public partial class Capitalization : IEquatable<Capitalization>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Capitalization" /> class.
@@ -154,6 +154,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Capitalization).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Capitalization instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Capitalization to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Capitalization input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ATT_NAME != null)
+                    hashCode = (hashCode * 59) + ATT_NAME.GetHashCode();
+
+                if (CapitalCamel != null)
+                    hashCode = (hashCode * 59) + CapitalCamel.GetHashCode();
+
+                if (CapitalSnake != null)
+                    hashCode = (hashCode * 59) + CapitalSnake.GetHashCode();
+
+                if (SCAETHFlowPoints != null)
+                    hashCode = (hashCode * 59) + SCAETHFlowPoints.GetHashCode();
+
+                if (SmallCamel != null)
+                    hashCode = (hashCode * 59) + SmallCamel.GetHashCode();
+
+                if (SmallSnake != null)
+                    hashCode = (hashCode * 59) + SmallSnake.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Cat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Cat
     /// </summary>
-    public partial class Cat : Animal, IValidatableObject
+    public partial class Cat : Animal, IEquatable<Cat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Cat" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Declawed: ").Append(Declawed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Cat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Cat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Cat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Cat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+                if (Declawed != null)
+                    hashCode = (hashCode * 59) + Declawed.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Category.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Category
     /// </summary>
-    public partial class Category : IValidatableObject
+    public partial class Category : IEquatable<Category>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Category" /> class.
@@ -82,6 +82,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Category).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Category instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Category to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Category input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ChildCat
     /// </summary>
-    public partial class ChildCat : ParentPet, IValidatableObject
+    public partial class ChildCat : ParentPet, IEquatable<ChildCat>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChildCat" /> class.
@@ -127,6 +127,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Name: ").Append(Name).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ChildCat).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ChildCat instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ChildCat to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ChildCat input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model with \&quot;_class\&quot; property
     /// </summary>
-    public partial class ClassModel : IValidatableObject
+    public partial class ClassModel : IEquatable<ClassModel>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ClassModel).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ClassModel instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ClassModel to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ClassModel input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ComplexQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ComplexQuadrilateral
     /// </summary>
-    public partial class ComplexQuadrilateral : IValidatableObject
+    public partial class ComplexQuadrilateral : IEquatable<ComplexQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ComplexQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ComplexQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ComplexQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ComplexQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ComplexQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/CopyActivity.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// CopyActivity
     /// </summary>
-    public partial class CopyActivity : EntityBase, IValidatableObject
+    public partial class CopyActivity : EntityBase, IEquatable<CopyActivity>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CopyActivity" /> class.
@@ -120,6 +120,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  CopyActivitytt: ").Append(CopyActivitytt).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as CopyActivity).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if CopyActivity instances are equal
+        /// </summary>
+        /// <param name="input">Instance of CopyActivity to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(CopyActivity input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + CopyActivitytt.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DanishPig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DanishPig
     /// </summary>
-    public partial class DanishPig : IValidatableObject
+    public partial class DanishPig : IEquatable<DanishPig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DanishPig" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DanishPig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DanishPig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DanishPig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DanishPig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DateOnlyClass
     /// </summary>
-    public partial class DateOnlyClass : IValidatableObject
+    public partial class DateOnlyClass : IEquatable<DateOnlyClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DateOnlyClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DateOnlyClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DateOnlyClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DateOnlyClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateOnlyProperty != null)
+                    hashCode = (hashCode * 59) + DateOnlyProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// DeprecatedObject
     /// </summary>
-    public partial class DeprecatedObject : IValidatableObject
+    public partial class DeprecatedObject : IEquatable<DeprecatedObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as DeprecatedObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if DeprecatedObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of DeprecatedObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(DeprecatedObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant1.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant1
     /// </summary>
-    public partial class Descendant1 : TestDescendants, IValidatableObject
+    public partial class Descendant1 : TestDescendants, IEquatable<Descendant1>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant1" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  DescendantName: ").Append(DescendantName).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant1).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant1 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant1 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant1 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + DescendantName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Descendant2.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Descendant2
     /// </summary>
-    public partial class Descendant2 : TestDescendants, IValidatableObject
+    public partial class Descendant2 : TestDescendants, IEquatable<Descendant2>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Descendant2" /> class.
@@ -61,6 +61,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Confidentiality: ").Append(Confidentiality).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Descendant2).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Descendant2 instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Descendant2 to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Descendant2 input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + Confidentiality.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Dog.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Dog
     /// </summary>
-    public partial class Dog : Animal, IValidatableObject
+    public partial class Dog : Animal, IEquatable<Dog>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Dog" /> class.
@@ -68,6 +68,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Breed: ").Append(Breed).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Dog).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Dog instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Dog to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Dog input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Breed != null)
+                    hashCode = (hashCode * 59) + Breed.GetHashCode();
+
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Drawing
     /// </summary>
-    public partial class Drawing : IValidatableObject
+    public partial class Drawing : IEquatable<Drawing>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Drawing" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Drawing).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Drawing instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Drawing to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Drawing input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MainShape != null)
+                    hashCode = (hashCode * 59) + MainShape.GetHashCode();
+
+                if (NullableShape != null)
+                    hashCode = (hashCode * 59) + NullableShape.GetHashCode();
+
+                if (ShapeOrNull != null)
+                    hashCode = (hashCode * 59) + ShapeOrNull.GetHashCode();
+
+                if (Shapes != null)
+                    hashCode = (hashCode * 59) + Shapes.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EntityBase.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EntityBase
     /// </summary>
-    public partial class EntityBase : IValidatableObject
+    public partial class EntityBase : IEquatable<EntityBase>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EntityBase" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EntityBase).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EntityBase instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EntityBase to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EntityBase input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Schema.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumArrays
     /// </summary>
-    public partial class EnumArrays : IValidatableObject
+    public partial class EnumArrays : IEquatable<EnumArrays>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumArrays" /> class.
@@ -221,6 +221,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumArrays).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumArrays instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumArrays to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumArrays input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayEnum != null)
+                    hashCode = (hashCode * 59) + ArrayEnum.GetHashCode();
+
+                if (JustSymbol != null)
+                    hashCode = (hashCode * 59) + JustSymbol.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EnumTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EnumTest
     /// </summary>
-    public partial class EnumTest : IValidatableObject
+    public partial class EnumTest : IEquatable<EnumTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumTest" /> class.
@@ -678,6 +678,66 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EnumTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EnumTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EnumTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EnumTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + EnumStringRequired.GetHashCode();
+                if (EnumInteger != null)
+                    hashCode = (hashCode * 59) + EnumInteger.GetHashCode();
+
+                if (EnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + EnumIntegerOnly.GetHashCode();
+
+                if (EnumNumber != null)
+                    hashCode = (hashCode * 59) + EnumNumber.GetHashCode();
+
+                if (EnumString != null)
+                    hashCode = (hashCode * 59) + EnumString.GetHashCode();
+
+                if (OuterEnum != null)
+                    hashCode = (hashCode * 59) + OuterEnum.GetHashCode();
+
+                if (OuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumDefaultValue.GetHashCode();
+
+                if (OuterEnumInteger != null)
+                    hashCode = (hashCode * 59) + OuterEnumInteger.GetHashCode();
+
+                if (OuterEnumIntegerDefaultValue != null)
+                    hashCode = (hashCode * 59) + OuterEnumIntegerDefaultValue.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/EquilateralTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// EquilateralTriangle
     /// </summary>
-    public partial class EquilateralTriangle : IValidatableObject
+    public partial class EquilateralTriangle : IEquatable<EquilateralTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquilateralTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as EquilateralTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if EquilateralTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of EquilateralTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(EquilateralTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/File.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Must be named &#x60;File&#x60; for test.
     /// </summary>
-    public partial class File : IValidatableObject
+    public partial class File : IEquatable<File>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="File" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as File).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if File instances are equal
+        /// </summary>
+        /// <param name="input">Instance of File to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(File input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SourceURI != null)
+                    hashCode = (hashCode * 59) + SourceURI.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FileSchemaTestClass
     /// </summary>
-    public partial class FileSchemaTestClass : IValidatableObject
+    public partial class FileSchemaTestClass : IEquatable<FileSchemaTestClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileSchemaTestClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FileSchemaTestClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FileSchemaTestClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FileSchemaTestClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FileSchemaTestClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (File != null)
+                    hashCode = (hashCode * 59) + File.GetHashCode();
+
+                if (Files != null)
+                    hashCode = (hashCode * 59) + Files.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Foo.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Foo
     /// </summary>
-    public partial class Foo : IValidatableObject
+    public partial class Foo : IEquatable<Foo>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Foo" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Foo).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Foo instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Foo to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Foo input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bar != null)
+                    hashCode = (hashCode * 59) + Bar.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FooGetDefaultResponse
     /// </summary>
-    public partial class FooGetDefaultResponse : IValidatableObject
+    public partial class FooGetDefaultResponse : IEquatable<FooGetDefaultResponse>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FooGetDefaultResponse).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FooGetDefaultResponse instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FooGetDefaultResponse to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FooGetDefaultResponse input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FormatTest
     /// </summary>
-    public partial class FormatTest : IValidatableObject
+    public partial class FormatTest : IEquatable<FormatTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FormatTest" /> class.
@@ -444,6 +444,109 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FormatTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FormatTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FormatTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FormatTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Byte.GetHashCode();
+                hashCode = (hashCode * 59) + Date.GetHashCode();
+                hashCode = (hashCode * 59) + Number.GetHashCode();
+                hashCode = (hashCode * 59) + Password.GetHashCode();
+                hashCode = (hashCode * 59) + StringFormattedAsDecimalRequired.GetHashCode();
+                if (Binary != null)
+                    hashCode = (hashCode * 59) + Binary.GetHashCode();
+
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Decimal != null)
+                    hashCode = (hashCode * 59) + Decimal.GetHashCode();
+
+                if (Double != null)
+                    hashCode = (hashCode * 59) + Double.GetHashCode();
+
+                if (Float != null)
+                    hashCode = (hashCode * 59) + Float.GetHashCode();
+
+                if (Int32 != null)
+                    hashCode = (hashCode * 59) + Int32.GetHashCode();
+
+                if (Int32Range != null)
+                    hashCode = (hashCode * 59) + Int32Range.GetHashCode();
+
+                if (Int64 != null)
+                    hashCode = (hashCode * 59) + Int64.GetHashCode();
+
+                if (Int64Negative != null)
+                    hashCode = (hashCode * 59) + Int64Negative.GetHashCode();
+
+                if (Int64NegativeExclusive != null)
+                    hashCode = (hashCode * 59) + Int64NegativeExclusive.GetHashCode();
+
+                if (Int64Positive != null)
+                    hashCode = (hashCode * 59) + Int64Positive.GetHashCode();
+
+                if (Int64PositiveExclusive != null)
+                    hashCode = (hashCode * 59) + Int64PositiveExclusive.GetHashCode();
+
+                if (Integer != null)
+                    hashCode = (hashCode * 59) + Integer.GetHashCode();
+
+                if (PatternWithBackslash != null)
+                    hashCode = (hashCode * 59) + PatternWithBackslash.GetHashCode();
+
+                if (PatternWithDigits != null)
+                    hashCode = (hashCode * 59) + PatternWithDigits.GetHashCode();
+
+                if (PatternWithDigitsAndDelimiter != null)
+                    hashCode = (hashCode * 59) + PatternWithDigitsAndDelimiter.GetHashCode();
+
+                if (String != null)
+                    hashCode = (hashCode * 59) + String.GetHashCode();
+
+                if (StringFormattedAsDecimal != null)
+                    hashCode = (hashCode * 59) + StringFormattedAsDecimal.GetHashCode();
+
+                if (UnsignedInteger != null)
+                    hashCode = (hashCode * 59) + UnsignedInteger.GetHashCode();
+
+                if (UnsignedLong != null)
+                    hashCode = (hashCode * 59) + UnsignedLong.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Fruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Fruit
     /// </summary>
-    public partial class Fruit : IValidatableObject
+    public partial class Fruit : IEquatable<Fruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Fruit" /> class.
@@ -89,6 +89,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Fruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Fruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Fruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Fruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/FruitReq.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// FruitReq
     /// </summary>
-    public partial class FruitReq : IValidatableObject
+    public partial class FruitReq : IEquatable<FruitReq>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FruitReq" /> class.
@@ -71,6 +71,40 @@ namespace Org.OpenAPITools.Model
             sb.Append("class FruitReq {\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as FruitReq).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if FruitReq instances are equal
+        /// </summary>
+        /// <param name="input">Instance of FruitReq to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(FruitReq input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GmFruit.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GmFruit
     /// </summary>
-    public partial class GmFruit : IValidatableObject
+    public partial class GmFruit : IEquatable<GmFruit>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GmFruit" /> class.
@@ -93,6 +93,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  Color: ").Append(Color).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GmFruit).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GmFruit instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GmFruit to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GmFruit input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Color != null)
+                    hashCode = (hashCode * 59) + Color.GetHashCode();
+
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/GrandparentAnimal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// GrandparentAnimal
     /// </summary>
-    public partial class GrandparentAnimal : IValidatableObject
+    public partial class GrandparentAnimal : IEquatable<GrandparentAnimal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GrandparentAnimal" /> class.
@@ -65,6 +65,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as GrandparentAnimal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if GrandparentAnimal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of GrandparentAnimal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(GrandparentAnimal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
     /// </summary>
-    public partial class HealthCheckResult : IValidatableObject
+    public partial class HealthCheckResult : IEquatable<HealthCheckResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as HealthCheckResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if HealthCheckResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of HealthCheckResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(HealthCheckResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (NullableMessage != null)
+                    hashCode = (hashCode * 59) + NullableMessage.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/IsoscelesTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// IsoscelesTriangle
     /// </summary>
-    public partial class IsoscelesTriangle : IValidatableObject
+    public partial class IsoscelesTriangle : IEquatable<IsoscelesTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IsoscelesTriangle" /> class.
@@ -68,6 +68,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  TriangleType: ").Append(TriangleType).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as IsoscelesTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if IsoscelesTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of IsoscelesTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(IsoscelesTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/List.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// List
     /// </summary>
-    public partial class List : IValidatableObject
+    public partial class List : IEquatable<List>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="List" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as List).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if List instances are equal
+        /// </summary>
+        /// <param name="input">Instance of List to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(List input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Var123List != null)
+                    hashCode = (hashCode * 59) + Var123List.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// LiteralStringClass
     /// </summary>
-    public partial class LiteralStringClass : IValidatableObject
+    public partial class LiteralStringClass : IEquatable<LiteralStringClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LiteralStringClass" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as LiteralStringClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if LiteralStringClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of LiteralStringClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(LiteralStringClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (EscapedLiteralString != null)
+                    hashCode = (hashCode * 59) + EscapedLiteralString.GetHashCode();
+
+                if (UnescapedLiteralString != null)
+                    hashCode = (hashCode * 59) + UnescapedLiteralString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Mammal.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mammal
     /// </summary>
-    public partial class Mammal : IValidatableObject
+    public partial class Mammal : IEquatable<Mammal>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Mammal" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Mammal).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Mammal instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Mammal to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Mammal input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MapTest
     /// </summary>
-    public partial class MapTest : IValidatableObject
+    public partial class MapTest : IEquatable<MapTest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MapTest" /> class.
@@ -187,6 +187,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MapTest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MapTest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MapTest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MapTest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DirectMap != null)
+                    hashCode = (hashCode * 59) + DirectMap.GetHashCode();
+
+                if (IndirectMap != null)
+                    hashCode = (hashCode * 59) + IndirectMap.GetHashCode();
+
+                if (MapMapOfString != null)
+                    hashCode = (hashCode * 59) + MapMapOfString.GetHashCode();
+
+                if (MapOfEnumString != null)
+                    hashCode = (hashCode * 59) + MapOfEnumString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedAnyOf
     /// </summary>
-    public partial class MixedAnyOf : IValidatableObject
+    public partial class MixedAnyOf : IEquatable<MixedAnyOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedAnyOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed anyOf types for testing
     /// </summary>
-    public partial class MixedAnyOfContent : IValidatableObject
+    public partial class MixedAnyOfContent : IEquatable<MixedAnyOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedAnyOfContent" /> class.
@@ -126,6 +126,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedAnyOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedAnyOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedAnyOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedAnyOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOf.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedOneOf
     /// </summary>
-    public partial class MixedOneOf : IValidatableObject
+    public partial class MixedOneOf : IEquatable<MixedOneOf>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOf" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOf).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOf instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOf to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOf input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Content != null)
+                    hashCode = (hashCode * 59) + Content.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedOneOfContent.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Mixed oneOf types for testing
     /// </summary>
-    public partial class MixedOneOfContent : IValidatableObject
+    public partial class MixedOneOfContent : IEquatable<MixedOneOfContent>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedOneOfContent" /> class.
@@ -123,6 +123,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedOneOfContent).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedOneOfContent instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedOneOfContent to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedOneOfContent input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedPropertiesAndAdditionalPropertiesClass
     /// </summary>
-    public partial class MixedPropertiesAndAdditionalPropertiesClass : IValidatableObject
+    public partial class MixedPropertiesAndAdditionalPropertiesClass : IEquatable<MixedPropertiesAndAdditionalPropertiesClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedPropertiesAndAdditionalPropertiesClass" /> class.
@@ -121,6 +121,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedPropertiesAndAdditionalPropertiesClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedPropertiesAndAdditionalPropertiesClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedPropertiesAndAdditionalPropertiesClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedPropertiesAndAdditionalPropertiesClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (DateTime != null)
+                    hashCode = (hashCode * 59) + DateTime.GetHashCode();
+
+                if (Map != null)
+                    hashCode = (hashCode * 59) + Map.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                if (UuidWithPattern != null)
+                    hashCode = (hashCode * 59) + UuidWithPattern.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/MixedSubId.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// MixedSubId
     /// </summary>
-    public partial class MixedSubId : IValidatableObject
+    public partial class MixedSubId : IEquatable<MixedSubId>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MixedSubId" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as MixedSubId).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if MixedSubId instances are equal
+        /// </summary>
+        /// <param name="input">Instance of MixedSubId to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(MixedSubId input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing model name starting with number
     /// </summary>
-    public partial class Model200Response : IValidatableObject
+    public partial class Model200Response : IEquatable<Model200Response>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Model200Response" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Model200Response).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Model200Response instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Model200Response to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Model200Response input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Class != null)
+                    hashCode = (hashCode * 59) + Class.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ModelClient
     /// </summary>
-    public partial class ModelClient : IValidatableObject
+    public partial class ModelClient : IEquatable<ModelClient>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ModelClient).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ModelClient instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ModelClient to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ModelClient input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarClient != null)
+                    hashCode = (hashCode * 59) + VarClient.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Name.cs
@@ -145,6 +145,10 @@ namespace Org.OpenAPITools.Model
             unchecked // Overflow is fine, just wrap
             {
                 int hashCode = 41;
+                hashCode = (hashCode * 59) + VarName.GetHashCode();
+                if (Property != null)
+                    hashCode = (hashCode * 59) + Property.GetHashCode();
+
                 if (SnakeCase != null)
                     hashCode = (hashCode * 59) + SnakeCase.GetHashCode();
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NotificationtestGetElementsV1ResponseMPayload.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NotificationtestGetElementsV1ResponseMPayload
     /// </summary>
-    public partial class NotificationtestGetElementsV1ResponseMPayload : IValidatableObject
+    public partial class NotificationtestGetElementsV1ResponseMPayload : IEquatable<NotificationtestGetElementsV1ResponseMPayload>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NotificationtestGetElementsV1ResponseMPayload" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NotificationtestGetElementsV1ResponseMPayload).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NotificationtestGetElementsV1ResponseMPayload instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NotificationtestGetElementsV1ResponseMPayload to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NotificationtestGetElementsV1ResponseMPayload input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AObjVariableobject.GetHashCode();
+                hashCode = (hashCode * 59) + PkiNotificationtestID.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableClass
     /// </summary>
-    public partial class NullableClass : IValidatableObject
+    public partial class NullableClass : IEquatable<NullableClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableClass" /> class.
@@ -249,6 +249,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ArrayAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayAndItemsNullableProp.GetHashCode();
+
+                if (ArrayItemsNullable != null)
+                    hashCode = (hashCode * 59) + ArrayItemsNullable.GetHashCode();
+
+                if (ArrayNullableProp != null)
+                    hashCode = (hashCode * 59) + ArrayNullableProp.GetHashCode();
+
+                if (BooleanProp != null)
+                    hashCode = (hashCode * 59) + BooleanProp.GetHashCode();
+
+                if (DateProp != null)
+                    hashCode = (hashCode * 59) + DateProp.GetHashCode();
+
+                if (DatetimeProp != null)
+                    hashCode = (hashCode * 59) + DatetimeProp.GetHashCode();
+
+                if (IntegerProp != null)
+                    hashCode = (hashCode * 59) + IntegerProp.GetHashCode();
+
+                if (NumberProp != null)
+                    hashCode = (hashCode * 59) + NumberProp.GetHashCode();
+
+                if (ObjectAndItemsNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectAndItemsNullableProp.GetHashCode();
+
+                if (ObjectItemsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectItemsNullable.GetHashCode();
+
+                if (ObjectNullableProp != null)
+                    hashCode = (hashCode * 59) + ObjectNullableProp.GetHashCode();
+
+                if (StringProp != null)
+                    hashCode = (hashCode * 59) + StringProp.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableGuidClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NullableGuidClass
     /// </summary>
-    public partial class NullableGuidClass : IValidatableObject
+    public partial class NullableGuidClass : IEquatable<NullableGuidClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableGuidClass" /> class.
@@ -74,6 +74,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableGuidClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableGuidClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableGuidClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableGuidClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NullableShape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. The &#39;nullable&#39; attribute was introduced in OAS schema &gt;&#x3D; 3.0 and has been deprecated in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class NullableShape : IValidatableObject
+    public partial class NullableShape : IEquatable<NullableShape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NullableShape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NullableShape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NullableShape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NullableShape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NullableShape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// NumberOnly
     /// </summary>
-    public partial class NumberOnly : IValidatableObject
+    public partial class NumberOnly : IEquatable<NumberOnly>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as NumberOnly).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if NumberOnly instances are equal
+        /// </summary>
+        /// <param name="input">Instance of NumberOnly to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(NumberOnly input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (JustNumber != null)
+                    hashCode = (hashCode * 59) + JustNumber.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ObjectWithDeprecatedFields
     /// </summary>
-    public partial class ObjectWithDeprecatedFields : IValidatableObject
+    public partial class ObjectWithDeprecatedFields : IEquatable<ObjectWithDeprecatedFields>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectWithDeprecatedFields" /> class.
@@ -124,6 +124,53 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ObjectWithDeprecatedFields).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ObjectWithDeprecatedFields instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ObjectWithDeprecatedFields to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ObjectWithDeprecatedFields input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Bars != null)
+                    hashCode = (hashCode * 59) + Bars.GetHashCode();
+
+                if (DeprecatedRef != null)
+                    hashCode = (hashCode * 59) + DeprecatedRef.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OneOfString
     /// </summary>
-    public partial class OneOfString : IValidatableObject
+    public partial class OneOfString : IEquatable<OneOfString>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
@@ -63,6 +63,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OneOfString).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OneOfString instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OneOfString to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OneOfString input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Order.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Order
     /// </summary>
-    public partial class Order : IValidatableObject
+    public partial class Order : IEquatable<Order>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Order" /> class.
@@ -236,6 +236,59 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Order).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Order instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Order to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Order input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Complete != null)
+                    hashCode = (hashCode * 59) + Complete.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (PetId != null)
+                    hashCode = (hashCode * 59) + PetId.GetHashCode();
+
+                if (Quantity != null)
+                    hashCode = (hashCode * 59) + Quantity.GetHashCode();
+
+                if (ShipDate != null)
+                    hashCode = (hashCode * 59) + ShipDate.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// OuterComposite
     /// </summary>
-    public partial class OuterComposite : IValidatableObject
+    public partial class OuterComposite : IEquatable<OuterComposite>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OuterComposite" /> class.
@@ -105,6 +105,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as OuterComposite).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if OuterComposite instances are equal
+        /// </summary>
+        /// <param name="input">Instance of OuterComposite to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(OuterComposite input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (MyBoolean != null)
+                    hashCode = (hashCode * 59) + MyBoolean.GetHashCode();
+
+                if (MyNumber != null)
+                    hashCode = (hashCode * 59) + MyNumber.GetHashCode();
+
+                if (MyString != null)
+                    hashCode = (hashCode * 59) + MyString.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ParentPet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ParentPet
     /// </summary>
-    public partial class ParentPet : GrandparentAnimal, IValidatableObject
+    public partial class ParentPet : GrandparentAnimal, IEquatable<ParentPet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParentPet" /> class.
@@ -51,6 +51,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  ").Append(base.ToString()?.Replace("\n", "\n  ")).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ParentPet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ParentPet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ParentPet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ParentPet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = base.GetHashCode();
+                hashCode = (hashCode * 59) + PetType.GetHashCode();
+
+                return hashCode;
+            }
         }
     }
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pet.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pet
     /// </summary>
-    public partial class Pet : IValidatableObject
+    public partial class Pet : IEquatable<Pet>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pet" /> class.
@@ -222,6 +222,55 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pet).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pet instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pet to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pet input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Name.GetHashCode();
+                hashCode = (hashCode * 59) + PhotoUrls.GetHashCode();
+                if (Category != null)
+                    hashCode = (hashCode * 59) + Category.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Status != null)
+                    hashCode = (hashCode * 59) + Status.GetHashCode();
+
+                if (Tags != null)
+                    hashCode = (hashCode * 59) + Tags.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Pig.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Pig
     /// </summary>
-    public partial class Pig : IValidatableObject
+    public partial class Pig : IEquatable<Pig>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Pig" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Pig).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Pig instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Pig to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Pig input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// PolymorphicProperty
     /// </summary>
-    public partial class PolymorphicProperty : IValidatableObject
+    public partial class PolymorphicProperty : IEquatable<PolymorphicProperty>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
@@ -108,6 +108,41 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as PolymorphicProperty).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if PolymorphicProperty instances are equal
+        /// </summary>
+        /// <param name="input">Instance of PolymorphicProperty to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(PolymorphicProperty input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Quadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Quadrilateral
     /// </summary>
-    public partial class Quadrilateral : IValidatableObject
+    public partial class Quadrilateral : IEquatable<Quadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Quadrilateral" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Quadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Quadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Quadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Quadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/QuadrilateralInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// QuadrilateralInterface
     /// </summary>
-    public partial class QuadrilateralInterface : IValidatableObject
+    public partial class QuadrilateralInterface : IEquatable<QuadrilateralInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadrilateralInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as QuadrilateralInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if QuadrilateralInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of QuadrilateralInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(QuadrilateralInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -123,6 +123,9 @@ namespace Org.OpenAPITools.Model
                 if (Bar != null)
                     hashCode = (hashCode * 59) + Bar.GetHashCode();
 
+                if (Baz != null)
+                    hashCode = (hashCode * 59) + Baz.GetHashCode();
+
                 hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
 
                 return hashCode;

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RequiredClass
     /// </summary>
-    public partial class RequiredClass : IValidatableObject
+    public partial class RequiredClass : IEquatable<RequiredClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequiredClass" /> class.
@@ -1689,6 +1689,151 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RequiredClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RequiredClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RequiredClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RequiredClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + RequiredNotNullableDateProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableArrayOfString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableBooleanProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableDatetimeProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumInteger.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumIntegerOnly.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableEnumString.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableStringProp.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableUuid.GetHashCode();
+                hashCode = (hashCode * 59) + RequiredNotnullableintegerProp.GetHashCode();
+                if (NotRequiredNotnullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableDateProp.GetHashCode();
+
+                if (NotRequiredNotnullableintegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNotnullableintegerProp.GetHashCode();
+
+                if (NotRequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableDateProp.GetHashCode();
+
+                if (NotRequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + NotRequiredNullableIntegerProp.GetHashCode();
+
+                if (NotrequiredNotnullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNotnullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNotnullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNotnullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNotnullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNotnullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableEnumString.GetHashCode();
+
+                if (NotrequiredNotnullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNotnullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableStringProp.GetHashCode();
+
+                if (NotrequiredNotnullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNotnullableUuid.GetHashCode();
+
+                if (NotrequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableArrayOfString.GetHashCode();
+
+                if (NotrequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableBooleanProp.GetHashCode();
+
+                if (NotrequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableDatetimeProp.GetHashCode();
+
+                if (NotrequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumInteger.GetHashCode();
+
+                if (NotrequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (NotrequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableEnumString.GetHashCode();
+
+                if (NotrequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (NotrequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableStringProp.GetHashCode();
+
+                if (NotrequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + NotrequiredNullableUuid.GetHashCode();
+
+                if (RequiredNullableArrayOfString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableArrayOfString.GetHashCode();
+
+                if (RequiredNullableBooleanProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableBooleanProp.GetHashCode();
+
+                if (RequiredNullableDateProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDateProp.GetHashCode();
+
+                if (RequiredNullableDatetimeProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableDatetimeProp.GetHashCode();
+
+                if (RequiredNullableEnumInteger != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumInteger.GetHashCode();
+
+                if (RequiredNullableEnumIntegerOnly != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumIntegerOnly.GetHashCode();
+
+                if (RequiredNullableEnumString != null)
+                    hashCode = (hashCode * 59) + RequiredNullableEnumString.GetHashCode();
+
+                if (RequiredNullableIntegerProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableIntegerProp.GetHashCode();
+
+                if (RequiredNullableOuterEnumDefaultValue != null)
+                    hashCode = (hashCode * 59) + RequiredNullableOuterEnumDefaultValue.GetHashCode();
+
+                if (RequiredNullableStringProp != null)
+                    hashCode = (hashCode * 59) + RequiredNullableStringProp.GetHashCode();
+
+                if (RequiredNullableUuid != null)
+                    hashCode = (hashCode * 59) + RequiredNullableUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Result.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Result
     /// </summary>
-    public partial class Result : IValidatableObject
+    public partial class Result : IEquatable<Result>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Result" /> class.
@@ -108,6 +108,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Result).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Result instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Result to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Result input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Return.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Model for testing reserved words
     /// </summary>
-    public partial class Return : IValidatableObject
+    public partial class Return : IEquatable<Return>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Return" /> class.
@@ -107,6 +107,51 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Return).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Return instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Return to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Return input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + Lock.GetHashCode();
+                if (Abstract != null)
+                    hashCode = (hashCode * 59) + Abstract.GetHashCode();
+
+                if (VarReturn != null)
+                    hashCode = (hashCode * 59) + VarReturn.GetHashCode();
+
+                if (Unsafe != null)
+                    hashCode = (hashCode * 59) + Unsafe.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Role report Hash
     /// </summary>
-    public partial class RolesReportsHash : IValidatableObject
+    public partial class RolesReportsHash : IEquatable<RolesReportsHash>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHash" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHash).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHash instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHash to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHash input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Role != null)
+                    hashCode = (hashCode * 59) + Role.GetHashCode();
+
+                if (RoleUuid != null)
+                    hashCode = (hashCode * 59) + RoleUuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// RolesReportsHashRole
     /// </summary>
-    public partial class RolesReportsHashRole : IValidatableObject
+    public partial class RolesReportsHashRole : IEquatable<RolesReportsHashRole>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as RolesReportsHashRole).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if RolesReportsHashRole instances are equal
+        /// </summary>
+        /// <param name="input">Instance of RolesReportsHashRole to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(RolesReportsHashRole input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ScaleneTriangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ScaleneTriangle
     /// </summary>
-    public partial class ScaleneTriangle : IValidatableObject
+    public partial class ScaleneTriangle : IEquatable<ScaleneTriangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleneTriangle" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ScaleneTriangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ScaleneTriangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ScaleneTriangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ScaleneTriangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Shape.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Shape
     /// </summary>
-    public partial class Shape : IValidatableObject
+    public partial class Shape : IEquatable<Shape>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Shape" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Shape).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Shape instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Shape to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Shape input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ShapeInterface
     /// </summary>
-    public partial class ShapeInterface : IValidatableObject
+    public partial class ShapeInterface : IEquatable<ShapeInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ShapeOrNull.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// The value may be a shape or the &#39;null&#39; value. This is introduced in OAS schema &gt;&#x3D; 3.1.
     /// </summary>
-    public partial class ShapeOrNull : IValidatableObject
+    public partial class ShapeOrNull : IEquatable<ShapeOrNull>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ShapeOrNull" /> class.
@@ -78,6 +78,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ShapeOrNull).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ShapeOrNull instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ShapeOrNull to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ShapeOrNull input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SimpleQuadrilateral.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SimpleQuadrilateral
     /// </summary>
-    public partial class SimpleQuadrilateral : IValidatableObject
+    public partial class SimpleQuadrilateral : IEquatable<SimpleQuadrilateral>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuadrilateral" /> class.
@@ -75,6 +75,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SimpleQuadrilateral).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SimpleQuadrilateral instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SimpleQuadrilateral to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SimpleQuadrilateral input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + QuadrilateralType.GetHashCode();
+                hashCode = (hashCode * 59) + ShapeType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// SpecialModelName
     /// </summary>
-    public partial class SpecialModelName : IValidatableObject
+    public partial class SpecialModelName : IEquatable<SpecialModelName>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecialModelName" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as SpecialModelName).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if SpecialModelName instances are equal
+        /// </summary>
+        /// <param name="input">Instance of SpecialModelName to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(SpecialModelName input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (VarSpecialModelName != null)
+                    hashCode = (hashCode * 59) + VarSpecialModelName.GetHashCode();
+
+                if (SpecialPropertyName != null)
+                    hashCode = (hashCode * 59) + SpecialPropertyName.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Tag.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Tag
     /// </summary>
-    public partial class Tag : IValidatableObject
+    public partial class Tag : IEquatable<Tag>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Tag" /> class.
@@ -89,6 +89,47 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Tag).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Tag instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Tag to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Tag input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (Name != null)
+                    hashCode = (hashCode * 59) + Name.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordList
     /// </summary>
-    public partial class TestCollectionEndingWithWordList : IValidatableObject
+    public partial class TestCollectionEndingWithWordList : IEquatable<TestCollectionEndingWithWordList>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordList).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordList instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordList to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordList input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Value != null)
+                    hashCode = (hashCode * 59) + Value.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestCollectionEndingWithWordListObject
     /// </summary>
-    public partial class TestCollectionEndingWithWordListObject : IValidatableObject
+    public partial class TestCollectionEndingWithWordListObject : IEquatable<TestCollectionEndingWithWordListObject>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestCollectionEndingWithWordListObject).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestCollectionEndingWithWordListObject instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestCollectionEndingWithWordListObject to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestCollectionEndingWithWordListObject input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (TestCollectionEndingWithWordList != null)
+                    hashCode = (hashCode * 59) + TestCollectionEndingWithWordList.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestDescendants.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestDescendants
     /// </summary>
-    public partial class TestDescendants : IValidatableObject
+    public partial class TestDescendants : IEquatable<TestDescendants>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestDescendants" /> class.
@@ -140,6 +140,43 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestDescendants).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestDescendants instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestDescendants to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestDescendants input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + AlternativeName.GetHashCode();
+                hashCode = (hashCode * 59) + ObjectType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestInlineFreeformAdditionalPropertiesRequest
     /// </summary>
-    public partial class TestInlineFreeformAdditionalPropertiesRequest : IValidatableObject
+    public partial class TestInlineFreeformAdditionalPropertiesRequest : IEquatable<TestInlineFreeformAdditionalPropertiesRequest>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
@@ -73,6 +73,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestInlineFreeformAdditionalPropertiesRequest).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestInlineFreeformAdditionalPropertiesRequest instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestInlineFreeformAdditionalPropertiesRequest to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestInlineFreeformAdditionalPropertiesRequest input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (SomeProperty != null)
+                    hashCode = (hashCode * 59) + SomeProperty.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TestResult.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TestResult
     /// </summary>
-    public partial class TestResult : IValidatableObject
+    public partial class TestResult : IEquatable<TestResult>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestResult" /> class.
@@ -107,6 +107,50 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TestResult).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TestResult instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TestResult to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TestResult input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (Code != null)
+                    hashCode = (hashCode * 59) + Code.GetHashCode();
+
+                if (Data != null)
+                    hashCode = (hashCode * 59) + Data.GetHashCode();
+
+                if (Uuid != null)
+                    hashCode = (hashCode * 59) + Uuid.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Triangle.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Triangle
     /// </summary>
-    public partial class Triangle : IValidatableObject
+    public partial class Triangle : IEquatable<Triangle>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Triangle" /> class.
@@ -93,6 +93,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Triangle).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Triangle instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Triangle to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Triangle input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/TriangleInterface.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// TriangleInterface
     /// </summary>
-    public partial class TriangleInterface : IValidatableObject
+    public partial class TriangleInterface : IEquatable<TriangleInterface>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TriangleInterface" /> class.
@@ -66,6 +66,42 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as TriangleInterface).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if TriangleInterface instances are equal
+        /// </summary>
+        /// <param name="input">Instance of TriangleInterface to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(TriangleInterface input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + TriangleType.GetHashCode();
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/User.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// User
     /// </summary>
-    public partial class User : IValidatableObject
+    public partial class User : IEquatable<User>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="User" /> class.
@@ -254,6 +254,77 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as User).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if User instances are equal
+        /// </summary>
+        /// <param name="input">Instance of User to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(User input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (AnyTypeProp != null)
+                    hashCode = (hashCode * 59) + AnyTypeProp.GetHashCode();
+
+                if (AnyTypePropNullable != null)
+                    hashCode = (hashCode * 59) + AnyTypePropNullable.GetHashCode();
+
+                if (Email != null)
+                    hashCode = (hashCode * 59) + Email.GetHashCode();
+
+                if (FirstName != null)
+                    hashCode = (hashCode * 59) + FirstName.GetHashCode();
+
+                if (Id != null)
+                    hashCode = (hashCode * 59) + Id.GetHashCode();
+
+                if (LastName != null)
+                    hashCode = (hashCode * 59) + LastName.GetHashCode();
+
+                if (ObjectWithNoDeclaredProps != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredProps.GetHashCode();
+
+                if (ObjectWithNoDeclaredPropsNullable != null)
+                    hashCode = (hashCode * 59) + ObjectWithNoDeclaredPropsNullable.GetHashCode();
+
+                if (Password != null)
+                    hashCode = (hashCode * 59) + Password.GetHashCode();
+
+                if (Phone != null)
+                    hashCode = (hashCode * 59) + Phone.GetHashCode();
+
+                if (UserStatus != null)
+                    hashCode = (hashCode * 59) + UserStatus.GetHashCode();
+
+                if (Username != null)
+                    hashCode = (hashCode * 59) + Username.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Whale.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Whale
     /// </summary>
-    public partial class Whale : IValidatableObject
+    public partial class Whale : IEquatable<Whale>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Whale" /> class.
@@ -98,6 +98,48 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Whale).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Whale instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Whale to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Whale input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (HasBaleen != null)
+                    hashCode = (hashCode * 59) + HasBaleen.GetHashCode();
+
+                if (HasTeeth != null)
+                    hashCode = (hashCode * 59) + HasTeeth.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/Zebra.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Zebra
     /// </summary>
-    public partial class Zebra : IValidatableObject
+    public partial class Zebra : IEquatable<Zebra>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Zebra" /> class.
@@ -162,6 +162,45 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as Zebra).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if Zebra instances are equal
+        /// </summary>
+        /// <param name="input">Instance of Zebra to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(Zebra input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                hashCode = (hashCode * 59) + ClassName.GetHashCode();
+                if (Type != null)
+                    hashCode = (hashCode * 59) + Type.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/ZeroBasedEnumClass.cs
@@ -27,7 +27,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// ZeroBasedEnumClass
     /// </summary>
-    public partial class ZeroBasedEnumClass : IValidatableObject
+    public partial class ZeroBasedEnumClass : IEquatable<ZeroBasedEnumClass>, IValidatableObject
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ZeroBasedEnumClass" /> class.
@@ -139,6 +139,44 @@ namespace Org.OpenAPITools.Model
             sb.Append("  AdditionalProperties: ").Append(AdditionalProperties).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as ZeroBasedEnumClass).AreEqual;
+        }
+
+        /// <summary>
+        /// Returns true if ZeroBasedEnumClass instances are equal
+        /// </summary>
+        /// <param name="input">Instance of ZeroBasedEnumClass to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals(ZeroBasedEnumClass input)
+        {
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = 41;
+                if (ZeroBasedEnum != null)
+                    hashCode = (hashCode * 59) + ZeroBasedEnum.GetHashCode();
+
+                hashCode = (hashCode * 59) + AdditionalProperties.GetHashCode();
+
+                return hashCode;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
There was a dependency on readOnlyVars where you had to have some readOnlyVars in order for your model to inherit IEquatable. I removed that dependency and used allVars in order to create the .Equals and .GetHashCode method.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
