### PR TITLE
[PHP] Fix type casting in HeaderSelector::getHeaderAndWeight

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/HeaderSelector.mustache
@@ -143,7 +143,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [

--- a/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php/HeaderSelector.mustache
@@ -173,7 +173,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [

--- a/samples/client/echo_api/php-nextgen-streaming/src/HeaderSelector.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/HeaderSelector.php
@@ -152,7 +152,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [

--- a/samples/client/echo_api/php-nextgen/src/HeaderSelector.php
+++ b/samples/client/echo_api/php-nextgen/src/HeaderSelector.php
@@ -152,7 +152,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/HeaderSelector.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/HeaderSelector.php
@@ -151,7 +151,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/HeaderSelector.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/HeaderSelector.php
@@ -181,7 +181,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [

--- a/samples/client/petstore/php/psr-18/lib/HeaderSelector.php
+++ b/samples/client/petstore/php/psr-18/lib/HeaderSelector.php
@@ -181,7 +181,7 @@ class HeaderSelector
         if (preg_match('/(.*);\s*q=(1(?:\.0+)?|0\.\d+)$/', $header, $outputArray) === 1) {
             $headerData = [
                 'header' => $outputArray[1],
-                'weight' => (int)($outputArray[2] * 1000),
+                'weight' => (int)$outputArray[2] * 1000,
             ];
         } else {
             $headerData = [


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
