### PR TITLE
fix(typescript): add Date instance check before date formatting

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -177,6 +177,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -182,11 +182,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -814,8 +814,8 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
 
         final String[] localVarAccepts = { 
             "text/plain"

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -814,8 +814,8 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
 
         final String[] localVarAccepts = { 
             "text/plain"

--- a/samples/client/echo_api/typescript/build/models/ObjectSerializer.ts
+++ b/samples/client/echo_api/typescript/build/models/ObjectSerializer.ts
@@ -185,6 +185,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/client/echo_api/typescript/build/models/ObjectSerializer.ts
+++ b/samples/client/echo_api/typescript/build/models/ObjectSerializer.ts
@@ -190,11 +190,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/others/typescript/builds/array-of-lists/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/models/ObjectSerializer.ts
@@ -157,11 +157,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/others/typescript/builds/array-of-lists/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/array-of-lists/models/ObjectSerializer.ts
@@ -152,6 +152,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/client/others/typescript/builds/enum-single-value/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/models/ObjectSerializer.ts
@@ -159,11 +159,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/others/typescript/builds/enum-single-value/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/enum-single-value/models/ObjectSerializer.ts
@@ -154,6 +154,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/client/others/typescript/builds/null-types-simple/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/models/ObjectSerializer.ts
@@ -157,11 +157,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/others/typescript/builds/null-types-simple/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/null-types-simple/models/ObjectSerializer.ts
@@ -152,6 +152,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -154,11 +154,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -149,6 +149,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/client/others/typescript/encode-decode/build/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/encode-decode/build/models/ObjectSerializer.ts
@@ -157,11 +157,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/client/others/typescript/encode-decode/build/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/encode-decode/build/models/ObjectSerializer.ts
@@ -152,6 +152,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -176,11 +176,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -171,6 +171,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/deno_object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno_object_params/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/models/ObjectSerializer.ts
@@ -296,6 +296,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/explode-query/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/explode-query/models/ObjectSerializer.ts
@@ -301,11 +301,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/models/ObjectSerializer.ts
@@ -150,6 +150,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()

--- a/samples/openapi3/client/petstore/typescript/builds/nullable-enum/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/nullable-enum/models/ObjectSerializer.ts
@@ -155,11 +155,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -171,11 +171,11 @@ export class ObjectSerializer {
             }
             if (format == "date") {
                 let month = data.getMonth()+1
-                month = month < 10 ? "0" + month.toString() : month.toString()
+                let monthStr = month < 10 ? "0" + month.toString() : month.toString()
                 let day = data.getDate();
-                day = day < 10 ? "0" + day.toString() : day.toString();
+                let dayStr = day < 10 ? "0" + day.toString() : day.toString();
 
-                return data.getFullYear() + "-" + month + "-" + day;
+                return data.getFullYear() + "-" + monthStr + "-" + dayStr;
             } else {
                 return data.toISOString();
             }

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -166,6 +166,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (!(data instanceof Date)) {
+                return data;
+            }
             if (format == "date") {
                 let month = data.getMonth()+1
                 month = month < 10 ? "0" + month.toString() : month.toString()


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fixes https://github.com/kubernetes-client/javascript/issues/2189

-  Similar to PR #17514, which fixed the same issue in the typescript-node generator.
-  This PR targets the typescript/typescript-fetch generators instead. Projects like kubernetes-client/javascript use typescript-fetch, not typescript-node, so they are still affected.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)