### PR TITLE
Add debug logging support to Rust client generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -39,6 +39,7 @@ serde_with = { version = "^3.8", default-features = false, features = ["base64",
 serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
+tracing = "^0.1"
 {{#hasUUIDs}}
 uuid = { version = "^1.8", features = ["serde", "v4"] }
 {{/hasUUIDs}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -4,6 +4,7 @@ use reqwest;
 use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
+use tracing::debug;
 
 {{#operations}}
 {{#operation}}
@@ -144,6 +145,7 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
 
     let uri_str = format!("{}{{{path}}}", configuration.base_path{{#pathParams}}, {{{baseName}}}={{#isString}}crate::apis::urlencode({{/isString}}{{{vendorExtensions.x-rust-param-identifier}}}{{^required}}.unwrap(){{/required}}{{#required}}{{#isNullable}}.unwrap(){{/isNullable}}{{/required}}{{#isArray}}.join(",").as_ref(){{/isArray}}{{^isString}}{{^isUuid}}{{^isPrimitiveType}}{{^isContainer}}.to_string(){{/isContainer}}{{/isPrimitiveType}}{{/isUuid}}{{/isString}}{{#isString}}){{/isString}}{{/pathParams}});
     let mut req_builder = configuration.client.request(reqwest::Method::{{{httpMethod}}}, &uri_str);
+    debug!("{{{httpMethod}}} {}", &uri_str);
 
     {{#queryParams}}
     {{#required}}


### PR DESCRIPTION
This PR adds debug logging capabilities to the Rust client generator. The changes enable developers to debug API calls by logging HTTP method and URI information.

### Changes:

- Added `tracing` dependency (^0.1) to the Rust client Cargo.toml template
- Added debug logging for HTTP method and URI when making API requests

This enhancement helps developers troubleshoot API interactions by providing visibility into the actual HTTP requests being made by the generated Rust client code.

Ideally, a configuration, such as `trace: "info" | "debug"`, should be added, but for now, `debug!` will work for me (and most of pepole). 
