### PR TITLE
[BUG][typescript-fetch] Default case for oneOf serialization method returning undefined variable.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -142,7 +142,7 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
             return Object.assign({}, {{modelName}}ToJSON(value), { {{discriminator.propertyName}}: '{{mappingName}}' } as const);
 {{/discriminator.mappedModels}}
         default:
-            return json;
+            return value;
     }
 {{/discriminator}}
 {{^discriminator}}

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestDiscriminatorResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestDiscriminatorResponse.ts
@@ -66,7 +66,7 @@ export function TestDiscriminatorResponseToJSONTyped(value?: TestDiscriminatorRe
         case 'optionTwo':
             return Object.assign({}, OptionTwoToJSON(value), { discriminatorField: 'optionTwo' } as const);
         default:
-            return json;
+            return value;
     }
 }
 


### PR DESCRIPTION
Closes #21668 

@ThorinEk reported a problem in [the discussion of Issue 21587](https://github.com/OpenAPITools/openapi-generator/issues/21587#issuecomment-3110136876) that relates to the default case in the switch statement generated for a oneOf model when the model has a discriminator.

```typescript
export function ExecuteCommandPostRequestToJSONTyped(value?: ExecuteCommandPostRequest | null, ignoreDiscriminator: boolean = false): any {
    if (value == null) {
        return value;
    }
    switch (value['command']) {
        ...  // removed
        default:
            // this should be return value since the variable json is undefined.
            return json;
    }
}
```

It looks like this bug was introduced in the PR for #20983

I did not implement a unit test for this bug because the typescript unit tests are asserting on the failure to match the presence of a string in a specific file.  I've looked through the codebase and it looks like there has been some work by @DavidGrath to use antlr to build a Kotlin parser for testing for proper syntax.  This can probably be done for Typescript & Javascript too.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Typescript: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
Prior work: PR #20983 - @aeneasr 