### PR TITLE
add curl handler pre-invoke-callback to c-libcurl

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.c.mustache
@@ -11,6 +11,7 @@ apiClient_t *apiClient_create() {
     apiClient->basePath = strdup("{{{basePath}}}");
     apiClient->sslConfig = NULL;
     apiClient->curlConfig = NULL;
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -67,6 +68,7 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
     apiClient->curlConfig->keepidle = 120;
     apiClient->curlConfig->keepintvl = 60;
 
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -154,6 +156,8 @@ void apiClient_free(apiClient_t *apiClient) {
         free(apiClient->curlConfig);
         apiClient->curlConfig = NULL;
     }
+
+    apiClient->curl_pre_invoke_func = NULL;
 
     free(apiClient);
 }
@@ -562,6 +566,10 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 curl_easy_setopt(handle, CURLOPT_TCP_KEEPINTVL, apiClient->curlConfig->keepintvl);
             }
             curl_easy_setopt(handle, CURLOPT_VERBOSE, apiClient->curlConfig->verbose);
+        }
+
+        if(apiClient->curl_pre_invoke_func) {
+            apiClient->curl_pre_invoke_func(handle);
         }
 
         res = curl_easy_perform(handle);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiClient.h.mustache
@@ -32,6 +32,7 @@ typedef struct apiClient_t {
     char *basePath;
     sslConfig_t *sslConfig;
     curlConfig_t *curlConfig;
+    void (*curl_pre_invoke_func)(CURL *);
     void *dataReceived;
     long dataReceivedLen;
     void (*data_callback_func)(void **, long *);

--- a/samples/client/others/c/bearerAuth/include/apiClient.h
+++ b/samples/client/others/c/bearerAuth/include/apiClient.h
@@ -32,6 +32,7 @@ typedef struct apiClient_t {
     char *basePath;
     sslConfig_t *sslConfig;
     curlConfig_t *curlConfig;
+    void (*curl_pre_invoke_func)(CURL *);
     void *dataReceived;
     long dataReceivedLen;
     void (*data_callback_func)(void **, long *);

--- a/samples/client/others/c/bearerAuth/src/apiClient.c
+++ b/samples/client/others/c/bearerAuth/src/apiClient.c
@@ -11,6 +11,7 @@ apiClient_t *apiClient_create() {
     apiClient->basePath = strdup("http://api.example.com/v1");
     apiClient->sslConfig = NULL;
     apiClient->curlConfig = NULL;
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -44,6 +45,7 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
     apiClient->curlConfig->keepidle = 120;
     apiClient->curlConfig->keepintvl = 60;
 
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -70,6 +72,8 @@ void apiClient_free(apiClient_t *apiClient) {
         free(apiClient->curlConfig);
         apiClient->curlConfig = NULL;
     }
+
+    apiClient->curl_pre_invoke_func = NULL;
 
     free(apiClient);
 }
@@ -417,6 +421,10 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 curl_easy_setopt(handle, CURLOPT_TCP_KEEPINTVL, apiClient->curlConfig->keepintvl);
             }
             curl_easy_setopt(handle, CURLOPT_VERBOSE, apiClient->curlConfig->verbose);
+        }
+
+        if(apiClient->curl_pre_invoke_func) {
+            apiClient->curl_pre_invoke_func(handle);
         }
 
         res = curl_easy_perform(handle);

--- a/samples/client/petstore/c-useJsonUnformatted/include/apiClient.h
+++ b/samples/client/petstore/c-useJsonUnformatted/include/apiClient.h
@@ -32,6 +32,7 @@ typedef struct apiClient_t {
     char *basePath;
     sslConfig_t *sslConfig;
     curlConfig_t *curlConfig;
+    void (*curl_pre_invoke_func)(CURL *);
     void *dataReceived;
     long dataReceivedLen;
     void (*data_callback_func)(void **, long *);

--- a/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
+++ b/samples/client/petstore/c-useJsonUnformatted/src/apiClient.c
@@ -11,6 +11,7 @@ apiClient_t *apiClient_create() {
     apiClient->basePath = strdup("http://petstore.swagger.io/v2");
     apiClient->sslConfig = NULL;
     apiClient->curlConfig = NULL;
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -46,6 +47,7 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
     apiClient->curlConfig->keepidle = 120;
     apiClient->curlConfig->keepintvl = 60;
 
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -97,6 +99,8 @@ void apiClient_free(apiClient_t *apiClient) {
         free(apiClient->curlConfig);
         apiClient->curlConfig = NULL;
     }
+
+    apiClient->curl_pre_invoke_func = NULL;
 
     free(apiClient);
 }
@@ -454,6 +458,10 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 curl_easy_setopt(handle, CURLOPT_TCP_KEEPINTVL, apiClient->curlConfig->keepintvl);
             }
             curl_easy_setopt(handle, CURLOPT_VERBOSE, apiClient->curlConfig->verbose);
+        }
+
+        if(apiClient->curl_pre_invoke_func) {
+            apiClient->curl_pre_invoke_func(handle);
         }
 
         res = curl_easy_perform(handle);

--- a/samples/client/petstore/c/include/apiClient.h
+++ b/samples/client/petstore/c/include/apiClient.h
@@ -32,6 +32,7 @@ typedef struct apiClient_t {
     char *basePath;
     sslConfig_t *sslConfig;
     curlConfig_t *curlConfig;
+    void (*curl_pre_invoke_func)(CURL *);
     void *dataReceived;
     long dataReceivedLen;
     void (*data_callback_func)(void **, long *);

--- a/samples/client/petstore/c/src/apiClient.c
+++ b/samples/client/petstore/c/src/apiClient.c
@@ -11,6 +11,7 @@ apiClient_t *apiClient_create() {
     apiClient->basePath = strdup("http://petstore.swagger.io/v2");
     apiClient->sslConfig = NULL;
     apiClient->curlConfig = NULL;
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -46,6 +47,7 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
     apiClient->curlConfig->keepidle = 120;
     apiClient->curlConfig->keepintvl = 60;
 
+    apiClient->curl_pre_invoke_func = NULL;
     apiClient->dataReceived = NULL;
     apiClient->dataReceivedLen = 0;
     apiClient->data_callback_func = NULL;
@@ -97,6 +99,8 @@ void apiClient_free(apiClient_t *apiClient) {
         free(apiClient->curlConfig);
         apiClient->curlConfig = NULL;
     }
+
+    apiClient->curl_pre_invoke_func = NULL;
 
     free(apiClient);
 }
@@ -454,6 +458,10 @@ void apiClient_invoke(apiClient_t    *apiClient,
                 curl_easy_setopt(handle, CURLOPT_TCP_KEEPINTVL, apiClient->curlConfig->keepintvl);
             }
             curl_easy_setopt(handle, CURLOPT_VERBOSE, apiClient->curlConfig->verbose);
+        }
+
+        if(apiClient->curl_pre_invoke_func) {
+            apiClient->curl_pre_invoke_func(handle);
         }
 
         res = curl_easy_perform(handle);

--- a/samples/client/petstore/c/unit-tests/manual-PetAPI.c
+++ b/samples/client/petstore/c/unit-tests/manual-PetAPI.c
@@ -2,8 +2,10 @@
     #include <stdlib.h>
     #include <string.h>
     #include <assert.h>
+    #include <curl/curl.h>
     #include "../api/PetAPI.h"
 
+    void preInvokeFunc(CURL *curl);
 
     #define EXAMPLE_CATEGORY_NAME "Example Category"
     #define EXAMPLE_CATEGORY_ID 5
@@ -16,10 +18,15 @@
     #define EXAMPLE_TAG_2_ID 542353
     #define EXAMPLE_PET_ID 1234 // Set to 0 to generate a new pet
 
+void preInvokeFunc(CURL *curl) {
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    printf("CURL pre-invoke function called - verbose mode enabled\n");
+}
 
 int main() {
 // Add pet test
 	apiClient_t *apiClient = apiClient_create();
+	apiClient->curl_pre_invoke_func = preInvokeFunc;
 
 	char *categoryName = malloc(strlen(EXAMPLE_CATEGORY_NAME) + 1);
 	strcpy(categoryName, EXAMPLE_CATEGORY_NAME);


### PR DESCRIPTION
Hello,

As proposed in my previous PR (https://github.com/OpenAPITools/openapi-generator/pull/21613#issuecomment-3113483836), I've implemented a callback just before the `curl_easy_perform(handle)`.
In this way programmers have a way to modify the curl handler as they want without limits.
I've tested it using `manual-PetAPI.c` unit-test.

<img width="725" height="380" alt="image" src="https://github.com/user-attachments/assets/21441599-2b9b-4b82-8dda-3efaee28e45e" />


Best,

hirish

C Committee: @zhemant (2018/11) @ityuhui (2019/12) @michelealbano (2020/03) @eafer (2024/12)
Also @wing328 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
