### PR TITLE
Codegen parameter for query json serialization

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -47,6 +47,10 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
             isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isPassword, isFreeFormObject, isAnyType, isShort, isUnboundedInteger;
     public boolean isArray, isMap;
     /**
+     * If a query parameter should be serialized as json
+     */
+    public boolean queryIsJsonMimeType;
+    /**
      * datatype is the generic inner parameter of a std::optional for C++, or Optional (Java)
      */
     public boolean isOptional;
@@ -265,6 +269,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         output.isAnyType = this.isAnyType;
         output.isArray = this.isArray;
         output.isMap = this.isMap;
+        output.queryIsJsonMimeType = this.queryIsJsonMimeType;
         output.isOptional = this.isOptional;
         output.isExplode = this.isExplode;
         output.style = this.style;
@@ -289,7 +294,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
                 isFormStyle, isSpaceDelimited, isPipeDelimited,
                 jsonSchema, isString, isNumeric, isInteger, isLong, isNumber, isFloat, isDouble, isDecimal,
                 isByteArray, isBinary, isBoolean, isDate, isDateTime, isUuid, isUri, isEmail, isPassword,
-                isFreeFormObject, isAnyType, isArray, isMap, isOptional, isFile, isEnum, isEnumRef, _enum, allowableValues,
+                isFreeFormObject, isAnyType, isArray, isMap, queryIsJsonMimeType, isOptional, isFile, isEnum, isEnumRef, _enum, allowableValues,
                 items, mostInnerItems, additionalProperties, vars, requiredVars, vendorExtensions, hasValidation,
                 getMaxProperties(), getMinProperties(), isNullable, isDeprecated, required, getMaximum(),
                 getExclusiveMaximum(), getMinimum(), getExclusiveMinimum(), getMaxLength(), getMinLength(),
@@ -339,6 +344,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
                 isAnyType == that.isAnyType &&
                 isArray == that.isArray &&
                 isMap == that.isMap &&
+                queryIsJsonMimeType == that.queryIsJsonMimeType &&
                 isOptional == that.isOptional &&
                 isFile == that.isFile &&
                 isEnum == that.isEnum &&
@@ -479,6 +485,7 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
         sb.append(", isAnyType=").append(isAnyType);
         sb.append(", isArray=").append(isArray);
         sb.append(", isMap=").append(isMap);
+        sb.append(", queryIsJsonMimeType=").append(queryIsJsonMimeType);
         sb.append(", isOptional=").append(isOptional);
         sb.append(", isFile=").append(isFile);
         sb.append(", isEnum=").append(isEnum);

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5359,6 +5359,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (parameter instanceof QueryParameter || "query".equalsIgnoreCase(parameter.getIn())) {
             codegenParameter.isQueryParam = true;
             codegenParameter.isAllowEmptyValue = parameter.getAllowEmptyValue() != null && parameter.getAllowEmptyValue();
+            codegenParameter.queryIsJsonMimeType = isJsonMimeType(codegenParameter.contentType);
         } else if (parameter instanceof PathParameter || "path".equalsIgnoreCase(parameter.getIn())) {
             codegenParameter.required = true;
             codegenParameter.isPathParam = true;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -5006,4 +5006,15 @@ public class DefaultCodegenTest {
         // When & Then
         assertThat(codegenOperation.getHasSingleParam()).isTrue();
     }
+
+    @Test
+    public void testQueryIsJsonMimeType() {
+        DefaultCodegen codegen = new DefaultCodegen();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/echo_api.yaml");
+        codegen.setOpenAPI(openAPI);
+        String path = "/query/style_jsonSerialization/object";
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", openAPI.getPaths().get(path).getGet(), null);
+
+        assertTrue(codegenOperation.queryParams.stream().allMatch(p -> p.queryIsJsonMimeType));
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -457,8 +457,37 @@ paths:
         explode: true #default
         schema:
           allOf:
-          - $ref: '#/components/schemas/Bird'
-          - $ref: '#/components/schemas/Category'
+            - $ref: '#/components/schemas/Bird'
+            - $ref: '#/components/schemas/Category'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            text/plain:
+              schema:
+                type: string
+  /query/style_jsonSerialization/object:
+    get:
+      tags:
+        - query
+      summary: Test query parameter(s)
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+        - in: query
+          name: json_serialized_object_ref_string_query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        - in: query
+          name: json_serialized_object_array_ref_string_query
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
       responses:
         '200':
           description: Successful operation

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -457,8 +457,8 @@ paths:
         explode: true #default
         schema:
           allOf:
-            - $ref: '#/components/schemas/Bird'
-            - $ref: '#/components/schemas/Category'
+          - $ref: '#/components/schemas/Bird'
+          - $ref: '#/components/schemas/Category'
       responses:
         '200':
           description: Successful operation

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/README.md
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/README.md
@@ -144,6 +144,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**TestQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testquerystyleformexplodetruearraystring) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**TestQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testquerystyleformexplodetrueobject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**TestQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testquerystyleformexplodetrueobjectallof) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**TestQueryStyleJsonSerializationObject**](docs/QueryApi.md#testquerystylejsonserializationobject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 <a id="documentation-for-models"></a>

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/api/openapi.yaml
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/api/openapi.yaml
@@ -434,6 +434,37 @@ paths:
       summary: Test query parameter(s)
       tags:
       - query
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/docs/QueryApi.md
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**TestQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testquerystyleformexplodetruearraystring) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**TestQueryStyleFormExplodeTrueObject**](QueryApi.md#testquerystyleformexplodetrueobject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**TestQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testquerystyleformexplodetrueobjectallof) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**TestQueryStyleJsonSerializationObject**](QueryApi.md#testquerystylejsonserializationobject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 <a id="testenumrefstring"></a>
 # **TestEnumRefString**
@@ -913,6 +914,99 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **queryObject** | [**DataQuery?**](DataQuery?.md) |  | [optional]  |
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="testquerystylejsonserializationobject"></a>
+# **TestQueryStyleJsonSerializationObject**
+> string TestQueryStyleJsonSerializationObject (Pet? jsonSerializedObjectRefStringQuery = null, List<Pet>? jsonSerializedObjectArrayRefStringQuery = null)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class TestQueryStyleJsonSerializationObjectExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://localhost:3000";
+            var apiInstance = new QueryApi(config);
+            var jsonSerializedObjectRefStringQuery = new Pet?(); // Pet? |  (optional) 
+            var jsonSerializedObjectArrayRefStringQuery = new List<Pet>?(); // List<Pet>? |  (optional) 
+
+            try
+            {
+                // Test query parameter(s)
+                string result = apiInstance.TestQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling QueryApi.TestQueryStyleJsonSerializationObject: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the TestQueryStyleJsonSerializationObjectWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    // Test query parameter(s)
+    ApiResponse<string> response = apiInstance.TestQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling QueryApi.TestQueryStyleJsonSerializationObjectWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+|------|------|-------------|-------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet?**](Pet?.md) |  | [optional]  |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;?**](Pet.md) |  | [optional]  |
 
 ### Return type
 

--- a/samples/client/echo_api/csharp/restsharp/net8/EchoApi/src/Org.OpenAPITools/Api/QueryApi.cs
+++ b/samples/client/echo_api/csharp/restsharp/net8/EchoApi/src/Org.OpenAPITools/Api/QueryApi.cs
@@ -267,6 +267,31 @@ namespace Org.OpenAPITools.Api
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
         ApiResponse<string> TestQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo(DataQuery? queryObject = default, int operationIndex = 0);
+        /// <summary>
+        /// Test query parameter(s)
+        /// </summary>
+        /// <remarks>
+        /// Test query parameter(s)
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        string TestQueryStyleJsonSerializationObject(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0);
+
+        /// <summary>
+        /// Test query parameter(s)
+        /// </summary>
+        /// <remarks>
+        /// Test query parameter(s)
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        ApiResponse<string> TestQueryStyleJsonSerializationObjectWithHttpInfo(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -536,6 +561,33 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
         System.Threading.Tasks.Task<ApiResponse<string>> TestQueryStyleFormExplodeTrueObjectAllOfWithHttpInfoAsync(DataQuery? queryObject = default, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Test query parameter(s)
+        /// </summary>
+        /// <remarks>
+        /// Test query parameter(s)
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        System.Threading.Tasks.Task<string> TestQueryStyleJsonSerializationObjectAsync(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Test query parameter(s)
+        /// </summary>
+        /// <remarks>
+        /// Test query parameter(s)
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        System.Threading.Tasks.Task<ApiResponse<string>> TestQueryStyleJsonSerializationObjectWithHttpInfoAsync(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default);
         #endregion Asynchronous Operations
     }
 
@@ -2141,6 +2193,157 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestQueryStyleFormExplodeTrueObjectAllOf", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        /// Test query parameter(s) Test query parameter(s)
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>string</returns>
+        public string TestQueryStyleJsonSerializationObject(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        /// Test query parameter(s) Test query parameter(s)
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of string</returns>
+        public Org.OpenAPITools.Client.ApiResponse<string> TestQueryStyleJsonSerializationObjectWithHttpInfo(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "text/plain"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            var localVarMultipartFormData = localVarContentType == "multipart/form-data";
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+            if (jsonSerializedObjectRefStringQuery != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+            }
+            if (jsonSerializedObjectArrayRefStringQuery != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+            }
+
+            localVarRequestOptions.Operation = "QueryApi.TestQueryStyleJsonSerializationObject";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Get<string>("/query/style_jsonSerialization/object", localVarRequestOptions, this.Configuration);
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("TestQueryStyleJsonSerializationObject", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        /// Test query parameter(s) Test query parameter(s)
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of string</returns>
+        public async System.Threading.Tasks.Task<string> TestQueryStyleJsonSerializationObjectAsync(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default)
+        {
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestQueryStyleJsonSerializationObjectWithHttpInfoAsync(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, operationIndex, cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        /// Test query parameter(s) Test query parameter(s)
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="jsonSerializedObjectRefStringQuery"> (optional)</param>
+        /// <param name="jsonSerializedObjectArrayRefStringQuery"> (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (string)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestQueryStyleJsonSerializationObjectWithHttpInfoAsync(Pet? jsonSerializedObjectRefStringQuery = default, List<Pet>? jsonSerializedObjectArrayRefStringQuery = default, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default)
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "text/plain"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+            if (jsonSerializedObjectRefStringQuery != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+            }
+            if (jsonSerializedObjectArrayRefStringQuery != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("csv", "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+            }
+
+            localVarRequestOptions.Operation = "QueryApi.TestQueryStyleJsonSerializationObject";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/query/style_jsonSerialization/object", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("TestQueryStyleJsonSerializationObject", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/echo_api/go/README.md
+++ b/samples/client/echo_api/go/README.md
@@ -105,6 +105,7 @@ Class | Method | HTTP request | Description
 *QueryAPI* | [**TestQueryStyleFormExplodeTrueArrayString**](docs/QueryAPI.md#testquerystyleformexplodetruearraystring) | **Get** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryAPI* | [**TestQueryStyleFormExplodeTrueObject**](docs/QueryAPI.md#testquerystyleformexplodetrueobject) | **Get** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryAPI* | [**TestQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryAPI.md#testquerystyleformexplodetrueobjectallof) | **Get** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryAPI* | [**TestQueryStyleJsonSerializationObject**](docs/QueryAPI.md#testquerystylejsonserializationobject) | **Get** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation For Models

--- a/samples/client/echo_api/go/api/openapi.yaml
+++ b/samples/client/echo_api/go/api/openapi.yaml
@@ -434,6 +434,37 @@ paths:
       summary: Test query parameter(s)
       tags:
       - query
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/go/api_query.go
+++ b/samples/client/echo_api/go/api_query.go
@@ -1148,3 +1148,120 @@ func (a *QueryAPIService) TestQueryStyleFormExplodeTrueObjectAllOfExecute(r ApiT
 
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
+
+type ApiTestQueryStyleJsonSerializationObjectRequest struct {
+	ctx context.Context
+	ApiService *QueryAPIService
+	jsonSerializedObjectRefStringQuery *Pet
+	jsonSerializedObjectArrayRefStringQuery *[]Pet
+}
+
+func (r ApiTestQueryStyleJsonSerializationObjectRequest) JsonSerializedObjectRefStringQuery(jsonSerializedObjectRefStringQuery Pet) ApiTestQueryStyleJsonSerializationObjectRequest {
+	r.jsonSerializedObjectRefStringQuery = &jsonSerializedObjectRefStringQuery
+	return r
+}
+
+func (r ApiTestQueryStyleJsonSerializationObjectRequest) JsonSerializedObjectArrayRefStringQuery(jsonSerializedObjectArrayRefStringQuery []Pet) ApiTestQueryStyleJsonSerializationObjectRequest {
+	r.jsonSerializedObjectArrayRefStringQuery = &jsonSerializedObjectArrayRefStringQuery
+	return r
+}
+
+func (r ApiTestQueryStyleJsonSerializationObjectRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.TestQueryStyleJsonSerializationObjectExecute(r)
+}
+
+/*
+TestQueryStyleJsonSerializationObject Test query parameter(s)
+
+Test query parameter(s)
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiTestQueryStyleJsonSerializationObjectRequest
+*/
+func (a *QueryAPIService) TestQueryStyleJsonSerializationObject(ctx context.Context) ApiTestQueryStyleJsonSerializationObjectRequest {
+	return ApiTestQueryStyleJsonSerializationObjectRequest{
+		ApiService: a,
+		ctx: ctx,
+	}
+}
+
+// Execute executes the request
+//  @return string
+func (a *QueryAPIService) TestQueryStyleJsonSerializationObjectExecute(r ApiTestQueryStyleJsonSerializationObjectRequest) (string, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodGet
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  string
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "QueryAPIService.TestQueryStyleJsonSerializationObject")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/query/style_jsonSerialization/object"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	if r.jsonSerializedObjectRefStringQuery != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "json_serialized_object_ref_string_query", r.jsonSerializedObjectRefStringQuery, "", "")
+	}
+	if r.jsonSerializedObjectArrayRefStringQuery != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "json_serialized_object_array_ref_string_query", r.jsonSerializedObjectArrayRefStringQuery, "", "csv")
+	}
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"text/plain"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}

--- a/samples/client/echo_api/go/docs/QueryAPI.md
+++ b/samples/client/echo_api/go/docs/QueryAPI.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**TestQueryStyleFormExplodeTrueArrayString**](QueryAPI.md#TestQueryStyleFormExplodeTrueArrayString) | **Get** /query/style_form/explode_true/array_string | Test query parameter(s)
 [**TestQueryStyleFormExplodeTrueObject**](QueryAPI.md#TestQueryStyleFormExplodeTrueObject) | **Get** /query/style_form/explode_true/object | Test query parameter(s)
 [**TestQueryStyleFormExplodeTrueObjectAllOf**](QueryAPI.md#TestQueryStyleFormExplodeTrueObjectAllOf) | **Get** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+[**TestQueryStyleJsonSerializationObject**](QueryAPI.md#TestQueryStyleJsonSerializationObject) | **Get** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 
@@ -669,6 +670,74 @@ Other parameters are passed through a pointer to a apiTestQueryStyleFormExplodeT
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **queryObject** | [**DataQuery**](DataQuery.md) |  | 
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## TestQueryStyleJsonSerializationObject
+
+> string TestQueryStyleJsonSerializationObject(ctx).JsonSerializedObjectRefStringQuery(jsonSerializedObjectRefStringQuery).JsonSerializedObjectArrayRefStringQuery(jsonSerializedObjectArrayRefStringQuery).Execute()
+
+Test query parameter(s)
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID"
+)
+
+func main() {
+	jsonSerializedObjectRefStringQuery := *openapiclient.NewPet("doggie", []string{"PhotoUrls_example"}) // Pet |  (optional)
+	jsonSerializedObjectArrayRefStringQuery := []openapiclient.Pet{*openapiclient.NewPet("doggie", []string{"PhotoUrls_example"})} // []Pet |  (optional)
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.QueryAPI.TestQueryStyleJsonSerializationObject(context.Background()).JsonSerializedObjectRefStringQuery(jsonSerializedObjectRefStringQuery).JsonSerializedObjectArrayRefStringQuery(jsonSerializedObjectArrayRefStringQuery).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `QueryAPI.TestQueryStyleJsonSerializationObject``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `TestQueryStyleJsonSerializationObject`: string
+	fmt.Fprintf(os.Stdout, "Response from `QueryAPI.TestQueryStyleJsonSerializationObject`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestQueryStyleJsonSerializationObjectRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **jsonSerializedObjectRefStringQuery** | [**Pet**](Pet.md) |  | 
+ **jsonSerializedObjectArrayRefStringQuery** | [**[]Pet**](Pet.md) |  | 
 
 ### Return type
 

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -139,6 +139,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/apache-httpclient/docs/QueryApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 
@@ -666,6 +667,74 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | [**DataQuery**](.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testQueryStyleJsonSerializationObject
+
+> String testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+        List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+        try {
+            String result = apiInstance.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -769,6 +769,79 @@ public class QueryApi extends BaseApi {
     );
   }
 
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testQueryStyleJsonSerializationObject(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws ApiException {
+    return this.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, Collections.emptyMap());
+  }
+
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testQueryStyleJsonSerializationObject(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/query/style_jsonSerialization/object";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPair("json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+    localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("csv", "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "text/plain"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    TypeReference<String> localVarReturnType = new TypeReference<String>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "GET",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
   @Override
   public <T> T invokeAPI(String url, String method, Object request, TypeReference<T> returnType, Map<String, String> additionalHeaders) throws ApiException {
     String localVarPath = url.replace(apiClient.getBaseURL(), "");

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -831,4 +831,89 @@ public interface QueryApi extends ApiClient.Api {
       return this;
     }
   }
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @return String
+   */
+  @RequestLine("GET /query/style_jsonSerialization/object?json_serialized_object_ref_string_query={jsonSerializedObjectRefStringQuery}&json_serialized_object_array_ref_string_query={jsonSerializedObjectArrayRefStringQuery}")
+  @Headers({
+    "Accept: text/plain",
+  })
+  String testQueryStyleJsonSerializationObject(@Param("jsonSerializedObjectRefStringQuery") @javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @Param("jsonSerializedObjectArrayRefStringQuery") @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery);
+
+  /**
+   * Test query parameter(s)
+   * Similar to <code>testQueryStyleJsonSerializationObject</code> but it also returns the http response headers .
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @return A ApiResponse that wraps the response boyd and the http headers.
+   */
+  @RequestLine("GET /query/style_jsonSerialization/object?json_serialized_object_ref_string_query={jsonSerializedObjectRefStringQuery}&json_serialized_object_array_ref_string_query={jsonSerializedObjectArrayRefStringQuery}")
+  @Headers({
+    "Accept: text/plain",
+  })
+  ApiResponse<String> testQueryStyleJsonSerializationObjectWithHttpInfo(@Param("jsonSerializedObjectRefStringQuery") @javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @Param("jsonSerializedObjectArrayRefStringQuery") @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery);
+
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * Note, this is equivalent to the other <code>testQueryStyleJsonSerializationObject</code> method,
+   * but with the query parameters collected into a single Map parameter. This
+   * is convenient for services with optional query parameters, especially when
+   * used with the {@link TestQueryStyleJsonSerializationObjectQueryParams} class that allows for
+   * building up this map in a fluent style.
+   * @param queryParams Map of query parameters as name-value pairs
+   *   <p>The following elements may be specified in the query map:</p>
+   *   <ul>
+   *   <li>jsonSerializedObjectRefStringQuery -  (optional)</li>
+   *   <li>jsonSerializedObjectArrayRefStringQuery -  (optional)</li>
+   *   </ul>
+   * @return String
+   */
+  @RequestLine("GET /query/style_jsonSerialization/object?json_serialized_object_ref_string_query={jsonSerializedObjectRefStringQuery}&json_serialized_object_array_ref_string_query={jsonSerializedObjectArrayRefStringQuery}")
+  @Headers({
+  "Accept: text/plain",
+  })
+  String testQueryStyleJsonSerializationObject(@QueryMap(encoded=true) TestQueryStyleJsonSerializationObjectQueryParams queryParams);
+
+  /**
+  * Test query parameter(s)
+  * Test query parameter(s)
+  * Note, this is equivalent to the other <code>testQueryStyleJsonSerializationObject</code> that receives the query parameters as a map,
+  * but this one also exposes the Http response headers
+      * @param queryParams Map of query parameters as name-value pairs
+      *   <p>The following elements may be specified in the query map:</p>
+      *   <ul>
+          *   <li>jsonSerializedObjectRefStringQuery -  (optional)</li>
+          *   <li>jsonSerializedObjectArrayRefStringQuery -  (optional)</li>
+      *   </ul>
+          * @return String
+      */
+      @RequestLine("GET /query/style_jsonSerialization/object?json_serialized_object_ref_string_query={jsonSerializedObjectRefStringQuery}&json_serialized_object_array_ref_string_query={jsonSerializedObjectArrayRefStringQuery}")
+      @Headers({
+    "Accept: text/plain",
+      })
+   ApiResponse<String> testQueryStyleJsonSerializationObjectWithHttpInfo(@QueryMap(encoded=true) TestQueryStyleJsonSerializationObjectQueryParams queryParams);
+
+
+   /**
+   * A convenience class for generating query parameters for the
+   * <code>testQueryStyleJsonSerializationObject</code> method in a fluent style.
+   */
+  public static class TestQueryStyleJsonSerializationObjectQueryParams extends HashMap<String, Object> {
+    public TestQueryStyleJsonSerializationObjectQueryParams jsonSerializedObjectRefStringQuery(@javax.annotation.Nullable final Pet value) {
+      put("json_serialized_object_ref_string_query", EncodingUtils.encode(value));
+      return this;
+    }
+    public TestQueryStyleJsonSerializationObjectQueryParams jsonSerializedObjectArrayRefStringQuery(@javax.annotation.Nullable final List<Pet> value) {
+      put("json_serialized_object_array_ref_string_query", EncodingUtils.encodeCollection(value, "csv"));
+      return this;
+    }
+  }
 }

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -160,6 +160,8 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectWithHttpInfo**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectWithHttpInfo) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObjectWithHttpInfo**](docs/QueryApi.md#testQueryStyleJsonSerializationObjectWithHttpInfo) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/native/docs/QueryApi.md
+++ b/samples/client/echo_api/java/native/docs/QueryApi.md
@@ -24,6 +24,8 @@ All URIs are relative to *http://localhost:3000*
 | [**testQueryStyleFormExplodeTrueObjectWithHttpInfo**](QueryApi.md#testQueryStyleFormExplodeTrueObjectWithHttpInfo) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOfWithHttpInfo) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObjectWithHttpInfo**](QueryApi.md#testQueryStyleJsonSerializationObjectWithHttpInfo) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 
@@ -1366,6 +1368,144 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | [**DataQuery**](.md)|  | [optional] |
+
+### Return type
+
+ApiResponse<**String**>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testQueryStyleJsonSerializationObject
+
+> String testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+        List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+        try {
+            String result = apiInstance.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testQueryStyleJsonSerializationObjectWithHttpInfo
+
+> ApiResponse<String> testQueryStyleJsonSerializationObject testQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+        List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+        try {
+            ApiResponse<String> response = apiInstance.testQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -1378,4 +1378,127 @@ public class QueryApi {
     return localVarRequestBuilder;
   }
 
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testQueryStyleJsonSerializationObject(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws ApiException {
+    return testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, null);
+  }
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @param headers Optional headers to include in the request
+   * @return String
+   * @throws ApiException if fails to make API call
+   */
+  public String testQueryStyleJsonSerializationObject(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, Map<String, String> headers) throws ApiException {
+    ApiResponse<String> localVarResponse = testQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, headers);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @return ApiResponse&lt;String&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<String> testQueryStyleJsonSerializationObjectWithHttpInfo(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws ApiException {
+    return testQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, null);
+  }
+
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @param headers Optional headers to include in the request
+   * @return ApiResponse&lt;String&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<String> testQueryStyleJsonSerializationObjectWithHttpInfo(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, Map<String, String> headers) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testQueryStyleJsonSerializationObjectRequestBuilder(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, headers);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testQueryStyleJsonSerializationObject", localVarResponse);
+        }
+        // for plain text response
+        if (localVarResponse.headers().map().containsKey("Content-Type") &&
+                "text/plain".equalsIgnoreCase(localVarResponse.headers().map().get("Content-Type").get(0).split(";")[0].trim())) {
+          java.util.Scanner s = new java.util.Scanner(localVarResponse.body()).useDelimiter("\\A");
+          String responseBodyText = s.hasNext() ? s.next() : "";
+          return new ApiResponse<String>(
+                  localVarResponse.statusCode(),
+                  localVarResponse.headers().map(),
+                  responseBodyText
+          );
+        } else {
+            throw new RuntimeException("Error! The response Content-Type is supposed to be `text/plain` but it's not: " + localVarResponse);
+        }
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testQueryStyleJsonSerializationObjectRequestBuilder(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, Map<String, String> headers) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/query/style_jsonSerialization/object";
+
+    List<Pair> localVarQueryParams = new ArrayList<>();
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    localVarQueryParameterBaseName = "json_serialized_object_ref_string_query";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+    localVarQueryParameterBaseName = "json_serialized_object_array_ref_string_query";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("csv", "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+
+    if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {
+      StringJoiner queryJoiner = new StringJoiner("&");
+      localVarQueryParams.forEach(p -> queryJoiner.add(p.getName() + '=' + p.getValue()));
+      if (localVarQueryStringJoiner.length() != 0) {
+        queryJoiner.add(localVarQueryStringJoiner.toString());
+      }
+      localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath + '?' + queryJoiner.toString()));
+    } else {
+      localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+    }
+
+    localVarRequestBuilder.header("Accept", "text/plain");
+
+    localVarRequestBuilder.method("GET", HttpRequest.BodyPublishers.noBody());
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    // Add custom headers if provided
+    localVarRequestBuilder = HttpRequestBuilderExtensions.withAdditionalHeaders(localVarRequestBuilder, headers);
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
+
 }

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -146,6 +146,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/okhttp-gson/docs/QueryApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 <a id="testEnumRefString"></a>
@@ -627,6 +628,70 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | [**DataQuery**](.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+<a id="testQueryStyleJsonSerializationObject"></a>
+# **testQueryStyleJsonSerializationObject**
+> String testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:3000");
+
+    QueryApi apiInstance = new QueryApi(defaultClient);
+    Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+    List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+    try {
+      String result = apiInstance.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -1368,4 +1368,137 @@ public class QueryApi {
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
+    /**
+     * Build call for testQueryStyleJsonSerializationObject
+     * @param jsonSerializedObjectRefStringQuery  (optional)
+     * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testQueryStyleJsonSerializationObjectCall(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/query/style_jsonSerialization/object";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (jsonSerializedObjectRefStringQuery != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+        }
+
+        if (jsonSerializedObjectArrayRefStringQuery != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("csv", "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+        }
+
+        final String[] localVarAccepts = {
+            "text/plain"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testQueryStyleJsonSerializationObjectValidateBeforeCall(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, final ApiCallback _callback) throws ApiException {
+        return testQueryStyleJsonSerializationObjectCall(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, _callback);
+
+    }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * @param jsonSerializedObjectRefStringQuery  (optional)
+     * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+     * @return String
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public String testQueryStyleJsonSerializationObject(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws ApiException {
+        ApiResponse<String> localVarResp = testQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * @param jsonSerializedObjectRefStringQuery  (optional)
+     * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+     * @return ApiResponse&lt;String&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<String> testQueryStyleJsonSerializationObjectWithHttpInfo(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws ApiException {
+        okhttp3.Call localVarCall = testQueryStyleJsonSerializationObjectValidateBeforeCall(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, null);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Test query parameter(s) (asynchronously)
+     * Test query parameter(s)
+     * @param jsonSerializedObjectRefStringQuery  (optional)
+     * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table border="1">
+       <caption>Response Details</caption>
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testQueryStyleJsonSerializationObjectAsync(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery, final ApiCallback<String> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testQueryStyleJsonSerializationObjectValidateBeforeCall(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, _callback);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
 }

--- a/samples/client/echo_api/java/restclient/README.md
+++ b/samples/client/echo_api/java/restclient/README.md
@@ -146,6 +146,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/java/restclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/restclient/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/restclient/docs/QueryApi.md
+++ b/samples/client/echo_api/java/restclient/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 
@@ -666,6 +667,74 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | [**DataQuery**](.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testQueryStyleJsonSerializationObject
+
+> String testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+        List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+        try {
+            String result = apiInstance.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -794,4 +794,80 @@ public class QueryApi {
     public ResponseSpec testQueryStyleFormExplodeTrueObjectAllOfWithResponseSpec(@jakarta.annotation.Nullable DataQuery queryObject) throws RestClientResponseException {
         return testQueryStyleFormExplodeTrueObjectAllOfRequestCreation(queryObject);
     }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * <p><b>200</b> - Successful operation
+     * @param jsonSerializedObjectRefStringQuery The jsonSerializedObjectRefStringQuery parameter
+     * @param jsonSerializedObjectArrayRefStringQuery The jsonSerializedObjectArrayRefStringQuery parameter
+     * @return String
+     * @throws RestClientResponseException if an error occurs while attempting to invoke the API
+     */
+    private ResponseSpec testQueryStyleJsonSerializationObjectRequestCreation(@jakarta.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @jakarta.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientResponseException {
+        Object postBody = null;
+        // create path and map variables
+        final Map<String, Object> pathParams = new HashMap<>();
+
+        final MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        final HttpHeaders headerParams = new HttpHeaders();
+        final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
+        final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
+
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+        
+        final String[] localVarAccepts = { 
+            "text/plain"
+        };
+        final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = { };
+        final MediaType localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+        String[] localVarAuthNames = new String[] {  };
+
+        ParameterizedTypeReference<String> localVarReturnType = new ParameterizedTypeReference<>() {};
+        return apiClient.invokeAPI("/query/style_jsonSerialization/object", HttpMethod.GET, pathParams, queryParams, postBody, headerParams, cookieParams, formParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * <p><b>200</b> - Successful operation
+     * @param jsonSerializedObjectRefStringQuery The jsonSerializedObjectRefStringQuery parameter
+     * @param jsonSerializedObjectArrayRefStringQuery The jsonSerializedObjectArrayRefStringQuery parameter
+     * @return String
+     * @throws RestClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public String testQueryStyleJsonSerializationObject(@jakarta.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @jakarta.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientResponseException {
+        ParameterizedTypeReference<String> localVarReturnType = new ParameterizedTypeReference<>() {};
+        return testQueryStyleJsonSerializationObjectRequestCreation(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery).body(localVarReturnType);
+    }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * <p><b>200</b> - Successful operation
+     * @param jsonSerializedObjectRefStringQuery The jsonSerializedObjectRefStringQuery parameter
+     * @param jsonSerializedObjectArrayRefStringQuery The jsonSerializedObjectArrayRefStringQuery parameter
+     * @return ResponseEntity&lt;String&gt;
+     * @throws RestClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<String> testQueryStyleJsonSerializationObjectWithHttpInfo(@jakarta.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @jakarta.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientResponseException {
+        ParameterizedTypeReference<String> localVarReturnType = new ParameterizedTypeReference<>() {};
+        return testQueryStyleJsonSerializationObjectRequestCreation(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery).toEntity(localVarReturnType);
+    }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * <p><b>200</b> - Successful operation
+     * @param jsonSerializedObjectRefStringQuery The jsonSerializedObjectRefStringQuery parameter
+     * @param jsonSerializedObjectArrayRefStringQuery The jsonSerializedObjectArrayRefStringQuery parameter
+     * @return ResponseSpec
+     * @throws RestClientResponseException if an error occurs while attempting to invoke the API
+     */
+    public ResponseSpec testQueryStyleJsonSerializationObjectWithResponseSpec(@jakarta.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @jakarta.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientResponseException {
+        return testQueryStyleJsonSerializationObjectRequestCreation(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+    }
 }

--- a/samples/client/echo_api/java/resteasy/README.md
+++ b/samples/client/echo_api/java/resteasy/README.md
@@ -146,6 +146,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/java/resteasy/api/openapi.yaml
+++ b/samples/client/echo_api/java/resteasy/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/resteasy/docs/QueryApi.md
+++ b/samples/client/echo_api/java/resteasy/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 
@@ -666,6 +667,74 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | [**DataQuery**](.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testQueryStyleJsonSerializationObject
+
+> String testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+        List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+        try {
+            String result = apiInstance.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -440,4 +440,45 @@ public class QueryApi {
     GenericType<String> localVarReturnType = new GenericType<String>() {};
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
       }
+  /**
+   * Test query parameter(s)
+   * Test query parameter(s)
+   * @param jsonSerializedObjectRefStringQuery  (optional)
+   * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+   * @return a {@code String}
+   * @throws ApiException if fails to make API call
+   */
+  public String testQueryStyleJsonSerializationObject(@javax.annotation.Nullable Pet jsonSerializedObjectRefStringQuery, @javax.annotation.Nullable List<Pet> jsonSerializedObjectArrayRefStringQuery) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/query/style_jsonSerialization/object".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("csv", "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+
+    
+    
+    
+    final String[] localVarAccepts = {
+      "text/plain"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    GenericType<String> localVarReturnType = new GenericType<String>() {};
+    return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+      }
 }

--- a/samples/client/echo_api/java/resttemplate/README.md
+++ b/samples/client/echo_api/java/resttemplate/README.md
@@ -146,6 +146,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/java/resttemplate/api/openapi.yaml
+++ b/samples/client/echo_api/java/resttemplate/api/openapi.yaml
@@ -467,6 +467,39 @@ paths:
       - query
       x-accepts:
       - text/plain
+  /query/style_jsonSerialization/object:
+    get:
+      description: Test query parameter(s)
+      operationId: test/query/style_jsonSerialization/object
+      parameters:
+      - content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+        in: query
+        name: json_serialized_object_ref_string_query
+        required: false
+      - content:
+          application/json:
+            schema:
+              items:
+                $ref: "#/components/schemas/Pet"
+              type: array
+        in: query
+        name: json_serialized_object_array_ref_string_query
+        required: false
+      responses:
+        "200":
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Successful operation
+      summary: Test query parameter(s)
+      tags:
+      - query
+      x-accepts:
+      - text/plain
   /body/application/octetstream/binary:
     post:
       description: Test body parameter(s)

--- a/samples/client/echo_api/java/resttemplate/docs/QueryApi.md
+++ b/samples/client/echo_api/java/resttemplate/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testQueryStyleFormExplodeTrueArrayString**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 
@@ -666,6 +667,74 @@ public class Example {
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | [**DataQuery**](.md)|  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testQueryStyleJsonSerializationObject
+
+> String testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.QueryApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        QueryApi apiInstance = new QueryApi(defaultClient);
+        Pet jsonSerializedObjectRefStringQuery = new Pet(); // Pet | 
+        List<Pet> jsonSerializedObjectArrayRefStringQuery = Arrays.asList(); // List<Pet> | 
+        try {
+            String result = apiInstance.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling QueryApi#testQueryStyleJsonSerializationObject");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | [**Pet**](.md)|  | [optional] |
+| **jsonSerializedObjectArrayRefStringQuery** | [**List&lt;Pet&gt;**](Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -514,6 +514,53 @@ public class QueryApi extends BaseApi {
         ParameterizedTypeReference<String> localReturnType = new ParameterizedTypeReference<String>() {};
         return apiClient.invokeAPI("/query/style_form/explode_true/object/allOf", HttpMethod.GET, Collections.<String, Object>emptyMap(), localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
     }
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * <p><b>200</b> - Successful operation
+     * @param jsonSerializedObjectRefStringQuery  (optional)
+     * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+     * @return String
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public String testQueryStyleJsonSerializationObject(Pet jsonSerializedObjectRefStringQuery, List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientException {
+        return testQueryStyleJsonSerializationObjectWithHttpInfo(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery).getBody();
+    }
+
+    /**
+     * Test query parameter(s)
+     * Test query parameter(s)
+     * <p><b>200</b> - Successful operation
+     * @param jsonSerializedObjectRefStringQuery  (optional)
+     * @param jsonSerializedObjectArrayRefStringQuery  (optional)
+     * @return ResponseEntity&lt;String&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<String> testQueryStyleJsonSerializationObjectWithHttpInfo(Pet jsonSerializedObjectRefStringQuery, List<Pet> jsonSerializedObjectArrayRefStringQuery) throws RestClientException {
+        Object localVarPostBody = null;
+        
+
+        final MultiValueMap<String, String> localVarQueryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders localVarHeaderParams = new HttpHeaders();
+        final MultiValueMap<String, String> localVarCookieParams = new LinkedMultiValueMap<String, String>();
+        final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
+
+        localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+        localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+        
+
+        final String[] localVarAccepts = { 
+            "text/plain"
+         };
+        final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = {  };
+        final MediaType localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+        String[] localVarAuthNames = new String[] {  };
+
+        ParameterizedTypeReference<String> localReturnType = new ParameterizedTypeReference<String>() {};
+        return apiClient.invokeAPI("/query/style_jsonSerialization/object", HttpMethod.GET, Collections.<String, Object>emptyMap(), localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
+    }
 
     @Override
     public <T> ResponseEntity<T> invokeAPI(String url, HttpMethod method, Object request, ParameterizedTypeReference<T> returnType) throws RestClientException {

--- a/samples/client/echo_api/php-nextgen-streaming/README.md
+++ b/samples/client/echo_api/php-nextgen-streaming/README.md
@@ -103,6 +103,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/Api/QueryApi.md#testquerystyleformexplodetruearraystring) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/Api/QueryApi.md#testquerystyleformexplodetrueobject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/Api/QueryApi.md#testquerystyleformexplodetrueobjectallof) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/Api/QueryApi.md#testquerystylejsonserializationobject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 ## Models
 

--- a/samples/client/echo_api/php-nextgen-streaming/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen-streaming/docs/Api/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to http://localhost:3000, except if the operation defines 
 | [**testQueryStyleFormExplodeTrueArrayString()**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject()**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf()**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject()**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 ## `testEnumRefString()`
@@ -568,6 +569,64 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **query_object** | [**\OpenAPI\Client\Model\DataQuery**](../Model/.md)|  | [optional] |
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: `text/plain`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
+
+## `testQueryStyleJsonSerializationObject()`
+
+```php
+testQueryStyleJsonSerializationObject($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query): string
+```
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+
+$apiInstance = new OpenAPI\Client\Api\QueryApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$json_serialized_object_ref_string_query = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet
+$json_serialized_object_array_ref_string_query = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet()); // \OpenAPI\Client\Model\Pet[]
+
+try {
+    $result = $apiInstance->testQueryStyleJsonSerializationObject($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling QueryApi->testQueryStyleJsonSerializationObject: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **json_serialized_object_ref_string_query** | [**\OpenAPI\Client\Model\Pet**](../Model/.md)|  | [optional] |
+| **json_serialized_object_array_ref_string_query** | [**\OpenAPI\Client\Model\Pet[]**](../Model/\OpenAPI\Client\Model\Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/Api/QueryApi.php
@@ -105,6 +105,9 @@ class QueryApi
         'testQueryStyleFormExplodeTrueObjectAllOf' => [
             'application/json',
         ],
+        'testQueryStyleJsonSerializationObject' => [
+            'application/json',
+        ],
     ];
 
     /**
@@ -2944,6 +2947,301 @@ class QueryApi
             'ObjectOpenAPIClientModelQuery', // openApiType
             'form', // style
             true, // explode
+            false // required
+        ) ?? []);
+
+
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['text/plain', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObject
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return string
+     */
+    public function testQueryStyleJsonSerializationObject(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): string
+    {
+        list($response) = $this->testQueryStyleJsonSerializationObjectWithHttpInfo($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObjectWithHttpInfo
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return array of string, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function testQueryStyleJsonSerializationObjectWithHttpInfo(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): array
+    {
+        $request = $this->testQueryStyleJsonSerializationObjectRequest($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            switch($statusCode) {
+                case 200:
+                    return $this->handleResponseWithDataType(
+                        'string',
+                        $request,
+                        $response,
+                    );
+            }
+            
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            return $this->handleResponseWithDataType(
+                'string',
+                $request,
+                $response,
+            );
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    throw $e;
+            }
+        
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObjectAsync
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function testQueryStyleJsonSerializationObjectAsync(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): PromiseInterface
+    {
+        return $this->testQueryStyleJsonSerializationObjectAsyncWithHttpInfo($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObjectAsyncWithHttpInfo
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function testQueryStyleJsonSerializationObjectAsyncWithHttpInfo(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): PromiseInterface
+    {
+        $returnType = 'string';
+        $request = $this->testQueryStyleJsonSerializationObjectRequest($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if (in_array($returnType, ['\SplFileObject', '\Psr\Http\Message\StreamInterface'])) {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'testQueryStyleJsonSerializationObject'
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function testQueryStyleJsonSerializationObjectRequest(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): Request
+    {
+
+
+
+
+        $resourcePath = '/query/style_jsonSerialization/object';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $json_serialized_object_ref_string_query,
+            'json_serialized_object_ref_string_query', // param base name
+            '', // openApiType
+            '', // style
+            false, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $json_serialized_object_array_ref_string_query,
+            'json_serialized_object_array_ref_string_query', // param base name
+            '', // openApiType
+            '', // style
+            false, // explode
             false // required
         ) ?? []);
 

--- a/samples/client/echo_api/php-nextgen/README.md
+++ b/samples/client/echo_api/php-nextgen/README.md
@@ -103,6 +103,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/Api/QueryApi.md#testquerystyleformexplodetruearraystring) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/Api/QueryApi.md#testquerystyleformexplodetrueobject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/Api/QueryApi.md#testquerystyleformexplodetrueobjectallof) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/Api/QueryApi.md#testquerystylejsonserializationobject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 ## Models
 

--- a/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to http://localhost:3000, except if the operation defines 
 | [**testQueryStyleFormExplodeTrueArrayString()**](QueryApi.md#testQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObject()**](QueryApi.md#testQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**testQueryStyleFormExplodeTrueObjectAllOf()**](QueryApi.md#testQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**testQueryStyleJsonSerializationObject()**](QueryApi.md#testQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 ## `testEnumRefString()`
@@ -568,6 +569,64 @@ try {
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **query_object** | [**\OpenAPI\Client\Model\DataQuery**](../Model/.md)|  | [optional] |
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: `text/plain`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
+
+## `testQueryStyleJsonSerializationObject()`
+
+```php
+testQueryStyleJsonSerializationObject($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query): string
+```
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+
+$apiInstance = new OpenAPI\Client\Api\QueryApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$json_serialized_object_ref_string_query = new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet(); // \OpenAPI\Client\Model\Pet
+$json_serialized_object_array_ref_string_query = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\Pet()); // \OpenAPI\Client\Model\Pet[]
+
+try {
+    $result = $apiInstance->testQueryStyleJsonSerializationObject($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling QueryApi->testQueryStyleJsonSerializationObject: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **json_serialized_object_ref_string_query** | [**\OpenAPI\Client\Model\Pet**](../Model/.md)|  | [optional] |
+| **json_serialized_object_array_ref_string_query** | [**\OpenAPI\Client\Model\Pet[]**](../Model/\OpenAPI\Client\Model\Pet.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -105,6 +105,9 @@ class QueryApi
         'testQueryStyleFormExplodeTrueObjectAllOf' => [
             'application/json',
         ],
+        'testQueryStyleJsonSerializationObject' => [
+            'application/json',
+        ],
     ];
 
     /**
@@ -2944,6 +2947,301 @@ class QueryApi
             'ObjectOpenAPIClientModelQuery', // openApiType
             'form', // style
             true, // explode
+            false // required
+        ) ?? []);
+
+
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['text/plain', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'GET',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObject
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return string
+     */
+    public function testQueryStyleJsonSerializationObject(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): string
+    {
+        list($response) = $this->testQueryStyleJsonSerializationObjectWithHttpInfo($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObjectWithHttpInfo
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return array of string, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function testQueryStyleJsonSerializationObjectWithHttpInfo(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): array
+    {
+        $request = $this->testQueryStyleJsonSerializationObjectRequest($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            switch($statusCode) {
+                case 200:
+                    return $this->handleResponseWithDataType(
+                        'string',
+                        $request,
+                        $response,
+                    );
+            }
+            
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            return $this->handleResponseWithDataType(
+                'string',
+                $request,
+                $response,
+            );
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        'string',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    throw $e;
+            }
+        
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObjectAsync
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function testQueryStyleJsonSerializationObjectAsync(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): PromiseInterface
+    {
+        return $this->testQueryStyleJsonSerializationObjectAsyncWithHttpInfo($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation testQueryStyleJsonSerializationObjectAsyncWithHttpInfo
+     *
+     * Test query parameter(s)
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function testQueryStyleJsonSerializationObjectAsyncWithHttpInfo(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): PromiseInterface
+    {
+        $returnType = 'string';
+        $request = $this->testQueryStyleJsonSerializationObjectRequest($json_serialized_object_ref_string_query, $json_serialized_object_array_ref_string_query, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if (in_array($returnType, ['\SplFileObject', '\Psr\Http\Message\StreamInterface'])) {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'testQueryStyleJsonSerializationObject'
+     *
+     * @param  \OpenAPI\Client\Model\Pet|null $json_serialized_object_ref_string_query (optional)
+     * @param  \OpenAPI\Client\Model\Pet[]|null $json_serialized_object_array_ref_string_query (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryStyleJsonSerializationObject'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function testQueryStyleJsonSerializationObjectRequest(
+        ?\OpenAPI\Client\Model\Pet $json_serialized_object_ref_string_query = null,
+        ?array $json_serialized_object_array_ref_string_query = null,
+        string $contentType = self::contentTypes['testQueryStyleJsonSerializationObject'][0]
+    ): Request
+    {
+
+
+
+
+        $resourcePath = '/query/style_jsonSerialization/object';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $json_serialized_object_ref_string_query,
+            'json_serialized_object_ref_string_query', // param base name
+            '', // openApiType
+            '', // style
+            false, // explode
+            false // required
+        ) ?? []);
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $json_serialized_object_array_ref_string_query,
+            'json_serialized_object_array_ref_string_query', // param base name
+            '', // openApiType
+            '', // style
+            false, // explode
             false // required
         ) ?? []);
 

--- a/samples/client/echo_api/powershell/README.md
+++ b/samples/client/echo_api/powershell/README.md
@@ -79,6 +79,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**Test-QueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#Test-QueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**Test-QueryStyleFormExplodeTrueObject**](docs/QueryApi.md#Test-QueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**Test-QueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#Test-QueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**Test-QueryStyleJsonSerializationObject**](docs/QueryApi.md#Test-QueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/powershell/docs/QueryApi.md
+++ b/samples/client/echo_api/powershell/docs/QueryApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**Test-QueryStyleFormExplodeTrueArrayString**](QueryApi.md#Test-QueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 [**Test-QueryStyleFormExplodeTrueObject**](QueryApi.md#Test-QueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 [**Test-QueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#Test-QueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+[**Test-QueryStyleJsonSerializationObject**](QueryApi.md#Test-QueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 <a id="Test-EnumRefString"></a>
@@ -449,6 +450,54 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **QueryObject** | [**DataQuery**](DataQuery.md)|  | [optional] 
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="Test-QueryStyleJsonSerializationObject"></a>
+# **Test-QueryStyleJsonSerializationObject**
+> String Test-QueryStyleJsonSerializationObject<br>
+> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-JsonSerializedObjectRefStringQuery] <PSCustomObject><br>
+> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-JsonSerializedObjectArrayRefStringQuery] <PSCustomObject[]><br>
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+```powershell
+$Category = Initialize-Category -Id 1 -Name "Dogs"
+$Tag = Initialize-Tag -Id 0 -Name "MyName"
+$Pet = Initialize-Pet -Id 10 -Name "doggie" -Category $Category -PhotoUrls "MyPhotoUrls" -Tags $Tag -Status "available" # Pet |  (optional)
+ # Pet[] |  (optional)
+
+# Test query parameter(s)
+try {
+    $Result = Test-QueryStyleJsonSerializationObject -JsonSerializedObjectRefStringQuery $JsonSerializedObjectRefStringQuery -JsonSerializedObjectArrayRefStringQuery $JsonSerializedObjectArrayRefStringQuery
+} catch {
+    Write-Host ("Exception occurred when calling Test-QueryStyleJsonSerializationObject: {0}" -f ($_.ErrorDetails | ConvertFrom-Json))
+    Write-Host ("Response headers: {0}" -f ($_.Exception.Response.Headers | ConvertTo-Json))
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **JsonSerializedObjectRefStringQuery** | [**Pet**](Pet.md)|  | [optional] 
+ **JsonSerializedObjectArrayRefStringQuery** | [**Pet[]**](Pet.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/QueryApi.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/QueryApi.ps1
@@ -787,3 +787,86 @@ function Test-QueryStyleFormExplodeTrueObjectAllOf {
     }
 }
 
+<#
+.SYNOPSIS
+
+Test query parameter(s)
+
+.DESCRIPTION
+
+No description available.
+
+.PARAMETER JsonSerializedObjectRefStringQuery
+No description available.
+
+.PARAMETER JsonSerializedObjectArrayRefStringQuery
+No description available.
+
+.PARAMETER WithHttpInfo
+
+A switch when turned on will return a hash table of Response, StatusCode and Headers instead of just the Response
+
+.OUTPUTS
+
+String
+#>
+function Test-QueryStyleJsonSerializationObject {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Mandatory = $false)]
+        [PSCustomObject]
+        ${JsonSerializedObjectRefStringQuery},
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName = $true, Mandatory = $false)]
+        [PSCustomObject[]]
+        ${JsonSerializedObjectArrayRefStringQuery},
+        [Switch]
+        $WithHttpInfo
+    )
+
+    Process {
+        'Calling method: Test-QueryStyleJsonSerializationObject' | Write-Debug
+        $PSBoundParameters | Out-DebugParameter | Write-Debug
+
+        $LocalVarAccepts = @()
+        $LocalVarContentTypes = @()
+        $LocalVarQueryParameters = @{}
+        $LocalVarHeaderParameters = @{}
+        $LocalVarFormParameters = @{}
+        $LocalVarPathParameters = @{}
+        $LocalVarCookieParameters = @{}
+        $LocalVarBodyParameter = $null
+
+        $Configuration = Get-Configuration
+        # HTTP header 'Accept' (if needed)
+        $LocalVarAccepts = @('text/plain')
+
+        $LocalVarUri = '/query/style_jsonSerialization/object'
+
+        if ($JsonSerializedObjectRefStringQuery) {
+            $LocalVarQueryParameters['json_serialized_object_ref_string_query'] = $JsonSerializedObjectRefStringQuery
+        }
+
+        if ($JsonSerializedObjectArrayRefStringQuery) {
+            $LocalVarQueryParameters['json_serialized_object_array_ref_string_query'] = $JsonSerializedObjectArrayRefStringQuery
+        }
+
+        $LocalVarResult = Invoke-ApiClient -Method 'GET' `
+                                -Uri $LocalVarUri `
+                                -Accepts $LocalVarAccepts `
+                                -ContentTypes $LocalVarContentTypes `
+                                -Body $LocalVarBodyParameter `
+                                -HeaderParameters $LocalVarHeaderParameters `
+                                -QueryParameters $LocalVarQueryParameters `
+                                -FormParameters $LocalVarFormParameters `
+                                -CookieParameters $LocalVarCookieParameters `
+                                -ReturnType "String" `
+                                -IsBodyNullable $false
+
+        if ($WithHttpInfo.IsPresent) {
+            return $LocalVarResult
+        } else {
+            return $LocalVarResult["Response"]
+        }
+    }
+}
+

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/README.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/README.md
@@ -121,6 +121,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**test_query_style_form_explode_true_array_string**](docs/QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**test_query_style_form_explode_true_object**](docs/QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**test_query_style_form_explode_true_object_all_of**](docs/QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**test_query_style_json_serialization_object**](docs/QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation For Models

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/docs/QueryApi.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/docs/QueryApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**test_query_style_form_explode_true_array_string**](QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 [**test_query_style_form_explode_true_object**](QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 [**test_query_style_form_explode_true_object_all_of**](QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+[**test_query_style_json_serialization_object**](QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 # **test_enum_ref_string**
@@ -678,6 +679,76 @@ with openapi_client.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **query_object** | [**DataQuery**](.md)|  | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_style_json_serialization_object**
+> str test_query_style_json_serialization_object(json_serialized_object_ref_string_query=json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+
+```python
+import openapi_client
+from openapi_client.models.pet import Pet
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.QueryApi(api_client)
+    json_serialized_object_ref_string_query = openapi_client.Pet() # Pet |  (optional)
+    json_serialized_object_array_ref_string_query = [openapi_client.Pet()] # List[Pet] |  (optional)
+
+    try:
+        # Test query parameter(s)
+        api_response = api_instance.test_query_style_json_serialization_object(json_serialized_object_ref_string_query=json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query)
+        print("The response of QueryApi->test_query_style_json_serialization_object:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling QueryApi->test_query_style_json_serialization_object: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **json_serialized_object_ref_string_query** | [**Pet**](.md)|  | [optional] 
+ **json_serialized_object_array_ref_string_query** | [**List[Pet]**](Pet.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api/query_api.py
@@ -2765,3 +2765,283 @@ class QueryApi:
         )
 
 
+
+
+    @validate_call
+    def test_query_style_json_serialization_object(
+        self,
+        json_serialized_object_ref_string_query: Optional[Pet] = None,
+        json_serialized_object_array_ref_string_query: Optional[List[Pet]] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> str:
+        """Test query parameter(s)
+
+        Test query parameter(s)
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_query_style_json_serialization_object_serialize(
+            json_serialized_object_ref_string_query=json_serialized_object_ref_string_query,
+            json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def test_query_style_json_serialization_object_with_http_info(
+        self,
+        json_serialized_object_ref_string_query: Optional[Pet] = None,
+        json_serialized_object_array_ref_string_query: Optional[List[Pet]] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[str]:
+        """Test query parameter(s)
+
+        Test query parameter(s)
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_query_style_json_serialization_object_serialize(
+            json_serialized_object_ref_string_query=json_serialized_object_ref_string_query,
+            json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def test_query_style_json_serialization_object_without_preload_content(
+        self,
+        json_serialized_object_ref_string_query: Optional[Pet] = None,
+        json_serialized_object_array_ref_string_query: Optional[List[Pet]] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Test query parameter(s)
+
+        Test query parameter(s)
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_query_style_json_serialization_object_serialize(
+            json_serialized_object_ref_string_query=json_serialized_object_ref_string_query,
+            json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _test_query_style_json_serialization_object_serialize(
+        self,
+        json_serialized_object_ref_string_query,
+        json_serialized_object_array_ref_string_query,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+            'json_serialized_object_array_ref_string_query': 'csv',
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        if json_serialized_object_ref_string_query is not None:
+            
+            _query_params.append(('json_serialized_object_ref_string_query', json_serialized_object_ref_string_query))
+            
+        if json_serialized_object_array_ref_string_query is not None:
+            
+            _query_params.append(('json_serialized_object_array_ref_string_query', json_serialized_object_array_ref_string_query))
+            
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'text/plain'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/query/style_jsonSerialization/object',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+

--- a/samples/client/echo_api/python-pydantic-v1/README.md
+++ b/samples/client/echo_api/python-pydantic-v1/README.md
@@ -122,6 +122,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**test_query_style_form_explode_true_array_string**](docs/QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**test_query_style_form_explode_true_object**](docs/QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**test_query_style_form_explode_true_object_all_of**](docs/QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**test_query_style_json_serialization_object**](docs/QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation For Models

--- a/samples/client/echo_api/python-pydantic-v1/docs/QueryApi.md
+++ b/samples/client/echo_api/python-pydantic-v1/docs/QueryApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**test_query_style_form_explode_true_array_string**](QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 [**test_query_style_form_explode_true_object**](QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 [**test_query_style_form_explode_true_object_all_of**](QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+[**test_query_style_json_serialization_object**](QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 # **test_enum_ref_string**
@@ -669,6 +670,75 @@ with openapi_client.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **query_object** | [**DataQuery**](.md)|  | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_style_json_serialization_object**
+> str test_query_style_json_serialization_object(json_serialized_object_ref_string_query=json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+```python
+import time
+import os
+import openapi_client
+from openapi_client.models.pet import Pet
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.QueryApi(api_client)
+    json_serialized_object_ref_string_query = openapi_client.Pet() # Pet |  (optional)
+    json_serialized_object_array_ref_string_query = [openapi_client.Pet()] # List[Pet] |  (optional)
+
+    try:
+        # Test query parameter(s)
+        api_response = api_instance.test_query_style_json_serialization_object(json_serialized_object_ref_string_query=json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query)
+        print("The response of QueryApi->test_query_style_json_serialization_object:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling QueryApi->test_query_style_json_serialization_object: %s\n" % e)
+```
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **json_serialized_object_ref_string_query** | [**Pet**](.md)|  | [optional] 
+ **json_serialized_object_array_ref_string_query** | [**List[Pet]**](Pet.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api/query_api.py
@@ -1496,3 +1496,152 @@ class QueryApi:
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
+    def test_query_style_json_serialization_object(self, json_serialized_object_ref_string_query : Optional[Pet] = None, json_serialized_object_array_ref_string_query : Optional[conlist(Pet)] = None, **kwargs) -> str:  # noqa: E501
+        """Test query parameter(s)  # noqa: E501
+
+        Test query parameter(s)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_query_style_json_serialization_object(json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query, async_req=True)
+        >>> result = thread.get()
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _request_timeout: timeout setting for this request.
+               If one number provided, it will be total request
+               timeout. It can also be a pair (tuple) of
+               (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: str
+        """
+        kwargs['_return_http_data_only'] = True
+        if '_preload_content' in kwargs:
+            message = "Error! Please call the test_query_style_json_serialization_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            raise ValueError(message)
+        return self.test_query_style_json_serialization_object_with_http_info(json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query, **kwargs)  # noqa: E501
+
+    @validate_arguments
+    def test_query_style_json_serialization_object_with_http_info(self, json_serialized_object_ref_string_query : Optional[Pet] = None, json_serialized_object_array_ref_string_query : Optional[conlist(Pet)] = None, **kwargs) -> ApiResponse:  # noqa: E501
+        """Test query parameter(s)  # noqa: E501
+
+        Test query parameter(s)  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_query_style_json_serialization_object_with_http_info(json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query, async_req=True)
+        >>> result = thread.get()
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the ApiResponse.data will
+                                 be set to none and raw_data will store the
+                                 HTTP response body without reading/decoding.
+                                 Default is True.
+        :type _preload_content: bool, optional
+        :param _return_http_data_only: response data instead of ApiResponse
+                                       object with status code, headers, etc
+        :type _return_http_data_only: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(str, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+            'json_serialized_object_ref_string_query',
+            'json_serialized_object_array_ref_string_query'
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_query_style_json_serialization_object" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        if _params.get('json_serialized_object_ref_string_query') is not None:  # noqa: E501
+            _query_params.append(('json_serialized_object_ref_string_query', _params['json_serialized_object_ref_string_query']))
+
+        if _params.get('json_serialized_object_array_ref_string_query') is not None:  # noqa: E501
+            _query_params.append(('json_serialized_object_array_ref_string_query', _params['json_serialized_object_array_ref_string_query']))
+            _collection_formats['json_serialized_object_array_ref_string_query'] = 'csv'
+
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['text/plain'])  # noqa: E501
+
+        # authentication setting
+        _auth_settings = []  # noqa: E501
+
+        _response_types_map = {
+            '200': "str",
+        }
+
+        return self.api_client.call_api(
+            '/query/style_jsonSerialization/object', 'GET',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))

--- a/samples/client/echo_api/python/README.md
+++ b/samples/client/echo_api/python/README.md
@@ -121,6 +121,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**test_query_style_form_explode_true_array_string**](docs/QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**test_query_style_form_explode_true_object**](docs/QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**test_query_style_form_explode_true_object_all_of**](docs/QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**test_query_style_json_serialization_object**](docs/QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation For Models

--- a/samples/client/echo_api/python/docs/QueryApi.md
+++ b/samples/client/echo_api/python/docs/QueryApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**test_query_style_form_explode_true_array_string**](QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 [**test_query_style_form_explode_true_object**](QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 [**test_query_style_form_explode_true_object_all_of**](QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+[**test_query_style_json_serialization_object**](QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 # **test_enum_ref_string**
@@ -678,6 +679,76 @@ with openapi_client.ApiClient(configuration) as api_client:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **query_object** | [**DataQuery**](.md)|  | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_query_style_json_serialization_object**
+> str test_query_style_json_serialization_object(json_serialized_object_ref_string_query=json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+
+
+```python
+import openapi_client
+from openapi_client.models.pet import Pet
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.QueryApi(api_client)
+    json_serialized_object_ref_string_query = openapi_client.Pet() # Pet |  (optional)
+    json_serialized_object_array_ref_string_query = [openapi_client.Pet()] # List[Pet] |  (optional)
+
+    try:
+        # Test query parameter(s)
+        api_response = api_instance.test_query_style_json_serialization_object(json_serialized_object_ref_string_query=json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query)
+        print("The response of QueryApi->test_query_style_json_serialization_object:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling QueryApi->test_query_style_json_serialization_object: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **json_serialized_object_ref_string_query** | [**Pet**](.md)|  | [optional] 
+ **json_serialized_object_array_ref_string_query** | [**List[Pet]**](Pet.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -2765,3 +2765,283 @@ class QueryApi:
         )
 
 
+
+
+    @validate_call
+    def test_query_style_json_serialization_object(
+        self,
+        json_serialized_object_ref_string_query: Optional[Pet] = None,
+        json_serialized_object_array_ref_string_query: Optional[List[Pet]] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> str:
+        """Test query parameter(s)
+
+        Test query parameter(s)
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_query_style_json_serialization_object_serialize(
+            json_serialized_object_ref_string_query=json_serialized_object_ref_string_query,
+            json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def test_query_style_json_serialization_object_with_http_info(
+        self,
+        json_serialized_object_ref_string_query: Optional[Pet] = None,
+        json_serialized_object_array_ref_string_query: Optional[List[Pet]] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[str]:
+        """Test query parameter(s)
+
+        Test query parameter(s)
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_query_style_json_serialization_object_serialize(
+            json_serialized_object_ref_string_query=json_serialized_object_ref_string_query,
+            json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def test_query_style_json_serialization_object_without_preload_content(
+        self,
+        json_serialized_object_ref_string_query: Optional[Pet] = None,
+        json_serialized_object_array_ref_string_query: Optional[List[Pet]] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Test query parameter(s)
+
+        Test query parameter(s)
+
+        :param json_serialized_object_ref_string_query:
+        :type json_serialized_object_ref_string_query: Pet
+        :param json_serialized_object_array_ref_string_query:
+        :type json_serialized_object_array_ref_string_query: List[Pet]
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_query_style_json_serialization_object_serialize(
+            json_serialized_object_ref_string_query=json_serialized_object_ref_string_query,
+            json_serialized_object_array_ref_string_query=json_serialized_object_array_ref_string_query,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _test_query_style_json_serialization_object_serialize(
+        self,
+        json_serialized_object_ref_string_query,
+        json_serialized_object_array_ref_string_query,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+            'json_serialized_object_array_ref_string_query': 'csv',
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        if json_serialized_object_ref_string_query is not None:
+            
+            _query_params.append(('json_serialized_object_ref_string_query', json_serialized_object_ref_string_query))
+            
+        if json_serialized_object_array_ref_string_query is not None:
+            
+            _query_params.append(('json_serialized_object_array_ref_string_query', json_serialized_object_array_ref_string_query))
+            
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'text/plain'
+                ]
+            )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='GET',
+            resource_path='/query/style_jsonSerialization/object',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+

--- a/samples/client/echo_api/r/R/query_api.R
+++ b/samples/client/echo_api/r/R/query_api.R
@@ -159,6 +159,21 @@
 #' dput(result)
 #'
 #'
+#' ####################  TestQueryStyleJsonSerializationObject  ####################
+#'
+#' library(openapi)
+#' var_json_serialized_object_ref_string_query <- Pet$new("name_example", c("photoUrls_example"), 123, Category$new(123, "name_example"), c(Tag$new(123, "name_example")), "available") # Pet |  (Optional)
+#' var_json_serialized_object_array_ref_string_query <- c(Pet$new("name_example", c("photoUrls_example"), 123, Category$new(123, "name_example"), c(Tag$new(123, "name_example")), "available")) # array[Pet] |  (Optional)
+#'
+#' #Test query parameter(s)
+#' api_instance <- QueryApi$new()
+#'
+#' # to save the result into a file, simply add the optional `data_file` parameter, e.g.
+#' # result <- api_instance$TestQueryStyleJsonSerializationObject(json_serialized_object_ref_string_query = var_json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query = var_json_serialized_object_array_ref_string_querydata_file = "result.txt")
+#' result <- api_instance$TestQueryStyleJsonSerializationObject(json_serialized_object_ref_string_query = var_json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query = var_json_serialized_object_array_ref_string_query)
+#' dput(result)
+#'
+#'
 #' }
 #' @importFrom R6 R6Class
 #' @importFrom base64enc base64encode
@@ -1126,6 +1141,110 @@ QueryApi <- R6::R6Class(
       query_params[["query_object"]] <- `query_object`
 
       local_var_url_path <- "/query/style_form/explode_true/object/allOf"
+
+      # The Accept request HTTP header
+      local_var_accepts <- list("text/plain")
+
+      # The Content-Type representation header
+      local_var_content_types <- list()
+
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
+                                 method = "GET",
+                                 query_params = query_params,
+                                 header_params = header_params,
+                                 form_params = form_params,
+                                 file_params = file_params,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
+                                 is_oauth = is_oauth,
+                                 oauth_scopes = oauth_scopes,
+                                 ...)
+
+      if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+          self$api_client$WriteFile(local_var_resp, data_file)
+        }
+
+        deserialized_resp_obj <- tryCatch(
+          self$api_client$DeserializeResponse(local_var_resp, "character"),
+          error = function(e) {
+            stop("Failed to deserialize response")
+          }
+        )
+        local_var_resp$content <- deserialized_resp_obj
+        return(local_var_resp)
+      } 
+      
+      local_var_error_msg <- local_var_resp$response_as_text()      
+      if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
+      } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
+        ApiResponse$new("API client error", local_var_resp)
+      } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
+        if (is.null(local_var_resp$response) || local_var_resp$response == "") {
+          local_var_resp$response <- "API server error"
+        }
+        return(local_var_resp)
+      }
+    },
+
+    #' @description
+    #' Test query parameter(s)
+    #'
+    #' @param json_serialized_object_ref_string_query (optional) No description
+    #' @param json_serialized_object_array_ref_string_query (optional) No description
+    #' @param data_file (optional) name of the data file to save the result
+    #' @param ... Other optional arguments
+    #'
+    #' @return character
+    TestQueryStyleJsonSerializationObject = function(json_serialized_object_ref_string_query = NULL, json_serialized_object_array_ref_string_query = NULL, data_file = NULL, ...) {
+      local_var_response <- self$TestQueryStyleJsonSerializationObjectWithHttpInfo(json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query, data_file = data_file, ...)
+      if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
+        return(local_var_response$content)
+      } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
+        return(local_var_response)
+      } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
+        return(local_var_response)
+      } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
+        return(local_var_response)
+      }
+    },
+
+    #' @description
+    #' Test query parameter(s)
+    #'
+    #' @param json_serialized_object_ref_string_query (optional) No description
+    #' @param json_serialized_object_array_ref_string_query (optional) No description
+    #' @param data_file (optional) name of the data file to save the result
+    #' @param ... Other optional arguments
+    #'
+    #' @return API response (character) with additional information such as HTTP status code, headers
+    TestQueryStyleJsonSerializationObjectWithHttpInfo = function(json_serialized_object_ref_string_query = NULL, json_serialized_object_array_ref_string_query = NULL, data_file = NULL, ...) {
+      args <- list(...)
+      query_params <- list()
+      header_params <- c()
+      form_params <- list()
+      file_params <- list()
+      local_var_body <- NULL
+      oauth_scopes <- NULL
+      is_oauth <- FALSE
+
+      if (!missing(`json_serialized_object_ref_string_query`) && is.null(`json_serialized_object_ref_string_query`)) {
+        stop("Invalid value for `json_serialized_object_ref_string_query` when calling QueryApi$TestQueryStyleJsonSerializationObject, `json_serialized_object_ref_string_query` is not nullable")
+      }
+
+      if (!missing(`json_serialized_object_array_ref_string_query`) && is.null(`json_serialized_object_array_ref_string_query`)) {
+        stop("Invalid value for `json_serialized_object_array_ref_string_query` when calling QueryApi$TestQueryStyleJsonSerializationObject, `json_serialized_object_array_ref_string_query` is not nullable")
+      }
+
+      query_params[["json_serialized_object_ref_string_query"]] <- `json_serialized_object_ref_string_query`
+
+      # no explore
+      query_params[["json_serialized_object_array_ref_string_query"]] <- I(paste(lapply(`json_serialized_object_array_ref_string_query`, URLencode, reserved = TRUE), collapse = ","))
+
+      local_var_url_path <- "/query/style_jsonSerialization/object"
 
       # The Accept request HTTP header
       local_var_accepts <- list("text/plain")

--- a/samples/client/echo_api/r/README.md
+++ b/samples/client/echo_api/r/README.md
@@ -100,6 +100,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**TestQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#TestQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**TestQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#TestQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**TestQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#TestQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**TestQueryStyleJsonSerializationObject**](docs/QueryApi.md#TestQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/r/docs/QueryApi.md
+++ b/samples/client/echo_api/r/docs/QueryApi.md
@@ -14,6 +14,7 @@ Method | HTTP request | Description
 [**TestQueryStyleFormExplodeTrueArrayString**](QueryApi.md#TestQueryStyleFormExplodeTrueArrayString) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 [**TestQueryStyleFormExplodeTrueObject**](QueryApi.md#TestQueryStyleFormExplodeTrueObject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 [**TestQueryStyleFormExplodeTrueObjectAllOf**](QueryApi.md#TestQueryStyleFormExplodeTrueObjectAllOf) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+[**TestQueryStyleJsonSerializationObject**](QueryApi.md#TestQueryStyleJsonSerializationObject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 # **TestEnumRefString**
@@ -477,6 +478,55 @@ dput(result)
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **query_object** | [**DataQuery**](.md)|  | [optional] 
+
+### Return type
+
+**character**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+# **TestQueryStyleJsonSerializationObject**
+> character TestQueryStyleJsonSerializationObject(json_serialized_object_ref_string_query = var.json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query = var.json_serialized_object_array_ref_string_query)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Example
+```R
+library(openapi)
+
+# Test query parameter(s)
+#
+# prepare function argument(s)
+var_json_serialized_object_ref_string_query <- Pet$new("name_example", c("photoUrls_example"), 123, Category$new(123, "name_example"), c(Tag$new(123, "name_example")), "available") # Pet |  (Optional)
+var_json_serialized_object_array_ref_string_query <- c(Pet$new("name_example", c("photoUrls_example"), 123, Category$new(123, "name_example"), c(Tag$new(123, "name_example")), "available")) # array[Pet] |  (Optional)
+
+api_instance <- QueryApi$new()
+# to save the result into a file, simply add the optional `data_file` parameter, e.g.
+# result <- api_instance$TestQueryStyleJsonSerializationObject(json_serialized_object_ref_string_query = var_json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query = var_json_serialized_object_array_ref_string_querydata_file = "result.txt")
+result <- api_instance$TestQueryStyleJsonSerializationObject(json_serialized_object_ref_string_query = var_json_serialized_object_ref_string_query, json_serialized_object_array_ref_string_query = var_json_serialized_object_array_ref_string_query)
+dput(result)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **json_serialized_object_ref_string_query** | [**Pet**](.md)|  | [optional] 
+ **json_serialized_object_array_ref_string_query** | list( [**Pet**](Pet.md) )|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/ruby-faraday/README.md
+++ b/samples/client/echo_api/ruby-faraday/README.md
@@ -111,6 +111,7 @@ Class | Method | HTTP request | Description
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_array_string**](docs/QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_object**](docs/QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_object_all_of**](docs/QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*OpenapiClient::QueryApi* | [**test_query_style_json_serialization_object**](docs/QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/ruby-faraday/docs/QueryApi.md
+++ b/samples/client/echo_api/ruby-faraday/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**test_query_style_form_explode_true_array_string**](QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**test_query_style_form_explode_true_object**](QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**test_query_style_form_explode_true_object_all_of**](QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**test_query_style_json_serialization_object**](QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 ## test_enum_ref_string
@@ -671,6 +672,74 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **query_object** | [**DataQuery**](.md) |  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+## test_query_style_json_serialization_object
+
+> String test_query_style_json_serialization_object(opts)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Examples
+
+```ruby
+require 'time'
+require 'openapi_client'
+
+api_instance = OpenapiClient::QueryApi.new
+opts = {
+  json_serialized_object_ref_string_query: OpenapiClient::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}), # Pet | 
+  json_serialized_object_array_ref_string_query: [OpenapiClient::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']})] # Array<Pet> | 
+}
+
+begin
+  # Test query parameter(s)
+  result = api_instance.test_query_style_json_serialization_object(opts)
+  p result
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling QueryApi->test_query_style_json_serialization_object: #{e}"
+end
+```
+
+#### Using the test_query_style_json_serialization_object_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> test_query_style_json_serialization_object_with_http_info(opts)
+
+```ruby
+begin
+  # Test query parameter(s)
+  data, status_code, headers = api_instance.test_query_style_json_serialization_object_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling QueryApi->test_query_style_json_serialization_object_with_http_info: #{e}"
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **json_serialized_object_ref_string_query** | [**Pet**](.md) |  | [optional] |
+| **json_serialized_object_array_ref_string_query** | [**Array&lt;Pet&gt;**](Pet.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/query_api.rb
@@ -637,5 +637,68 @@ module OpenapiClient
       end
       return data, status_code, headers
     end
+
+    # Test query parameter(s)
+    # Test query parameter(s)
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :json_serialized_object_ref_string_query 
+    # @option opts [Array<Pet>] :json_serialized_object_array_ref_string_query 
+    # @return [String]
+    def test_query_style_json_serialization_object(opts = {})
+      data, _status_code, _headers = test_query_style_json_serialization_object_with_http_info(opts)
+      data
+    end
+
+    # Test query parameter(s)
+    # Test query parameter(s)
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :json_serialized_object_ref_string_query 
+    # @option opts [Array<Pet>] :json_serialized_object_array_ref_string_query 
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
+    def test_query_style_json_serialization_object_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: QueryApi.test_query_style_json_serialization_object ...'
+      end
+      # resource path
+      local_var_path = '/query/style_jsonSerialization/object'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'] if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_array_ref_string_query'] = @api_client.build_collection_param(opts[:'json_serialized_object_array_ref_string_query'], :csv) if !opts[:'json_serialized_object_array_ref_string_query'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'String'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"QueryApi.test_query_style_json_serialization_object",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: QueryApi#test_query_style_json_serialization_object\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/samples/client/echo_api/ruby-httpx/README.md
+++ b/samples/client/echo_api/ruby-httpx/README.md
@@ -111,6 +111,7 @@ Class | Method | HTTP request | Description
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_array_string**](docs/QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_object**](docs/QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_object_all_of**](docs/QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*OpenapiClient::QueryApi* | [**test_query_style_json_serialization_object**](docs/QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/ruby-httpx/docs/QueryApi.md
+++ b/samples/client/echo_api/ruby-httpx/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**test_query_style_form_explode_true_array_string**](QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**test_query_style_form_explode_true_object**](QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**test_query_style_form_explode_true_object_all_of**](QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**test_query_style_json_serialization_object**](QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 ## test_enum_ref_string
@@ -671,6 +672,74 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **query_object** | [**DataQuery**](.md) |  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+## test_query_style_json_serialization_object
+
+> String test_query_style_json_serialization_object(opts)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Examples
+
+```ruby
+require 'time'
+require 'openapi_client'
+
+api_instance = OpenapiClient::QueryApi.new
+opts = {
+  json_serialized_object_ref_string_query: OpenapiClient::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}), # Pet | 
+  json_serialized_object_array_ref_string_query: [OpenapiClient::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']})] # Array<Pet> | 
+}
+
+begin
+  # Test query parameter(s)
+  result = api_instance.test_query_style_json_serialization_object(opts)
+  p result
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling QueryApi->test_query_style_json_serialization_object: #{e}"
+end
+```
+
+#### Using the test_query_style_json_serialization_object_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> test_query_style_json_serialization_object_with_http_info(opts)
+
+```ruby
+begin
+  # Test query parameter(s)
+  data, status_code, headers = api_instance.test_query_style_json_serialization_object_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling QueryApi->test_query_style_json_serialization_object_with_http_info: #{e}"
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **json_serialized_object_ref_string_query** | [**Pet**](.md) |  | [optional] |
+| **json_serialized_object_array_ref_string_query** | [**Array&lt;Pet&gt;**](Pet.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
@@ -637,5 +637,68 @@ module OpenapiClient
       end
       return data, status_code, headers
     end
+
+    # Test query parameter(s)
+    # Test query parameter(s)
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :json_serialized_object_ref_string_query 
+    # @option opts [Array<Pet>] :json_serialized_object_array_ref_string_query 
+    # @return [String]
+    def test_query_style_json_serialization_object(opts = {})
+      data, _status_code, _headers = test_query_style_json_serialization_object_with_http_info(opts)
+      data
+    end
+
+    # Test query parameter(s)
+    # Test query parameter(s)
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :json_serialized_object_ref_string_query 
+    # @option opts [Array<Pet>] :json_serialized_object_array_ref_string_query 
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
+    def test_query_style_json_serialization_object_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: QueryApi.test_query_style_json_serialization_object ...'
+      end
+      # resource path
+      local_var_path = '/query/style_jsonSerialization/object'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'] if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_array_ref_string_query'] = @api_client.build_collection_param(opts[:'json_serialized_object_array_ref_string_query'], :csv) if !opts[:'json_serialized_object_array_ref_string_query'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'String'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"QueryApi.test_query_style_json_serialization_object",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: QueryApi#test_query_style_json_serialization_object\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/samples/client/echo_api/ruby-typhoeus/README.md
+++ b/samples/client/echo_api/ruby-typhoeus/README.md
@@ -109,6 +109,7 @@ Class | Method | HTTP request | Description
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_array_string**](docs/QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_object**](docs/QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_style_form_explode_true_object_all_of**](docs/QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*OpenapiClient::QueryApi* | [**test_query_style_json_serialization_object**](docs/QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ## Documentation for Models

--- a/samples/client/echo_api/ruby-typhoeus/docs/QueryApi.md
+++ b/samples/client/echo_api/ruby-typhoeus/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 | [**test_query_style_form_explode_true_array_string**](QueryApi.md#test_query_style_form_explode_true_array_string) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s) |
 | [**test_query_style_form_explode_true_object**](QueryApi.md#test_query_style_form_explode_true_object) | **GET** /query/style_form/explode_true/object | Test query parameter(s) |
 | [**test_query_style_form_explode_true_object_all_of**](QueryApi.md#test_query_style_form_explode_true_object_all_of) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s) |
+| [**test_query_style_json_serialization_object**](QueryApi.md#test_query_style_json_serialization_object) | **GET** /query/style_jsonSerialization/object | Test query parameter(s) |
 
 
 ## test_enum_ref_string
@@ -671,6 +672,74 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **query_object** | [**DataQuery**](.md) |  | [optional] |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: text/plain
+
+
+## test_query_style_json_serialization_object
+
+> String test_query_style_json_serialization_object(opts)
+
+Test query parameter(s)
+
+Test query parameter(s)
+
+### Examples
+
+```ruby
+require 'time'
+require 'openapi_client'
+
+api_instance = OpenapiClient::QueryApi.new
+opts = {
+  json_serialized_object_ref_string_query: OpenapiClient::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']}), # Pet | 
+  json_serialized_object_array_ref_string_query: [OpenapiClient::Pet.new({name: 'doggie', photo_urls: ['photo_urls_example']})] # Array<Pet> | 
+}
+
+begin
+  # Test query parameter(s)
+  result = api_instance.test_query_style_json_serialization_object(opts)
+  p result
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling QueryApi->test_query_style_json_serialization_object: #{e}"
+end
+```
+
+#### Using the test_query_style_json_serialization_object_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(String, Integer, Hash)> test_query_style_json_serialization_object_with_http_info(opts)
+
+```ruby
+begin
+  # Test query parameter(s)
+  data, status_code, headers = api_instance.test_query_style_json_serialization_object_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => String
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling QueryApi->test_query_style_json_serialization_object_with_http_info: #{e}"
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **json_serialized_object_ref_string_query** | [**Pet**](.md) |  | [optional] |
+| **json_serialized_object_array_ref_string_query** | [**Array&lt;Pet&gt;**](Pet.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/query_api.rb
@@ -637,5 +637,68 @@ module OpenapiClient
       end
       return data, status_code, headers
     end
+
+    # Test query parameter(s)
+    # Test query parameter(s)
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :json_serialized_object_ref_string_query 
+    # @option opts [Array<Pet>] :json_serialized_object_array_ref_string_query 
+    # @return [String]
+    def test_query_style_json_serialization_object(opts = {})
+      data, _status_code, _headers = test_query_style_json_serialization_object_with_http_info(opts)
+      data
+    end
+
+    # Test query parameter(s)
+    # Test query parameter(s)
+    # @param [Hash] opts the optional parameters
+    # @option opts [Pet] :json_serialized_object_ref_string_query 
+    # @option opts [Array<Pet>] :json_serialized_object_array_ref_string_query 
+    # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
+    def test_query_style_json_serialization_object_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: QueryApi.test_query_style_json_serialization_object ...'
+      end
+      # resource path
+      local_var_path = '/query/style_jsonSerialization/object'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'json_serialized_object_ref_string_query'] = opts[:'json_serialized_object_ref_string_query'] if !opts[:'json_serialized_object_ref_string_query'].nil?
+      query_params[:'json_serialized_object_array_ref_string_query'] = @api_client.build_collection_param(opts[:'json_serialized_object_array_ref_string_query'], :csv) if !opts[:'json_serialized_object_array_ref_string_query'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['text/plain']) unless header_params['Accept']
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'String'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"QueryApi.test_query_style_json_serialization_object",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: QueryApi#test_query_style_json_serialization_object\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/samples/client/echo_api/typescript-axios/build/README.md
+++ b/samples/client/echo_api/typescript-axios/build/README.md
@@ -78,6 +78,7 @@ Class | Method | HTTP request | Description
 *QueryApi* | [**testQueryStyleFormExplodeTrueArrayString**](docs/QueryApi.md#testquerystyleformexplodetruearraystring) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObject**](docs/QueryApi.md#testquerystyleformexplodetrueobject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)
 *QueryApi* | [**testQueryStyleFormExplodeTrueObjectAllOf**](docs/QueryApi.md#testquerystyleformexplodetrueobjectallof) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)
+*QueryApi* | [**testQueryStyleJsonSerializationObject**](docs/QueryApi.md#testquerystylejsonserializationobject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)
 
 
 ### Documentation For Models

--- a/samples/client/echo_api/typescript-axios/build/api.ts
+++ b/samples/client/echo_api/typescript-axios/build/api.ts
@@ -2259,6 +2259,46 @@ export const QueryApiAxiosParamCreator = function (configuration?: Configuration
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Test query parameter(s)
+         * @summary Test query parameter(s)
+         * @param {Pet} [jsonSerializedObjectRefStringQuery] 
+         * @param {Array<Pet>} [jsonSerializedObjectArrayRefStringQuery] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testQueryStyleJsonSerializationObject: async (jsonSerializedObjectRefStringQuery?: Pet, jsonSerializedObjectArrayRefStringQuery?: Array<Pet>, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/query/style_jsonSerialization/object`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (jsonSerializedObjectRefStringQuery !== undefined) {
+                localVarQueryParameter['json_serialized_object_ref_string_query'] = jsonSerializedObjectRefStringQuery;
+            }
+
+            if (jsonSerializedObjectArrayRefStringQuery) {
+                localVarQueryParameter['json_serialized_object_array_ref_string_query'] = jsonSerializedObjectArrayRefStringQuery.join(COLLECTION_FORMATS.csv);
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -2404,6 +2444,20 @@ export const QueryApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['QueryApi.testQueryStyleFormExplodeTrueObjectAllOf']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         * Test query parameter(s)
+         * @summary Test query parameter(s)
+         * @param {Pet} [jsonSerializedObjectRefStringQuery] 
+         * @param {Array<Pet>} [jsonSerializedObjectArrayRefStringQuery] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery?: Pet, jsonSerializedObjectArrayRefStringQuery?: Array<Pet>, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<string>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['QueryApi.testQueryStyleJsonSerializationObject']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -2518,6 +2572,17 @@ export const QueryApiFactory = function (configuration?: Configuration, basePath
          */
         testQueryStyleFormExplodeTrueObjectAllOf(queryObject?: DataQuery, options?: RawAxiosRequestConfig): AxiosPromise<string> {
             return localVarFp.testQueryStyleFormExplodeTrueObjectAllOf(queryObject, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Test query parameter(s)
+         * @summary Test query parameter(s)
+         * @param {Pet} [jsonSerializedObjectRefStringQuery] 
+         * @param {Array<Pet>} [jsonSerializedObjectArrayRefStringQuery] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery?: Pet, jsonSerializedObjectArrayRefStringQuery?: Array<Pet>, options?: RawAxiosRequestConfig): AxiosPromise<string> {
+            return localVarFp.testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -2652,6 +2717,19 @@ export class QueryApi extends BaseAPI {
      */
     public testQueryStyleFormExplodeTrueObjectAllOf(queryObject?: DataQuery, options?: RawAxiosRequestConfig) {
         return QueryApiFp(this.configuration).testQueryStyleFormExplodeTrueObjectAllOf(queryObject, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Test query parameter(s)
+     * @summary Test query parameter(s)
+     * @param {Pet} [jsonSerializedObjectRefStringQuery] 
+     * @param {Array<Pet>} [jsonSerializedObjectArrayRefStringQuery] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof QueryApi
+     */
+    public testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery?: Pet, jsonSerializedObjectArrayRefStringQuery?: Array<Pet>, options?: RawAxiosRequestConfig) {
+        return QueryApiFp(this.configuration).testQueryStyleJsonSerializationObject(jsonSerializedObjectRefStringQuery, jsonSerializedObjectArrayRefStringQuery, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/samples/client/echo_api/typescript-axios/build/docs/QueryApi.md
+++ b/samples/client/echo_api/typescript-axios/build/docs/QueryApi.md
@@ -14,6 +14,7 @@ All URIs are relative to *http://localhost:3000*
 |[**testQueryStyleFormExplodeTrueArrayString**](#testquerystyleformexplodetruearraystring) | **GET** /query/style_form/explode_true/array_string | Test query parameter(s)|
 |[**testQueryStyleFormExplodeTrueObject**](#testquerystyleformexplodetrueobject) | **GET** /query/style_form/explode_true/object | Test query parameter(s)|
 |[**testQueryStyleFormExplodeTrueObjectAllOf**](#testquerystyleformexplodetrueobjectallof) | **GET** /query/style_form/explode_true/object/allOf | Test query parameter(s)|
+|[**testQueryStyleJsonSerializationObject**](#testquerystylejsonserializationobject) | **GET** /query/style_jsonSerialization/object | Test query parameter(s)|
 
 # **testEnumRefString**
 > string testEnumRefString()
@@ -522,6 +523,61 @@ const { status, data } = await apiInstance.testQueryStyleFormExplodeTrueObjectAl
 |Name | Type | Description  | Notes|
 |------------- | ------------- | ------------- | -------------|
 | **queryObject** | **DataQuery** |  | (optional) defaults to undefined|
+
+
+### Return type
+
+**string**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **testQueryStyleJsonSerializationObject**
+> string testQueryStyleJsonSerializationObject()
+
+Test query parameter(s)
+
+### Example
+
+```typescript
+import {
+    QueryApi,
+    Configuration,
+    Pet
+} from '@openapitools/typescript-axios-echo-api';
+
+const configuration = new Configuration();
+const apiInstance = new QueryApi(configuration);
+
+let jsonSerializedObjectRefStringQuery: Pet; // (optional) (default to undefined)
+let jsonSerializedObjectArrayRefStringQuery: Array<Pet>; // (optional) (default to undefined)
+
+const { status, data } = await apiInstance.testQueryStyleJsonSerializationObject(
+    jsonSerializedObjectRefStringQuery,
+    jsonSerializedObjectArrayRefStringQuery
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **jsonSerializedObjectRefStringQuery** | **Pet** |  | (optional) defaults to undefined|
+| **jsonSerializedObjectArrayRefStringQuery** | **Array&lt;Pet&gt;** |  | (optional) defaults to undefined|
 
 
 ### Return type

--- a/samples/server/echo_api/erlang-server/priv/openapi.json
+++ b/samples/server/echo_api/erlang-server/priv/openapi.json
@@ -582,6 +582,52 @@
         "tags" : [ "query" ]
       }
     },
+    "/query/style_jsonSerialization/object" : {
+      "get" : {
+        "description" : "Test query parameter(s)",
+        "operationId" : "test/query/style_jsonSerialization/object",
+        "parameters" : [ {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Pet"
+              }
+            }
+          },
+          "in" : "query",
+          "name" : "json_serialized_object_ref_string_query",
+          "required" : false
+        }, {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "items" : {
+                  "$ref" : "#/components/schemas/Pet"
+                },
+                "type" : "array"
+              }
+            }
+          },
+          "in" : "query",
+          "name" : "json_serialized_object_array_ref_string_query",
+          "required" : false
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "text/plain" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "description" : "Successful operation"
+          }
+        },
+        "summary" : "Test query parameter(s)",
+        "tags" : [ "query" ]
+      }
+    },
     "/body/application/octetstream/binary" : {
       "post" : {
         "description" : "Test body parameter(s)",

--- a/samples/server/echo_api/erlang-server/src/openapi_api.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_api.erl
@@ -81,6 +81,7 @@ accept_callback(Class, OperationID, Req0, Context0) ->
     'test/query/style_form/explode_true/array_string' | %% Test query parameter(s)
     'test/query/style_form/explode_true/object' | %% Test query parameter(s)
     'test/query/style_form/explode_true/object/allOf' | %% Test query parameter(s)
+    'test/query/style_jsonSerialization/object' | %% Test query parameter(s)
     {error, unknown_operation}.
 
 -type request_param() :: atom().
@@ -206,6 +207,8 @@ validate_response('test/query/style_form/explode_true/array_string', 200, Body, 
 validate_response('test/query/style_form/explode_true/object', 200, Body, ValidatorState) ->
     validate_response_body('binary', 'string', Body, ValidatorState);
 validate_response('test/query/style_form/explode_true/object/allOf', 200, Body, ValidatorState) ->
+    validate_response_body('binary', 'string', Body, ValidatorState);
+validate_response('test/query/style_jsonSerialization/object', 200, Body, ValidatorState) ->
     validate_response_body('binary', 'string', Body, ValidatorState);
 validate_response(_OperationID, _Code, _Body, _ValidatorState) ->
     ok.
@@ -335,6 +338,11 @@ request_params('test/query/style_form/explode_true/object') ->
 request_params('test/query/style_form/explode_true/object/allOf') ->
     [
         'query_object'
+    ];
+request_params('test/query/style_jsonSerialization/object') ->
+    [
+        'json_serialized_object_ref_string_query',
+        'json_serialized_object_array_ref_string_query'
     ];
 request_params(_) ->
     error(unknown_operation).
@@ -669,6 +677,20 @@ request_param_info('test/query/style_form/explode_true/object', 'query_object') 
         ]
     };
 request_param_info('test/query/style_form/explode_true/object/allOf', 'query_object') ->
+    #{
+        source => qs_val,
+        rules => [
+            not_required
+        ]
+    };
+request_param_info('test/query/style_jsonSerialization/object', 'json_serialized_object_ref_string_query') ->
+    #{
+        source => qs_val,
+        rules => [
+            not_required
+        ]
+    };
+request_param_info('test/query/style_jsonSerialization/object', 'json_serialized_object_array_ref_string_query') ->
     #{
         source => qs_val,
         rules => [

--- a/samples/server/echo_api/erlang-server/src/openapi_query_handler.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_query_handler.erl
@@ -42,6 +42,10 @@ Test query parameter(s)
 Test query parameter(s).
 Test query parameter(s)
 
+- `GET` to `/query/style_jsonSerialization/object`, OperationId: `test/query/style_jsonSerialization/object`:
+Test query parameter(s).
+Test query parameter(s)
+
 """.
 
 -behaviour(cowboy_rest).
@@ -74,7 +78,8 @@ Test query parameter(s)
     | 'test/query/style_form/explode_false/array_string' %% Test query parameter(s)
     | 'test/query/style_form/explode_true/array_string' %% Test query parameter(s)
     | 'test/query/style_form/explode_true/object' %% Test query parameter(s)
-    | 'test/query/style_form/explode_true/object/allOf'. %% Test query parameter(s)
+    | 'test/query/style_form/explode_true/object/allOf' %% Test query parameter(s)
+    | 'test/query/style_jsonSerialization/object'. %% Test query parameter(s)
 
 
 -record(state,
@@ -122,6 +127,8 @@ allowed_methods(Req, #state{operation_id = 'test/query/style_form/explode_true/o
     {[<<"GET">>], Req, State};
 allowed_methods(Req, #state{operation_id = 'test/query/style_form/explode_true/object/allOf'} = State) ->
     {[<<"GET">>], Req, State};
+allowed_methods(Req, #state{operation_id = 'test/query/style_jsonSerialization/object'} = State) ->
+    {[<<"GET">>], Req, State};
 allowed_methods(Req, State) ->
     {[], Req, State}.
 
@@ -152,6 +159,8 @@ content_types_accepted(Req, #state{operation_id = 'test/query/style_form/explode
     {[], Req, State};
 content_types_accepted(Req, #state{operation_id = 'test/query/style_form/explode_true/object/allOf'} = State) ->
     {[], Req, State};
+content_types_accepted(Req, #state{operation_id = 'test/query/style_jsonSerialization/object'} = State) ->
+    {[], Req, State};
 content_types_accepted(Req, State) ->
     {[], Req, State}.
 
@@ -176,6 +185,8 @@ valid_content_headers(Req, #state{operation_id = 'test/query/style_form/explode_
 valid_content_headers(Req, #state{operation_id = 'test/query/style_form/explode_true/object'} = State) ->
     {true, Req, State};
 valid_content_headers(Req, #state{operation_id = 'test/query/style_form/explode_true/object/allOf'} = State) ->
+    {true, Req, State};
+valid_content_headers(Req, #state{operation_id = 'test/query/style_jsonSerialization/object'} = State) ->
     {true, Req, State};
 valid_content_headers(Req, State) ->
     {false, Req, State}.
@@ -219,6 +230,10 @@ content_types_provided(Req, #state{operation_id = 'test/query/style_form/explode
       {<<"text/plain">>, handle_type_provided}
      ], Req, State};
 content_types_provided(Req, #state{operation_id = 'test/query/style_form/explode_true/object/allOf'} = State) ->
+    {[
+      {<<"text/plain">>, handle_type_provided}
+     ], Req, State};
+content_types_provided(Req, #state{operation_id = 'test/query/style_jsonSerialization/object'} = State) ->
     {[
       {<<"text/plain">>, handle_type_provided}
      ], Req, State};

--- a/samples/server/echo_api/erlang-server/src/openapi_router.erl
+++ b/samples/server/echo_api/erlang-server/src/openapi_router.erl
@@ -235,5 +235,12 @@ get_operations() ->
             path => "/query/style_form/explode_true/object/allOf",
             method => <<"GET">>,
             handler => 'openapi_query_handler'
+        },
+       'test/query/style_jsonSerialization/object' => #{
+            servers => [],
+            base_path => "",
+            path => "/query/style_jsonSerialization/object",
+            method => <<"GET">>,
+            handler => 'openapi_query_handler'
         }
     }.


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
I am interested in implementing so that the Spring http clients can support Json serialization for query parameters. 

Since this effort might take a while, especially to get right, I would find it beneficial if the project exposed a codegenParameter which could be used to handle this with a local template-modification until a finished implementation is available in the project.

This PR adds this, in the form of a codegenParameter `queryIsJsonMimeType`. It can be used as `{{#queryIsJsonMimeType}}` as a [complement](https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content) to `{{#isExplode}}` in the `api.mustache` file to adjust how an object is serialized.

I have also added an endpoint to a sample specification that use query parameters with json serialization, so that it can be seen later how they are affected when a serialization implementation is in place.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
