### PR TITLE
[Bug][typescript-fetch] Typescript fetch one of addtl props imports

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -787,21 +787,26 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                 .map(CodegenComposedSchemas::getOneOf)
                 .orElse(Collections.emptyList());
 
+        // create a set of any non-primitive types used in the oneOf schemas which will need to
+        // be imported.
         cm.oneOfModels = oneOfsList.stream()
-                .filter(CodegenProperty::getIsModel)
+                .filter(cp -> !cp.getIsPrimitiveType())
                 .map(CodegenProperty::getBaseType)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(TreeSet::new));
 
+        // create a set of any complex, inner types used by arrays in the oneOf schema (e.g. if
+        // the oneOf uses Array<Foo>, Foo needs to be imported).
         cm.oneOfArrays = oneOfsList.stream()
                 .filter(CodegenProperty::getIsArray)
                 .map(CodegenProperty::getComplexType)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(TreeSet::new));
 
+        // create a set of primitive types used in the oneOf schemas for use in the to & from
+        // typed JSON methods.
         cm.oneOfPrimitives = oneOfsList.stream()
                 .filter(CodegenProperty::getIsPrimitiveType)
-                .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(HashSet::new));
 
         if (!cm.oneOf.isEmpty()) {
@@ -1485,6 +1490,9 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
         @Getter @Setter
         public Set<String> modelImports = new TreeSet<String>();
 
+        // oneOfModels, oneOfArrays & oneOfPrimitives contain a list of types used in schemas
+        // composed with oneOf and are used to define the import list and the to & from
+        // 'TypedJSON' conversion methods in the composed model classes.
         @Getter @Setter
         public Set<String> oneOfModels = new TreeSet<>();
         @Getter @Setter

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -787,10 +787,10 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
                 .map(CodegenComposedSchemas::getOneOf)
                 .orElse(Collections.emptyList());
 
-        // create a set of any non-primitive types used in the oneOf schemas which will need to
-        // be imported.
+        // create a set of any non-primitive, non-array types used in the oneOf schemas which will
+        // need to be imported.
         cm.oneOfModels = oneOfsList.stream()
-                .filter(cp -> !cp.getIsPrimitiveType())
+                .filter(cp -> !cp.getIsPrimitiveType() && !cp.getIsArray())
                 .map(CodegenProperty::getBaseType)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(TreeSet::new));

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -441,6 +441,7 @@ public class TypeScriptFetchClientCodegenTest {
         );
         TestUtils.assertFileContains(testResponse, "import type { OptionOne } from './OptionOne'");
         TestUtils.assertFileContains(testResponse, "import type { OptionTwo } from './OptionTwo'");
+        TestUtils.assertFileContains(testResponse, "import type { OptionThree } from './OptionThree'");
     }
 
     private static File generate(

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.models.media.MapSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.util.Collections;
+import java.util.Locale;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
@@ -402,6 +404,43 @@ public class TypeScriptFetchClientCodegenTest {
         TestUtils.assertFileContains(testDiscriminatorResponse, "import type { OptionOne } from './OptionOne'");
         TestUtils.assertFileContains(testDiscriminatorResponse, "import type { OptionTwo } from './OptionTwo'");
         TestUtils.assertFileContains(testDiscriminatorResponse, "export type TestDiscriminatorResponse = { discriminatorField: 'optionOne' } & OptionOne | { discriminatorField: 'optionTwo' } & OptionTwo");
+    }
+
+    /**
+     * Issue #21587
+     * When using oneOf, the Typescript Fetch generator should import modelled types except for
+     * types built-in primitive types, even those marked with additional properties.
+     */
+    @Test()
+    public void testOneOfModelsImportNonPrimitiveTypes() throws IOException {
+        File output = generate(
+            Collections.emptyMap(),
+            "src/test/resources/3_0/typescript-fetch/issue_21587.yaml"
+        );
+
+        Path testResponse = Paths.get(output + "/models/OneOfResponse.ts");
+        TestUtils.assertFileExists(testResponse);
+
+        // Primitive built-in types should not be included. This list is based off the type mappings
+        // and language specific primitive keywords established in the AbstractTypeScriptClientCodegen
+        Stream.of(
+            "Set",
+            "Array",
+            "boolean",
+            "string",
+            "number",
+            "object",
+            "any",
+            "Date",
+            "Error"
+        ).forEach(primitiveType ->
+            TestUtils.assertFileNotContains(
+                testResponse,
+                String.format(Locale.ROOT, "import type { %s } from './%s'", primitiveType, primitiveType)
+            )
+        );
+        TestUtils.assertFileContains(testResponse, "import type { OptionOne } from './OptionOne'");
+        TestUtils.assertFileContains(testResponse, "import type { OptionTwo } from './OptionTwo'");
     }
 
     private static File generate(

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_21587.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_21587.yaml
@@ -20,6 +20,9 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/OptionOne'
                   - $ref: '#/components/schemas/OptionTwo'
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/OptionThree'
                   - type: string
                     enum:
                       - "fixed-value-a"
@@ -67,3 +70,10 @@ components:
       properties:
         propTwo:
           type: string
+    OptionThree:
+      type: object
+      title: OptionThree
+      properties:
+        propThree:
+          type: boolean
+      additionalProperties: true

--- a/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_21587.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/typescript-fetch/issue_21587.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.1
+info:
+  title: Example API
+  version: 1.0.0
+paths:
+  /api/endpoint:
+    get:
+      operationId: GetEndpoint
+      summary: Get endpoint
+      tags:
+        - Examples
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                title: OneOfResponse
+                oneOf:
+                  - $ref: '#/components/schemas/OptionOne'
+                  - $ref: '#/components/schemas/OptionTwo'
+                  - type: string
+                    enum:
+                      - "fixed-value-a"
+                      - "fixed-value-b"
+                      - "fixed-value-c"
+                  - type: boolean
+                  - type: number
+                  - type: string
+                    format: date
+                  - type: string
+                    format: date-time
+                  - type: integer
+                    format: int64
+                    enum: [10, 20, 30]
+                  - type: array
+                    items:
+                      type: number
+                  - type: array
+                    items:
+                      type: object
+                  - type: array
+                    items:
+                      type: string
+                      enum:
+                        - "oneof-array-enum-a"
+                        - "oneof-array-enum-b"
+                        - "oneof-array-enum-c"
+                  - type: array
+                    items:
+                      type: number
+                    uniqueItems: true
+
+components:
+  schemas:
+    OptionOne:
+      type: object
+      title: OptionOne
+      properties:
+        propOne:
+          type: number
+      additionalProperties: true
+    OptionTwo:
+      type: object
+      title: OptionTwo
+      properties:
+        propTwo:
+          type: string

--- a/modules/openapi-generator/src/test/resources/bugs/issue_21259.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_21259.yaml
@@ -49,7 +49,6 @@ components:
           items:
             type: string
             enum:
-              # It seems enums within arrays don't work. Leaving this here, though
               - "oneof-array-enum-a"
               - "oneof-array-enum-b"
               - "oneof-array-enum-c"

--- a/modules/openapi-generator/src/test/resources/bugs/issue_21259.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_21259.yaml
@@ -49,6 +49,7 @@ components:
           items:
             type: string
             enum:
+              # It seems enums within arrays don't work. Leaving this here, though
               - "oneof-array-enum-a"
               - "oneof-array-enum-b"
               - "oneof-array-enum-c"


### PR DESCRIPTION
Closes #21587

The typescript-fetch client generator has a bug when generating model code where the list of imports will be missing items if the OAS spec includes a schema a `oneOf` section and the `oneOf` schema has `additionalProperties: true`. 

An example OAS would be 
```yaml
openapi: 3.0.1
info:
  title: Example API
  version: 1.0.0
paths:
  /api/endpoint:
    get:
      operationId: GetEndpoint
      responses:
        '200':
          description: Successful Response
          content:
            application/json:
              schema:
                type: object
                title: OneOfResponse
                oneOf:
                  - $ref: '#/components/schemas/OptionOne'
                  - $ref: '#/components/schemas/OptionTwo'
components:
  schemas:
    OptionOne:
      type: object
      title: OptionOne
      properties:
        propOne:
          type: number
      additionalProperties: true
    OptionTwo:
      type: object
      title: OptionTwo
      properties:
        propTwo:
          type: string
```

The model code generated for `OneOfResponse.ts` includes the following type:
`export type OneOfResponse = OptionOne | OptionTwo;`

However, the imports in `OneOfResponse.ts` will only have imports for `OptionTwo`.

The underlying issue is that [TypeScriptFetchClientCodegen.processCodeGenModel](https://github.com/OpenAPITools/openapi-generator/blob/ef22749345b6a34994190242134a812566f7f39b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java#L790) is creating a set of model imports by filtering out schemas using the `CodegenProperty::getIsModel` method.  

```java
        cm.oneOfModels = oneOfsList.stream()
                .filter(CodegenProperty::getIsModel)
                .map(CodegenProperty::getBaseType)
                .filter(Objects::nonNull)
                .collect(Collectors.toCollection(TreeSet::new));
```

Schemas which have additional properties set will not be marked as models because  [IJsonSchemaValidationProperties.setTypeProperties](https://github.com/OpenAPITools/openapi-generator/blob/ef22749345b6a34994190242134a812566f7f39b/modules/openapi-generator/src/main/java/org/openapitools/codegen/IJsonSchemaValidationProperties.java#L282) because [ModelUtils.isModelWithPropertiesOnly](https://github.com/OpenAPITools/openapi-generator/blob/ef22749345b6a34994190242134a812566f7f39b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java#L810) evaluates to false due to the presence of the additional properties.

That probably wasn't the intention of the original PR #21057 (addressing #19909), which was to filter out imports for built-in language primitive types like `string`, `object`, `Array`, etc.

This PR changes the filter used in `TypeScriptFetchClientCodegen` to use `.filter(cp -> !cp.getIsPrimitiveType() && !cp.isArrayType())` to filter out schemas for language built-in types or arrays.  

The language built-in types are defined in `AbstractTypeScriptClientCodegen` as a combination between the -[languageSpecificPrimitives](https://github.com/OpenAPITools/openapi-generator/blob/7c1dce4756cd7c3bd00da7dcb77b20ab34350db6/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java#L315) variable and the default [typeMapping](https://github.com/OpenAPITools/openapi-generator/blob/7c1dce4756cd7c3bd00da7dcb77b20ab34350db6/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java#L344).  Types will be mapped first using the `typeMapping` map and then be compared against the list of language specific primitives.

I've added a unit test for this bug using the OAS `issue_21587.yaml` which uses a `oneOf` composed of a schema with `additionalProperties: true` and also a bunch of primitive types which should hit most of primitives available with the default type mappings.

One area I wasn't entirely 100% on is the use of `Set` as a primitive.  My understanding is that the `Set` type is only available starting with ES6.  The typescript client generators have a setting, `supportsES6`, which is false by default.  I'm not sure how valid it is to have `Set` as a language primitive type if `supportsES6` is false.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Typescript: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
Prior work: PR #21057 - @GregoryMerlet  