### PR TITLE
 Fix [OpenAPI 3.1] preserve sibling properties on $ref (fixes #20304)

### DIFF
--- a/modules/openapi-generator/src/test/resources/3_1/issue_20304.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_20304.yaml
@@ -1,0 +1,59 @@
+# src/test/resources/3_1/issue_20304_siblings.yaml
+openapi: 3.1.0
+info:
+  title: Test siblings
+  version: 1.0.0
+components:
+  schemas:
+    ModelWithTitledProperties:
+      type: object
+      properties:
+        # 1) simple $ref
+        simpleProperty:
+          $ref: '#/components/schemas/Inner'
+          title: Simple-Property-Title
+          description: Simple-Property-Description
+
+        # 2) allOf wrapping a $ref
+        allOfRefProperty:
+          allOf:
+            - $ref: '#/components/schemas/Inner'
+          title: All-Of-Ref-Property-Title
+          description: All-Of-Ref-Property-Description
+
+        # 3) array alias
+        arrayRefProperty:
+          $ref: '#/components/schemas/ArrayOfInner'
+          title: Array-Ref-Property-Title
+          description: Array-Ref-Property-Description
+
+        # 4) map alias
+        mapRefProperty:
+          $ref: '#/components/schemas/MapOfInner'
+          title: Map-Ref-Property-Title
+          description: Map-Ref-Property-Description
+
+        # 5) object-model alias
+        objectRefProperty:
+          $ref: '#/components/schemas/ObjectInner'
+          title: Object-Ref-Property-Title
+          description: Object-Ref-Property-Description
+
+    Inner:
+      type: string
+
+    ArrayOfInner:
+      type: array
+      items:
+        $ref: '#/components/schemas/Inner'
+
+    MapOfInner:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/Inner'
+
+    ObjectInner:
+      type: object
+      properties:
+        foo:
+          type: integer


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
**Core changes**
 - Fixed #20304 
 - Ensure all ref sibling properties from OAS 3.1 are not lost after resolving schema.
 - This PR creates `mergeSiblingFields()` function (in `ModelUtils`) to copy every non-null OAS 3.1 sibling keyword from the wrapper onto the resolved definition, and created `deepCopy()` helper to preserve concrete schema subtypes (so flags like isNull/isDate still work).
 
**Added tests:**
-  A comprehensive smoke test (DefaultCodegenTest.testRefSiblingMergingOnAllAliasForms) was added to assert that every allowed sibling property is carried through on a variety of alias forms ($ref, allOf, free-form object, array alias, map alias, primitive alias).

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
