### PR TITLE
[csharp][generichost] Fix response testing when dataType missing

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/api_test.mustache
@@ -37,14 +37,18 @@ namespace {{packageName}}.Test.{{apiPackage}}
             {{#allParams}}
             {{^required}}Client.Option<{{/required}}{{{dataType}}}{{>NullConditionalParameter}}{{^required}}>{{/required}} {{paramName}} = default{{nrt!}};
             {{/allParams}}
-            {{#returnType}}
+            {{#responses}}
+            {{#-first}}
+            {{#dataType}}
             var response = await _instance.{{operationId}}Async({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
-            var model = response.{{#lambda.first}}{{#responses}}{{vendorExtensions.x-http-status}}  {{/responses}}{{/lambda.first}}();
+            var model = response.{{vendorExtensions.x-http-status}}();
             Assert.IsType<{{{.}}}>(model);
-            {{/returnType}}
-            {{^returnType}}
+            {{/dataType}}
+            {{^dataType}}
             await _instance.{{operationId}}Async({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
-            {{/returnType}}
+            {{/dataType}}
+            {{/-first}}
+            {{/responses}}
         }
         {{/operation}}
         {{/operations}}

--- a/modules/openapi-generator/src/test/resources/3_0/csharp/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/csharp/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml
@@ -612,6 +612,19 @@ paths:
         - api_key_query: []
       requestBody:
         $ref: '#/components/requestBodies/Client'
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        '301':
+          description: redirect
+          # response that does not provide any content
+        default:
+          description: default
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Bar'
   /fake:
     patch:
       tags:

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/api/openapi.yaml
@@ -639,6 +639,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -953,6 +1012,207 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+                    httpRequestMessageLocalVar.Method = new HttpMethod("GET");
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new RedirectOrDefaultApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : default;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault(out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -953,6 +1012,207 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+                    httpRequestMessageLocalVar.Method = new HttpMethod("GET");
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new RedirectOrDefaultApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : default;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault(out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/api/openapi.yaml
@@ -639,6 +639,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -953,6 +1012,207 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+                    httpRequestMessageLocalVar.Method = new HttpMethod("GET");
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new RedirectOrDefaultApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : default;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault(out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -953,6 +1012,207 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+                    httpRequestMessageLocalVar.Method = new HttpMethod("GET");
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new RedirectOrDefaultApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : default;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault(out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/api/openapi.yaml
@@ -639,6 +639,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -955,6 +1014,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -108,6 +108,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>?&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -177,6 +198,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string?>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -266,6 +305,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs>? OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs>? OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -957,6 +1016,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string? acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string? Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string? result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -955,6 +1014,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -108,6 +108,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>?&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -177,6 +198,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string?>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -266,6 +305,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs>? OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs>? OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -957,6 +1016,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string? acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string? Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string? result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/api/openapi.yaml
@@ -639,6 +639,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -955,6 +1014,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -108,6 +108,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>?&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -177,6 +198,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string?>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -266,6 +305,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs>? OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs>? OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -957,6 +1016,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string? acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string? Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string? result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -106,6 +106,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -175,6 +196,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -264,6 +303,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -955,6 +1014,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -108,6 +108,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>?&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -177,6 +198,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string?>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -266,6 +305,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs>? OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs>? OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -957,6 +1016,208 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse?> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress!.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string? acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+
+                    httpRequestMessageLocalVar.Method = HttpMethod.Get;
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string? Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : null;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault([NotNullWhen(true)]out string? result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/docs/apis/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -103,6 +104,37 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../README.md#documentation-for-models) [[Back to README]](../../README.md)
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools.Test/Api/DefaultApiTests.cs
@@ -83,6 +83,15 @@ namespace Org.OpenAPITools.Test.Api
         }
 
         /// <summary>
+        /// Test RedirectOrDefault
+        /// </summary>
+        [Fact (Skip = "not implemented")]
+        public async Task RedirectOrDefaultAsyncTest()
+        {
+            await _instance.RedirectOrDefaultAsync();
+        }
+
+        /// <summary>
         /// Test RolesReportGet
         /// </summary>
         [Fact (Skip = "not implemented")]
@@ -90,7 +99,7 @@ namespace Org.OpenAPITools.Test.Api
         {
             var response = await _instance.RolesReportGetAsync();
             var model = response.Ok();
-            Assert.IsType<List<List<RolesReportsHash>>>(model);
+            Assert.IsType<List<List>>(model);
         }
 
         /// <summary>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -105,6 +105,27 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns><see cref="Task"/>&lt;<see cref="IRolesReportGetApiResponse"/>&gt;</returns>
         Task<IRolesReportGetApiResponse> RolesReportGetAsync(System.Threading.CancellationToken cancellationToken = default);
 
@@ -174,6 +195,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <returns></returns>
         bool IsOk { get; }
+    }
+
+    /// <summary>
+    /// The <see cref="IRedirectOrDefaultApiResponse"/>
+    /// </summary>
+    public interface IRedirectOrDefaultApiResponse : Org.OpenAPITools.Client.IApiResponse, IDefault<string>
+    {
+        /// <summary>
+        /// Returns true if the response is 301 MovedPermanently
+        /// </summary>
+        /// <returns></returns>
+        bool IsMovedPermanently { get; }
+
+        /// <summary>
+        /// Returns true if the response is the default response type
+        /// </summary>
+        /// <returns></returns>
+        bool IsDefault { get; }
     }
 
     /// <summary>
@@ -263,6 +302,26 @@ namespace Org.OpenAPITools.Api
         internal void ExecuteOnErrorHello(Exception exception)
         {
             OnErrorHello?.Invoke(this, new ExceptionEventArgs(exception));
+        }
+
+        /// <summary>
+        /// The event raised after the server response
+        /// </summary>
+        public event EventHandler<ApiResponseEventArgs> OnRedirectOrDefault;
+
+        /// <summary>
+        /// The event raised after an error querying the server
+        /// </summary>
+        public event EventHandler<ExceptionEventArgs> OnErrorRedirectOrDefault;
+
+        internal void ExecuteOnRedirectOrDefault(DefaultApi.RedirectOrDefaultApiResponse apiResponse)
+        {
+            OnRedirectOrDefault?.Invoke(this, new ApiResponseEventArgs(apiResponse));
+        }
+
+        internal void ExecuteOnErrorRedirectOrDefault(Exception exception)
+        {
+            OnErrorRedirectOrDefault?.Invoke(this, new ExceptionEventArgs(exception));
         }
 
         /// <summary>
@@ -952,6 +1011,207 @@ namespace Org.OpenAPITools.Api
                 } catch (Exception e)
                 {
                     OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)200);
+                }
+
+                return result != null;
+            }
+
+            private void OnDeserializationErrorDefaultImplementation(Exception exception, HttpStatusCode httpStatusCode)
+            {
+                bool suppressDefaultLog = false;
+                OnDeserializationError(ref suppressDefaultLog, exception, httpStatusCode);
+                if (!suppressDefaultLog)
+                    Logger.LogError(exception, "An error occurred while deserializing the {code} response.", httpStatusCode);
+            }
+
+            partial void OnDeserializationError(ref bool suppressDefaultLog, Exception exception, HttpStatusCode httpStatusCode);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="apiResponseLocalVar"></param>
+        private void AfterRedirectOrDefaultDefaultImplementation(IRedirectOrDefaultApiResponse apiResponseLocalVar)
+        {
+            bool suppressDefaultLog = false;
+            AfterRedirectOrDefault(ref suppressDefaultLog, apiResponseLocalVar);
+            if (!suppressDefaultLog)
+                Logger.LogInformation("{0,-9} | {1} | {3}", (apiResponseLocalVar.DownloadedAt - apiResponseLocalVar.RequestedAt).TotalSeconds, apiResponseLocalVar.StatusCode, apiResponseLocalVar.Path);
+        }
+
+        /// <summary>
+        /// Processes the server response
+        /// </summary>
+        /// <param name="suppressDefaultLog"></param>
+        /// <param name="apiResponseLocalVar"></param>
+        partial void AfterRedirectOrDefault(ref bool suppressDefaultLog, IRedirectOrDefaultApiResponse apiResponseLocalVar);
+
+        /// <summary>
+        /// Logs exceptions that occur while retrieving the server response
+        /// </summary>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        private void OnErrorRedirectOrDefaultDefaultImplementation(Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar)
+        {
+            bool suppressDefaultLogLocalVar = false;
+            OnErrorRedirectOrDefault(ref suppressDefaultLogLocalVar, exceptionLocalVar, pathFormatLocalVar, pathLocalVar);
+            if (!suppressDefaultLogLocalVar)
+                Logger.LogError(exceptionLocalVar, "An error occurred while sending the request to the server.");
+        }
+
+        /// <summary>
+        /// A partial method that gives developers a way to provide customized exception handling
+        /// </summary>
+        /// <param name="suppressDefaultLogLocalVar"></param>
+        /// <param name="exceptionLocalVar"></param>
+        /// <param name="pathFormatLocalVar"></param>
+        /// <param name="pathLocalVar"></param>
+        partial void OnErrorRedirectOrDefault(ref bool suppressDefaultLogLocalVar, Exception exceptionLocalVar, string pathFormatLocalVar, string pathLocalVar);
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await RedirectOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns><see cref="Task"/>&lt;<see cref="IRedirectOrDefaultApiResponse"/>&gt;</returns>
+        public async Task<IRedirectOrDefaultApiResponse> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            UriBuilder uriBuilderLocalVar = new UriBuilder();
+
+            try
+            {
+                using (HttpRequestMessage httpRequestMessageLocalVar = new HttpRequestMessage())
+                {
+                    uriBuilderLocalVar.Host = HttpClient.BaseAddress.Host;
+                    uriBuilderLocalVar.Port = HttpClient.BaseAddress.Port;
+                    uriBuilderLocalVar.Scheme = HttpClient.BaseAddress.Scheme;
+                    uriBuilderLocalVar.Path = HttpClient.BaseAddress.AbsolutePath == "/"
+                        ? "/redirectOrDefault"
+                        : string.Concat(HttpClient.BaseAddress.AbsolutePath, "/redirectOrDefault");
+
+                    httpRequestMessageLocalVar.RequestUri = uriBuilderLocalVar.Uri;
+
+                    string[] acceptLocalVars = new string[] {
+                        "application/json"
+                    };
+
+                    string acceptLocalVar = ClientUtils.SelectHeaderAccept(acceptLocalVars);
+
+                    if (acceptLocalVar != null)
+                        httpRequestMessageLocalVar.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(acceptLocalVar));
+                    httpRequestMessageLocalVar.Method = new HttpMethod("GET");
+
+                    DateTime requestedAtLocalVar = DateTime.UtcNow;
+
+                    using (HttpResponseMessage httpResponseMessageLocalVar = await HttpClient.SendAsync(httpRequestMessageLocalVar, cancellationToken).ConfigureAwait(false))
+                    {
+                        string responseContentLocalVar = await httpResponseMessageLocalVar.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                        ILogger<RedirectOrDefaultApiResponse> apiResponseLoggerLocalVar = LoggerFactory.CreateLogger<RedirectOrDefaultApiResponse>();
+
+                        RedirectOrDefaultApiResponse apiResponseLocalVar = new RedirectOrDefaultApiResponse(apiResponseLoggerLocalVar, httpRequestMessageLocalVar, httpResponseMessageLocalVar, responseContentLocalVar, "/redirectOrDefault", requestedAtLocalVar, _jsonSerializerOptions);
+
+                        AfterRedirectOrDefaultDefaultImplementation(apiResponseLocalVar);
+
+                        Events.ExecuteOnRedirectOrDefault(apiResponseLocalVar);
+
+                        return apiResponseLocalVar;
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                OnErrorRedirectOrDefaultDefaultImplementation(e, "/redirectOrDefault", uriBuilderLocalVar.Path);
+                Events.ExecuteOnErrorRedirectOrDefault(e);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The <see cref="RedirectOrDefaultApiResponse"/>
+        /// </summary>
+        public partial class RedirectOrDefaultApiResponse : Org.OpenAPITools.Client.ApiResponse, IRedirectOrDefaultApiResponse
+        {
+            /// <summary>
+            /// The logger
+            /// </summary>
+            public ILogger<RedirectOrDefaultApiResponse> Logger { get; }
+
+            /// <summary>
+            /// The <see cref="RedirectOrDefaultApiResponse"/>
+            /// </summary>
+            /// <param name="logger"></param>
+            /// <param name="httpRequestMessage"></param>
+            /// <param name="httpResponseMessage"></param>
+            /// <param name="rawContent"></param>
+            /// <param name="path"></param>
+            /// <param name="requestedAt"></param>
+            /// <param name="jsonSerializerOptions"></param>
+            public RedirectOrDefaultApiResponse(ILogger<RedirectOrDefaultApiResponse> logger, System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage, string rawContent, string path, DateTime requestedAt, System.Text.Json.JsonSerializerOptions jsonSerializerOptions) : base(httpRequestMessage, httpResponseMessage, rawContent, path, requestedAt, jsonSerializerOptions)
+            {
+                Logger = logger;
+                OnCreated(httpRequestMessage, httpResponseMessage);
+            }
+
+            partial void OnCreated(global::System.Net.Http.HttpRequestMessage httpRequestMessage, System.Net.Http.HttpResponseMessage httpResponseMessage);
+
+            /// <summary>
+            /// Returns true if the response is 301 MovedPermanently
+            /// </summary>
+            /// <returns></returns>
+            public bool IsMovedPermanently => 301 == (int)StatusCode;
+
+            /// <summary>
+            /// Returns true if the response is the default response type
+            /// </summary>
+            /// <returns></returns>
+            public bool IsDefault => !IsMovedPermanently;
+
+            /// <summary>
+            /// Deserializes the response if the response is 0 Default
+            /// </summary>
+            /// <returns></returns>
+            public string Default()
+            {
+                // This logic may be modified with the AsModel.mustache template
+                return IsDefault
+                    ? System.Text.Json.JsonSerializer.Deserialize<string>(RawContent, _jsonSerializerOptions)
+                    : default;
+            }
+
+            /// <summary>
+            /// Returns true if the response is 0 Default and the deserialized response is not null
+            /// </summary>
+            /// <param name="result"></param>
+            /// <returns></returns>
+            public bool TryDefault(out string result)
+            {
+                result = null;
+
+                try
+                {
+                    result = Default();
+                } catch (Exception e)
+                {
+                    OnDeserializationErrorDefaultImplementation(e, (HttpStatusCode)0);
                 }
 
                 return result != null;

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/README.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/README.md
@@ -145,6 +145,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**FooGet**](docs/DefaultApi.md#fooget) | **GET** /foo | 
 *DefaultApi* | [**GetCountry**](docs/DefaultApi.md#getcountry) | **POST** /country | 
 *DefaultApi* | [**Hello**](docs/DefaultApi.md#hello) | **GET** /hello | Hello
+*DefaultApi* | [**RedirectOrDefault**](docs/DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault | 
 *DefaultApi* | [**RolesReportGet**](docs/DefaultApi.md#rolesreportget) | **GET** /roles/report | 
 *DefaultApi* | [**Test**](docs/DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest's Elements
 *FakeApi* | [**FakeHealthGet**](docs/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/docs/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -270,6 +271,93 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class RedirectOrDefaultExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://petstore.swagger.io:80/v2";
+            // create instances of HttpClient, HttpClientHandler to be reused later with different Api classes
+            HttpClient httpClient = new HttpClient();
+            HttpClientHandler httpClientHandler = new HttpClientHandler();
+            var apiInstance = new DefaultApi(httpClient, config, httpClientHandler);
+
+            try
+            {
+                string result = apiInstance.RedirectOrDefault();
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling DefaultApi.RedirectOrDefault: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the RedirectOrDefaultWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    ApiResponse<string> response = apiInstance.RedirectOrDefaultWithHttpInfo();
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling DefaultApi.RedirectOrDefaultWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/httpclient/net9/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -84,6 +84,22 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        string RedirectOrDefault();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> RedirectOrDefaultWithHttpInfo();
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <returns>List&lt;List&lt;RolesReportsHash&gt;&gt;</returns>
         List<List<RolesReportsHash>> RolesReportGet();
 
@@ -186,6 +202,27 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Guid&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Guid>>> HelloWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
         /// <summary>
         /// 
         /// </summary>
@@ -750,6 +787,107 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Hello", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        public string RedirectOrDefault()
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = RedirectOrDefaultWithHttpInfo();
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> RedirectOrDefaultWithHttpInfo()
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await RedirectOrDefaultWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
                 if (_exception != null) throw _exception;
             }
 

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/README.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/README.md
@@ -133,6 +133,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**FooGet**](docs/DefaultApi.md#fooget) | **GET** /foo | 
 *DefaultApi* | [**GetCountry**](docs/DefaultApi.md#getcountry) | **POST** /country | 
 *DefaultApi* | [**Hello**](docs/DefaultApi.md#hello) | **GET** /hello | Hello
+*DefaultApi* | [**RedirectOrDefault**](docs/DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault | 
 *DefaultApi* | [**RolesReportGet**](docs/DefaultApi.md#rolesreportget) | **GET** /roles/report | 
 *DefaultApi* | [**Test**](docs/DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest's Elements
 *FakeApi* | [**FakeHealthGet**](docs/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/docs/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -270,6 +271,93 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class RedirectOrDefaultExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://petstore.swagger.io:80/v2";
+            // create instances of HttpClient, HttpClientHandler to be reused later with different Api classes
+            HttpClient httpClient = new HttpClient();
+            HttpClientHandler httpClientHandler = new HttpClientHandler();
+            var apiInstance = new DefaultApi(httpClient, config, httpClientHandler);
+
+            try
+            {
+                string result = apiInstance.RedirectOrDefault();
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling DefaultApi.RedirectOrDefault: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the RedirectOrDefaultWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    ApiResponse<string> response = apiInstance.RedirectOrDefaultWithHttpInfo();
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling DefaultApi.RedirectOrDefaultWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -84,6 +84,22 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        string RedirectOrDefault();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> RedirectOrDefaultWithHttpInfo();
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <returns>List&lt;List&lt;RolesReportsHash&gt;&gt;</returns>
         List<List<RolesReportsHash>> RolesReportGet();
 
@@ -186,6 +202,27 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Guid&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Guid>>> HelloWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
         /// <summary>
         /// 
         /// </summary>
@@ -750,6 +787,107 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Hello", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        public string RedirectOrDefault()
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = RedirectOrDefaultWithHttpInfo();
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> RedirectOrDefaultWithHttpInfo()
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await RedirectOrDefaultWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
                 if (_exception != null) throw _exception;
             }
 

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/README.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/README.md
@@ -120,6 +120,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**FooGet**](docs/DefaultApi.md#fooget) | **GET** /foo | 
 *DefaultApi* | [**GetCountry**](docs/DefaultApi.md#getcountry) | **POST** /country | 
 *DefaultApi* | [**Hello**](docs/DefaultApi.md#hello) | **GET** /hello | Hello
+*DefaultApi* | [**RedirectOrDefault**](docs/DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault | 
 *DefaultApi* | [**RolesReportGet**](docs/DefaultApi.md#rolesreportget) | **GET** /roles/report | 
 *DefaultApi* | [**Test**](docs/DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest's Elements
 *FakeApi* | [**FakeHealthGet**](docs/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/docs/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -258,6 +259,89 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class RedirectOrDefaultExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new DefaultApi(config);
+
+            try
+            {
+                string result = apiInstance.RedirectOrDefault();
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling DefaultApi.RedirectOrDefault: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the RedirectOrDefaultWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    ApiResponse<string> response = apiInstance.RedirectOrDefaultWithHttpInfo();
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling DefaultApi.RedirectOrDefaultWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/restsharp/net8/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -91,6 +91,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        string RedirectOrDefault(int operationIndex = 0);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> RedirectOrDefaultWithHttpInfo(int operationIndex = 0);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>List&lt;List&lt;RolesReportsHash&gt;&gt;</returns>
         List<List<RolesReportsHash>> RolesReportGet(int operationIndex = 0);
 
@@ -202,6 +220,29 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Guid&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Guid>>> HelloWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
         /// <summary>
         /// 
         /// </summary>
@@ -756,6 +797,133 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Hello", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        public string RedirectOrDefault(int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = RedirectOrDefaultWithHttpInfo();
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> RedirectOrDefaultWithHttpInfo(int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            var localVarMultipartFormData = localVarContentType == "multipart/form-data";
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+
+            localVarRequestOptions.Operation = "DefaultApi.RedirectOrDefault";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration);
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await RedirectOrDefaultWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+
+            localVarRequestOptions.Operation = "DefaultApi.RedirectOrDefault";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/README.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/README.md
@@ -108,6 +108,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**FooGet**](docs/DefaultApi.md#fooget) | **GET** /foo | 
 *DefaultApi* | [**GetCountry**](docs/DefaultApi.md#getcountry) | **POST** /country | 
 *DefaultApi* | [**Hello**](docs/DefaultApi.md#hello) | **GET** /hello | Hello
+*DefaultApi* | [**RedirectOrDefault**](docs/DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault | 
 *DefaultApi* | [**RolesReportGet**](docs/DefaultApi.md#rolesreportget) | **GET** /roles/report | 
 *DefaultApi* | [**Test**](docs/DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest's Elements
 *FakeApi* | [**FakeHealthGet**](docs/FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/docs/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -258,6 +259,89 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class RedirectOrDefaultExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new DefaultApi(config);
+
+            try
+            {
+                string result = apiInstance.RedirectOrDefault();
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling DefaultApi.RedirectOrDefault: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the RedirectOrDefaultWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    ApiResponse<string> response = apiInstance.RedirectOrDefaultWithHttpInfo();
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling DefaultApi.RedirectOrDefaultWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -91,6 +91,24 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        string RedirectOrDefault(int operationIndex = 0);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> RedirectOrDefaultWithHttpInfo(int operationIndex = 0);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>List&lt;List&lt;RolesReportsHash&gt;&gt;</returns>
         List<List<RolesReportsHash>> RolesReportGet(int operationIndex = 0);
 
@@ -202,6 +220,29 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Guid&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Guid>>> HelloWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
         /// <summary>
         /// 
         /// </summary>
@@ -756,6 +797,133 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Hello", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        public string RedirectOrDefault(int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = RedirectOrDefaultWithHttpInfo();
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> RedirectOrDefaultWithHttpInfo(int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            var localVarMultipartFormData = localVarContentType == "multipart/form-data";
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+
+            localVarRequestOptions.Operation = "DefaultApi.RedirectOrDefault";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration);
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await RedirectOrDefaultWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+
+            localVarRequestOptions.Operation = "DefaultApi.RedirectOrDefault";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/README.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/README.md
@@ -94,6 +94,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo | 
 *DefaultApi* | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country | 
 *DefaultApi* | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello
+*DefaultApi* | [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault | 
 *DefaultApi* | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report | 
 *DefaultApi* | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest's Elements
 *FakeApi* | [**FakeHealthGet**](FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/docs/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -258,6 +259,89 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class RedirectOrDefaultExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new DefaultApi(config);
+
+            try
+            {
+                string result = apiInstance.RedirectOrDefault();
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling DefaultApi.RedirectOrDefault: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the RedirectOrDefaultWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    ApiResponse<string> response = apiInstance.RedirectOrDefaultWithHttpInfo();
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling DefaultApi.RedirectOrDefaultWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/net9/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -83,6 +83,22 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        string RedirectOrDefault();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> RedirectOrDefaultWithHttpInfo();
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <returns>List&lt;List&lt;RolesReportsHash&gt;&gt;</returns>
         List<List<RolesReportsHash>> RolesReportGet();
 
@@ -185,6 +201,27 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Guid&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Guid>>> HelloWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
         /// <summary>
         /// 
         /// </summary>
@@ -713,6 +750,118 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Hello", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        public string RedirectOrDefault()
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = RedirectOrDefaultWithHttpInfo();
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> RedirectOrDefaultWithHttpInfo()
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            var task = RedirectOrDefaultWithHttpInfoAsync(cancellationToken);
+#if UNITY_EDITOR || !UNITY_WEBGL
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await task.ConfigureAwait(false);
+#else
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await task;
+#endif
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+
+            var task = this.AsynchronousClient.GetAsync<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration, cancellationToken);
+
+#if UNITY_EDITOR || !UNITY_WEBGL
+            var localVarResponse = await task.ConfigureAwait(false);
+#else
+            var localVarResponse = await task;
+#endif
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
                 if (_exception != null) throw _exception;
             }
 

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/README.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/README.md
@@ -94,6 +94,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo | 
 *DefaultApi* | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country | 
 *DefaultApi* | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello
+*DefaultApi* | [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault | 
 *DefaultApi* | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report | 
 *DefaultApi* | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest's Elements
 *FakeApi* | [**FakeHealthGet**](FakeApi.md#fakehealthget) | **GET** /fake/health | Health check endpoint

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/api/openapi.yaml
@@ -644,6 +644,18 @@ paths:
       summary: To test class name in snake case
       tags:
       - fake_classname_tags 123#$%^
+  /redirectOrDefault:
+    get:
+      operationId: redirectOrDefault
+      responses:
+        "301":
+          description: redirect
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Bar"
+          description: default
   /fake:
     delete:
       description: Fake endpoint to test group parameters (optional)

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/docs/DefaultApi.md
@@ -7,6 +7,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 | [**FooGet**](DefaultApi.md#fooget) | **GET** /foo |  |
 | [**GetCountry**](DefaultApi.md#getcountry) | **POST** /country |  |
 | [**Hello**](DefaultApi.md#hello) | **GET** /hello | Hello |
+| [**RedirectOrDefault**](DefaultApi.md#redirectordefault) | **GET** /redirectOrDefault |  |
 | [**RolesReportGet**](DefaultApi.md#rolesreportget) | **GET** /roles/report |  |
 | [**Test**](DefaultApi.md#test) | **GET** /test | Retrieve an existing Notificationtest&#39;s Elements |
 
@@ -258,6 +259,89 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | UUIDs |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="redirectordefault"></a>
+# **RedirectOrDefault**
+> string RedirectOrDefault ()
+
+
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class RedirectOrDefaultExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://petstore.swagger.io:80/v2";
+            var apiInstance = new DefaultApi(config);
+
+            try
+            {
+                string result = apiInstance.RedirectOrDefault();
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling DefaultApi.RedirectOrDefault: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the RedirectOrDefaultWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    ApiResponse<string> response = apiInstance.RedirectOrDefaultWithHttpInfo();
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling DefaultApi.RedirectOrDefaultWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+This endpoint does not need any parameter.
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **301** | redirect |  -  |
+| **0** | default |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -83,6 +83,22 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        string RedirectOrDefault();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> RedirectOrDefaultWithHttpInfo();
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <returns>List&lt;List&lt;RolesReportsHash&gt;&gt;</returns>
         List<List<RolesReportsHash>> RolesReportGet();
 
@@ -185,6 +201,27 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (List&lt;Guid&gt;)</returns>
         System.Threading.Tasks.Task<ApiResponse<List<Guid>>> HelloWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default);
         /// <summary>
         /// 
         /// </summary>
@@ -713,6 +750,118 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Hello", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>string</returns>
+        public string RedirectOrDefault()
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = RedirectOrDefaultWithHttpInfo();
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> RedirectOrDefaultWithHttpInfo()
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
+                if (_exception != null) throw _exception;
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> RedirectOrDefaultAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+            var task = RedirectOrDefaultWithHttpInfoAsync(cancellationToken);
+#if UNITY_EDITOR || !UNITY_WEBGL
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await task.ConfigureAwait(false);
+#else
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await task;
+#endif
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        ///  
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> RedirectOrDefaultWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null) localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+
+
+
+            // make the HTTP request
+
+            var task = this.AsynchronousClient.GetAsync<string>("/redirectOrDefault", localVarRequestOptions, this.Configuration, cancellationToken);
+
+#if UNITY_EDITOR || !UNITY_WEBGL
+            var localVarResponse = await task.ConfigureAwait(false);
+#else
+            var localVarResponse = await task;
+#endif
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("RedirectOrDefault", localVarResponse);
                 if (_exception != null) throw _exception;
             }
 


### PR DESCRIPTION
Partial fix for https://github.com/OpenAPITools/openapi-generator/issues/21585. This change exposes bug https://github.com/OpenAPITools/openapi-generator/issues/21686 which can be fixed in another PR.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
