### PR TITLE
[Swift5][Swift6] support "x-enum-descriptions" 

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelEnum.mustache
@@ -1,6 +1,9 @@
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{classname}}: {{dataType}}, {{#useVapor}}Content, Hashable{{/useVapor}}{{^useVapor}}Codable{{^isString}}{{^isInteger}}{{^isFloat}}{{^isDouble}}, JSONEncodable{{/isDouble}}{{/isFloat}}{{/isInteger}}{{/isString}}{{/useVapor}}, CaseIterable{{#enumUnknownDefaultCase}}{{#isInteger}}, CaseIterableDefaultsLast{{/isInteger}}{{#isFloat}}, CaseIterableDefaultsLast{{/isFloat}}{{#isDouble}}, CaseIterableDefaultsLast{{/isDouble}}{{#isString}}, CaseIterableDefaultsLast{{/isString}}{{/enumUnknownDefaultCase}} {
 {{#allowableValues}}
 {{#enumVars}}
+    {{#enumDescription}}
+    /// {{enumDescription}}
+    {{/enumDescription}}
     case {{{name}}} = {{{value}}}
 {{/enumVars}}
 {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/swift5/modelInlineEnumDeclaration.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelInlineEnumDeclaration.mustache
@@ -1,6 +1,9 @@
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{enumName}}: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, {{#useVapor}}Content, Hashable{{/useVapor}}{{^useVapor}}Codable{{^isContainer}}{{^isString}}{{^isInteger}}{{^isFloat}}{{^isDouble}}, JSONEncodable{{/isDouble}}{{/isFloat}}{{/isInteger}}{{/isString}}{{/isContainer}}{{/useVapor}}, CaseIterable{{#enumUnknownDefaultCase}}{{#isInteger}}, CaseIterableDefaultsLast{{/isInteger}}{{#isFloat}}, CaseIterableDefaultsLast{{/isFloat}}{{#isDouble}}, CaseIterableDefaultsLast{{/isDouble}}{{#isString}}, CaseIterableDefaultsLast{{/isString}}{{#isContainer}}, CaseIterableDefaultsLast{{/isContainer}}{{/enumUnknownDefaultCase}} {
         {{#allowableValues}}
         {{#enumVars}}
+        {{#enumDescription}}
+        /// {{enumDescription}}
+        {{/enumDescription}}
         case {{{name}}} = {{{value}}}
         {{/enumVars}}
         {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/swift6/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelEnum.mustache
@@ -1,6 +1,9 @@
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{classname}}: {{dataType}}, Sendable, {{#useVapor}}Content, Hashable{{/useVapor}}{{^useVapor}}Codable{{^isString}}{{^isInteger}}{{^isFloat}}{{^isDouble}}{{#useParameterConvertible}}, ParameterConvertible{{/useParameterConvertible}}{{/isDouble}}{{/isFloat}}{{/isInteger}}{{/isString}}{{/useVapor}}, CaseIterable{{#enumUnknownDefaultCase}}{{#isInteger}}, CaseIterableDefaultsLast{{/isInteger}}{{#isFloat}}, CaseIterableDefaultsLast{{/isFloat}}{{#isDouble}}, CaseIterableDefaultsLast{{/isDouble}}{{#isString}}, CaseIterableDefaultsLast{{/isString}}{{/enumUnknownDefaultCase}} {
 {{#allowableValues}}
 {{#enumVars}}
+    {{#enumDescription}}
+    /// {{enumDescription}}
+    {{/enumDescription}}
     case {{{name}}} = {{{value}}}
 {{/enumVars}}
 {{/allowableValues}}

--- a/modules/openapi-generator/src/main/resources/swift6/modelInlineEnumDeclaration.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelInlineEnumDeclaration.mustache
@@ -1,6 +1,9 @@
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum {{enumName}}: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}String{{/isContainer}}, Sendable, {{#useVapor}}Content, Hashable{{/useVapor}}{{^useVapor}}Codable{{^isContainer}}{{^isString}}{{^isInteger}}{{^isFloat}}{{^isDouble}}{{#useParameterConvertible}}, ParameterConvertible{{/useParameterConvertible}}{{/isDouble}}{{/isFloat}}{{/isInteger}}{{/isString}}{{/isContainer}}{{/useVapor}}, CaseIterable{{#enumUnknownDefaultCase}}{{#isInteger}}, CaseIterableDefaultsLast{{/isInteger}}{{#isFloat}}, CaseIterableDefaultsLast{{/isFloat}}{{#isDouble}}, CaseIterableDefaultsLast{{/isDouble}}{{#isString}}, CaseIterableDefaultsLast{{/isString}}{{#isContainer}}, CaseIterableDefaultsLast{{/isContainer}}{{/enumUnknownDefaultCase}} {
         {{#allowableValues}}
         {{#enumVars}}
+        {{#enumDescription}}
+        /// {{enumDescription}}
+        {{/enumDescription}}
         case {{{name}}} = {{{value}}}
         {{/enumVars}}
         {{/allowableValues}}

--- a/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/swift/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -1362,6 +1362,9 @@ definitions:
         enum:
           - 1.1
           - -1.2
+        x-enum-descriptions:
+          - Description for 1.1
+          - Description for -1.2
       outerEnum:
         $ref: '#/definitions/OuterEnum'
   AdditionalPropertiesClass:
@@ -1547,6 +1550,10 @@ definitions:
     - "placed"
     - "approved"
     - "delivered"
+    x-enum-descriptions:
+    - Description for placed
+    - Description for approved
+    - Description for delivered
   OuterComposite:
     type: object
     properties:

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ public struct EnumTest: Codable, JSONEncodable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,7 +11,10 @@ import AnyCodable
 #endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ public struct EnumTest: Codable, JSONEncodable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,7 +11,10 @@ import AnyCodable
 #endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ public struct EnumTest: Codable, JSONEncodable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,7 +11,10 @@ import AnyCodable
 #endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ import AnyCodable
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,7 +11,10 @@ import AnyCodable
 #endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ public struct EnumTest: Codable, JSONEncodable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,7 +11,10 @@ import AnyCodable
 #endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -30,7 +30,9 @@ internal struct EnumTest: Codable, JSONEncodable {
         case unknownDefaultOpenApi = 11184809
     }
     internal enum EnumNumber: Double, Codable, CaseIterable, CaseIterableDefaultsLast {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
         case unknownDefaultOpenApi = 11184809
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,8 +11,11 @@ import AnyCodable
 #endif
 
 internal enum OuterEnum: String, Codable, CaseIterable, CaseIterableDefaultsLast {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
     case unknownDefaultOpenApi = "unknown_default_open_api"
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ public struct EnumTest: Codable, JSONEncodable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -11,7 +11,10 @@ import AnyCodable
 #endif
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -32,7 +32,9 @@ public final class EnumTest: Codable, JSONEncodable, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -16,8 +16,11 @@ public typealias OuterEnum = PetstoreClientAPI.OuterEnum
 extension PetstoreClientAPI {
 
 public enum OuterEnum: String, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }
 }

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/EnumTest.swift
@@ -24,7 +24,9 @@ import Foundation
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -27,7 +27,9 @@ internal struct EnumTest: Sendable, Codable, ParameterConvertible {
         case unknownDefaultOpenApi = 11184809
     }
     internal enum EnumNumber: Double, Sendable, Codable, CaseIterable, CaseIterableDefaultsLast {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
         case unknownDefaultOpenApi = 11184809
     }

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,8 +8,11 @@
 import Foundation
 
 internal enum OuterEnum: String, Sendable, Codable, CaseIterable, CaseIterableDefaultsLast {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
     case unknownDefaultOpenApi = "unknown_default_open_api"
 }

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/EnumTest.swift
@@ -24,7 +24,9 @@ public struct EnumTest: Sendable, Codable, ParameterConvertible, Hashable {
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public var enumString: EnumString?

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models/OuterEnum.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/EnumTest.swift
@@ -29,7 +29,9 @@ public final class EnumTest: @unchecked Sendable, Codable, ParameterConvertible,
         case number1 = -1
     }
     public enum EnumNumber: Double, Sendable, Codable, CaseIterable {
+        /// Description for 1.1
         case _11 = 1.1
+        /// Description for -1.2
         case number12 = -1.2
     }
     public private(set) var enumString: EnumString?

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Models/OuterEnum.swift
@@ -13,8 +13,11 @@ public typealias OuterEnum = PetstoreClientAPI.OuterEnum
 extension PetstoreClientAPI {
 
 public enum OuterEnum: String, Sendable, Codable, CaseIterable {
+    /// Description for placed
     case placed = "placed"
+    /// Description for approved
     case approved = "approved"
+    /// Description for delivered
     case delivered = "delivered"
 }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Added support for `x-enum-descriptions` in swift5 and swift6.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)