### PR TITLE
Support Json-serialized query parameters in Spring client RestClient and WebClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/ApiClient.mustache
@@ -6,6 +6,7 @@ package {{invokerPackage}};
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 {{/withXml}}
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -501,6 +502,36 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/api.mustache
@@ -108,10 +108,28 @@ public class {{classname}} {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
         {{#hasQueryParams}}
 
-        {{#queryParams}}{{#isExplode}}{{#hasVars}}{{#vars}}queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
-        {{/vars}}{{/hasVars}}{{^hasVars}}queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
-        {{/hasVars}}{{/isExplode}}{{^isExplode}}queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
-        {{/isExplode}}{{/queryParams}}{{/hasQueryParams}}{{#hasHeaderParams}}
+            {{#queryParams}}
+            {{#queryIsJsonMimeType}}
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+            {{/queryIsJsonMimeType}}
+            {{^queryIsJsonMimeType}}
+            {{#isExplode}}
+                {{#hasVars}}
+                    {{#vars}}
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
+                    {{/vars}}
+                {{/hasVars}}
+                {{^hasVars}}
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+                {{/hasVars}}
+            {{/isExplode}}
+            {{^isExplode}}
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+            {{/isExplode}}
+            {{/queryIsJsonMimeType}}
+            {{/queryParams}}
+        {{/hasQueryParams}}
+        {{#hasHeaderParams}}
 
         {{#headerParams}}
         if ({{paramName}} != null)

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -2,6 +2,7 @@
 
 package {{invokerPackage}};
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -444,6 +445,36 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/api.mustache
@@ -110,10 +110,28 @@ public class {{classname}} {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
         {{#hasQueryParams}}
 
-        {{#queryParams}}{{#isExplode}}{{#hasVars}}{{#vars}}queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
-        {{/vars}}{{/hasVars}}{{^hasVars}}queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
-        {{/hasVars}}{{/isExplode}}{{^isExplode}}queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
-        {{/isExplode}}{{/queryParams}}{{/hasQueryParams}}{{#hasHeaderParams}}
+            {{#queryParams}}
+            {{#queryIsJsonMimeType}}
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+            {{/queryIsJsonMimeType}}
+            {{^queryIsJsonMimeType}}
+            {{#isExplode}}
+                {{#hasVars}}
+                    {{#vars}}
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}.{{getter}}()));
+                    {{/vars}}
+                {{/hasVars}}
+                {{^hasVars}}
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+                {{/hasVars}}
+            {{/isExplode}}
+            {{^isExplode}}
+        queryParams.putAll(apiClient.parameterToMultiValueMap({{#collectionFormat}}ApiClient.CollectionFormat.valueOf("{{{.}}}".toUpperCase(Locale.ROOT)){{/collectionFormat}}{{^collectionFormat}}null{{/collectionFormat}}, "{{baseName}}", {{paramName}}));
+            {{/isExplode}}
+            {{/queryIsJsonMimeType}}
+            {{/queryParams}}
+        {{/hasQueryParams}}
+        {{#hasHeaderParams}}
 
         {{#headerParams}}
         if ({{paramName}} != null)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -47,6 +47,7 @@ import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.testutils.ConfigAssert;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -72,6 +73,8 @@ import static org.openapitools.codegen.languages.JavaClientCodegen.*;
 import static org.testng.Assert.*;
 
 public class JavaClientCodegenTest {
+
+    private static final String JAVA_GENERATOR = "java";
 
     // This is the kind of information that ideally would be defined and available system-wide
     @Getter
@@ -299,7 +302,7 @@ public class JavaClientCodegenTest {
     public void testGeneratedAuthClassesJersey() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.JERSEY3)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml")
@@ -322,7 +325,7 @@ public class JavaClientCodegenTest {
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .addTypeMapping("OffsetDateTime", "Instant")
                 .addImportMapping("OffsetDateTime", "java.time.Instant")
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/echo_api.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
 
@@ -414,7 +417,7 @@ public class JavaClientCodegenTest {
     public void testGeneratePing() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.OKHTTP_GSON)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/ping.yaml")
@@ -471,7 +474,7 @@ public class JavaClientCodegenTest {
     public void testGeneratePingSomeObj() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.MODEL_PACKAGE, "zz.yyyy.model.xxxx")
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "zz.yyyy.api.xxxx")
                 .addAdditionalProperty(CodegenConstants.INVOKER_PACKAGE, "zz.yyyy.invoker.xxxx")
@@ -534,7 +537,7 @@ public class JavaClientCodegenTest {
     public void testJdkHttpClient() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/ping.yaml")
@@ -561,7 +564,7 @@ public class JavaClientCodegenTest {
     public void testJdkHttpClientWithUseBeanValidationEnabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_BEANVALIDATION, true)
@@ -580,7 +583,7 @@ public class JavaClientCodegenTest {
     public void testJdkHttpClientWithAndWithoutDiscriminator() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(CodegenConstants.MODEL_PACKAGE, "xyz.abcdef.model")
@@ -603,7 +606,7 @@ public class JavaClientCodegenTest {
     public void testJdkHttpAsyncClient() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.ASYNC_NATIVE, true)
                 .setLibrary(JavaClientCodegen.NATIVE)
@@ -685,7 +688,7 @@ public class JavaClientCodegenTest {
     public void testAuthorizationScopeValues_Issue6733() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTEASY)
                 .setValidateSpec(false)
                 .setInputSpec("src/test/resources/3_0/regression-6734.yaml")
@@ -709,7 +712,7 @@ public class JavaClientCodegenTest {
     public void testTypedAndNonTypedComposedSchemaGeneration_3_1() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTEASY)
                 .setValidateSpec(false)
                 .setInputSpec("src/test/resources/3_1/composed-schemas-with-and-without-type.yaml")
@@ -732,7 +735,7 @@ public class JavaClientCodegenTest {
     public void testMultiPartSpecifiesFileName_Issue17367() throws IOException {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTEASY)
                 .setValidateSpec(false)
                 .setInputSpec("src/test/resources/3_0/issue-17367.yaml")
@@ -818,7 +821,7 @@ public class JavaClientCodegenTest {
     public void testSchemaMapping() throws IOException {
         final Path output = newTempFolder();
         final ClientOptInput clientOptInput = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTEASY)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setSchemaMappings(Map.of("TypeAlias", "foo.bar.TypeAlias"))
@@ -868,7 +871,7 @@ public class JavaClientCodegenTest {
     public void testVertXAuthInfoWithHyphenSeparatedSecurityScheme() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.VERTX)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/ping-with-hyphen-separated-security-scheme.yaml")
@@ -1080,7 +1083,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateFormMultipart() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
@@ -1116,7 +1119,7 @@ public class JavaClientCodegenTest {
     public void testWebClientFormMultipart() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
@@ -1146,7 +1149,7 @@ public class JavaClientCodegenTest {
     public void shouldGenerateBlockingAndNoBlockingOperationsForWebClient() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.WEBCLIENT_BLOCKING_OPERATIONS, true)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
@@ -1176,7 +1179,7 @@ public class JavaClientCodegenTest {
     public void testAllowModelWithNoProperties() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.OKHTTP_GSON)
                 .setInputSpec("src/test/resources/2_0/emptyBaseModel.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1205,7 +1208,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithUseAbstractionForFiles() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
@@ -1292,7 +1295,7 @@ public class JavaClientCodegenTest {
     public void testCustomMethodParamsAreCamelizedWhenUsingFeign() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(FEIGN)
                 .setInputSpec("src/test/resources/3_0/issue_7791.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1320,7 +1323,7 @@ public class JavaClientCodegenTest {
     public void testCharsetInContentTypeCorrectlyEncodedForFeignApi_issue19895() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(FEIGN)
                 .setInputSpec("src/test/resources/3_0/issue_19895.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1353,7 +1356,7 @@ public class JavaClientCodegenTest {
     public void testWebClientWithUseAbstractionForFiles() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
@@ -1386,7 +1389,8 @@ public class JavaClientCodegenTest {
     @Test
     public void testRestTemplateWithFreeFormInQueryParameters() {
         final Path output = newTempFolder();
-        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/issue8352.yaml")
@@ -1404,7 +1408,8 @@ public class JavaClientCodegenTest {
     @Test
     public void testWebClientWithFreeFormInQueryParameters() {
         final Path output = newTempFolder();
-        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/issue8352.yaml")
@@ -1424,7 +1429,7 @@ public class JavaClientCodegenTest {
     public void testNativeClientWhiteSpacePathParamEncoding() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/issue11242.yaml")
@@ -1447,7 +1452,7 @@ public class JavaClientCodegenTest {
     public void testNativeClientExplodedQueryParamObject() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/issue4808.yaml")
@@ -1470,7 +1475,7 @@ public class JavaClientCodegenTest {
     public void testDefaultMicroprofileRestClientVersion() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.MICROPROFILE)
                 .setInputSpec("src/test/resources/3_0/petstore.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1494,7 +1499,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setAdditionalProperties(Map.of(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "1.4.1"))
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.MICROPROFILE)
                 .setInputSpec("src/test/resources/3_0/petstore.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1523,7 +1528,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setAdditionalProperties(Map.of(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "incorrectVersion"))
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.MICROPROFILE)
                 .setInputSpec("src/test/resources/3_0/petstore.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1538,7 +1543,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setAdditionalProperties(Map.of(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0"))
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.MICROPROFILE)
                 .setInputSpec("src/test/resources/3_0/petstore.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1562,7 +1567,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setAdditionalProperties(Map.of(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0"))
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.MICROPROFILE)
                 .setInputSpec("src/test/resources/bugs/issue_12622.json")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1593,9 +1598,8 @@ public class JavaClientCodegenTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-
                 .setAdditionalProperties(properties)
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.MICROPROFILE)
                 .setInputSpec("src/test/resources/bugs/issue_18336.yaml")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
@@ -1620,7 +1624,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setAdditionalProperties(Map.of(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "3.0"))
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setOutputDir(output.toString().replace("\\", "/"))
                 .setInputSpec("src/test/resources/bugs/java-codegen-empty-array-as-default-value/issue_wrong-default.yaml");
@@ -1644,7 +1648,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setAdditionalProperties(Map.of(AbstractJavaCodegen.OPENAPI_NULLABLE, "true"))
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setInputSpec("src/test/resources/bugs/issue_12790.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1665,7 +1669,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateResponseTypeWithUseAbstractionForFiles() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
@@ -1689,7 +1693,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final String outputPath = output.toString().replace('\\', '/');
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library.value)
                 .setAdditionalProperties(Map.of(CXFServerFeatures.LOAD_TEST_DATA_FROM_FILE, "true"))
                 .setInputSpec("src/test/resources/3_0/issue_11772.yml")
@@ -1710,7 +1714,8 @@ public class JavaClientCodegenTest {
     @Test
     public void testReferencedHeader2() {
         final Path output = newTempFolder();
-        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
                 .setAdditionalProperties(Map.of(BeanValidationFeatures.USE_BEANVALIDATION, "true"))
                 .setInputSpec("src/test/resources/3_0/issue-11340.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -1733,7 +1738,7 @@ public class JavaClientCodegenTest {
     public void testReturnTypeMapping() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/issue14525.yaml")
                 .addTypeMapping("array", "Stack")
                 .addImportMapping("Stack", "java.util.Stack")
@@ -1749,7 +1754,7 @@ public class JavaClientCodegenTest {
     public void testNativeClientExplodedQueryParamWithArrayProperty() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/exploded-query-param-array.yaml")
@@ -1767,7 +1772,7 @@ public class JavaClientCodegenTest {
     public void testJdkHttpClientWithAndWithoutParentExtension() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 // use default `okhttp-gson`
                 //.setLibrary(JavaClientCodegen.NATIVE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
@@ -1966,7 +1971,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library)
                 .setAdditionalProperties(properties)
                 .setInputSpec(pathToSpecification)
@@ -2073,7 +2078,7 @@ public class JavaClientCodegenTest {
     public void testDeprecatedProperty() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.OKHTTP_GSON)
                 .setInputSpec("src/test/resources/3_0/deprecated-properties.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -2093,7 +2098,7 @@ public class JavaClientCodegenTest {
     public void testDeprecatedPropertyJersey3() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.JERSEY3)
                 .setInputSpec("src/test/resources/3_0/deprecated-properties.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -2122,7 +2127,7 @@ public class JavaClientCodegenTest {
     public void shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684(String library) {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library)
                 .addAdditionalProperty(AbstractJavaCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS, "@annotation1;@annotation2")
                 .setInputSpec("src/test/resources/3_0/deprecated-properties.yaml")
@@ -2145,7 +2150,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithGeneratedClientAsBeanDisabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.GENERATE_CLIENT_AS_BEAN, false)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
@@ -2163,7 +2168,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithGeneratedClientAsBeanEnabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.GENERATE_CLIENT_AS_BEAN, true)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
@@ -2181,7 +2186,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithUseBeanValidationEnabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_BEANVALIDATION, true)
@@ -2199,7 +2204,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithUseBeanValidationDisabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_BEANVALIDATION, false)
@@ -2217,7 +2222,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithPerformBeanValidationEnabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.PERFORM_BEANVALIDATION, true)
@@ -2235,7 +2240,7 @@ public class JavaClientCodegenTest {
     public void testRestTemplateWithPerformBeanValidationDisabled() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.PERFORM_BEANVALIDATION, false)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
@@ -2252,7 +2257,7 @@ public class JavaClientCodegenTest {
     @Test
     public void testLogicToAvoidStackOverflow() {
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.GENERATE_CLIENT_AS_BEAN, true)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
@@ -2268,7 +2273,7 @@ public class JavaClientCodegenTest {
     public void testWebClientSupportListOfStringReturnType_issue7118() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
@@ -2346,7 +2351,7 @@ public class JavaClientCodegenTest {
     public void testWebClientResponseTypeWithUseAbstractionForFiles_issue16589() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
@@ -2502,7 +2507,7 @@ public class JavaClientCodegenTest {
     private void testHandleURIEnum(String library, String[] expectedInnerEnumLines, String[] expectedEnumLines) {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library)
                 .setInputSpec("src/test/resources/3_0/enum-and-inner-enum-uri.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -2525,7 +2530,7 @@ public class JavaClientCodegenTest {
     public void testQueryParamsExploded_whenQueryParamIsNull() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTTEMPLATE)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/issue_17555.yaml")
@@ -2602,7 +2607,7 @@ public class JavaClientCodegenTest {
     public void testRestClientFormMultipart() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/form-multipart-binary-array.yaml")
@@ -2632,7 +2637,7 @@ public class JavaClientCodegenTest {
     public void testRestClientWithUseAbstractionForFiles() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
@@ -2661,7 +2666,8 @@ public class JavaClientCodegenTest {
     @Test
     public void testRestClientWithFreeFormInQueryParameters() {
         final Path output = newTempFolder();
-        final CodegenConfigurator configurator = new CodegenConfigurator().setGeneratorName("java")
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setAdditionalProperties(Map.of(CodegenConstants.API_PACKAGE, "xyz.abcdef.api"))
                 .setInputSpec("src/test/resources/3_0/issue8352.yaml")
@@ -2678,7 +2684,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .addAdditionalProperty(AbstractJavaCodegen.OPENAPI_NULLABLE, "true")
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setInputSpec("src/test/resources/bugs/issue_12790.yaml")
                 .setOutputDir(output.toString().replace("\\", "/"));
@@ -2700,7 +2706,7 @@ public class JavaClientCodegenTest {
     public void testRestClientSupportListOfStringReturnType_issue7118() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
@@ -2727,7 +2733,7 @@ public class JavaClientCodegenTest {
     public void testRestClientResponseTypeWithUseAbstractionForFiles_issue16589() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .addAdditionalProperty(CodegenConstants.API_PACKAGE, "xyz.abcdef.api")
                 .addAdditionalProperty(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
@@ -2797,7 +2803,7 @@ public class JavaClientCodegenTest {
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .addAdditionalProperty(SERIALIZATION_LIBRARY, Serializer.GSON)
                 .addAdditionalProperty(OPENAPI_NULLABLE, "false")
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library.getValue())
                 .setInputSpec("src/test/resources/3_0/java/autoset_constant.yaml")
                 .setOutputDir(newTempFolder().toString());
@@ -2817,7 +2823,7 @@ public class JavaClientCodegenTest {
     @Test
     void doesNotGenerateJacksonJsonFormatAnnotation_whenLibraryIsGson_andSerializeBigDecimalAsStringIsTrue() {
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.OKHTTP_GSON)
                 .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, SERIALIZATION_LIBRARY_GSON)
                 .addAdditionalProperty(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, true)
@@ -2844,7 +2850,7 @@ public class JavaClientCodegenTest {
     @Test
     void generatesJacksonJsonFormatAnnotation_whenLibraryIsJackson_andSerializeBigDecimalAsStringIsTrue() {
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .addAdditionalProperty(CodegenConstants.SERIALIZATION_LIBRARY, SERIALIZATION_LIBRARY_JACKSON)
                 .addAdditionalProperty(CodegenConstants.SERIALIZE_BIG_DECIMAL_AS_STRING, true)
@@ -2881,7 +2887,7 @@ public class JavaClientCodegenTest {
                 .addGlobalProperty(CodegenConstants.MODELS, "Pet")
                 .addGlobalProperty(CodegenConstants.MODEL_DOCS, null)
                 .addGlobalProperty(CodegenConstants.MODEL_TESTS, null)
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setInputSpec("src/test/resources/3_0/java/xml-annotations-test.yaml")
                 .setLibrary(library.value)
                 .setOutputDir(newTempFolder().toString());
@@ -3021,7 +3027,7 @@ public class JavaClientCodegenTest {
                 .addGlobalProperty(CodegenConstants.MODELS, "Pet")
                 .addGlobalProperty(CodegenConstants.MODEL_DOCS, null)
                 .addGlobalProperty(CodegenConstants.MODEL_TESTS, null)
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library.value)
                 .setInputSpec("src/test/resources/3_0/java/xml-annotations-test.yaml")
                 .setOutputDir(newTempFolder().toString());
@@ -3166,7 +3172,7 @@ public class JavaClientCodegenTest {
     public void testRestClientWithXML_issue_19137() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3189,7 +3195,7 @@ public class JavaClientCodegenTest {
     public void testRestClientWithUseSingleRequestParameter_issue_19406() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3216,7 +3222,7 @@ public class JavaClientCodegenTest {
     public void testRestClientWithUseSingleRequestParameter_static_issue_20668() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3252,7 +3258,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setValidateSpec(false)
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.RESTCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3288,7 +3294,7 @@ public class JavaClientCodegenTest {
     public void testWebClientWithUseSingleRequestParameter_issue_19407() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3318,7 +3324,7 @@ public class JavaClientCodegenTest {
     public void testWebClientWithUseSingleRequestParameter_static() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3348,7 +3354,7 @@ public class JavaClientCodegenTest {
     public void testWebClientWithUseSingleRequestParameter_static_issue_20668() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.WEBCLIENT)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3381,7 +3387,7 @@ public class JavaClientCodegenTest {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setValidateSpec(false)
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api"
                 ))
@@ -3411,7 +3417,7 @@ public class JavaClientCodegenTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .setAdditionalProperties(properties)
                 .setInputSpec("src/test/resources/3_0/java/native/issue13968.yaml")
@@ -3448,7 +3454,7 @@ public class JavaClientCodegenTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JavaClientCodegen.NATIVE)
                 .setAdditionalProperties(properties)
                 .setInputSpec("src/test/resources/3_0/java/native/issue13968.yaml")
@@ -3493,7 +3499,7 @@ public class JavaClientCodegenTest {
     public void testClassesAreValidJavaJersey2() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JERSEY2)
                 .setSchemaMappings(Map.of(
                         "A", "some.pkg.A",
@@ -3530,7 +3536,7 @@ public class JavaClientCodegenTest {
     public void testClassesAreValidJavaJersey3() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(JERSEY3)
                 .setSchemaMappings(Map.of(
                         "A", "some.pkg.A",
@@ -3567,7 +3573,7 @@ public class JavaClientCodegenTest {
     public void testClassesAreValidJavaOkHttpGson() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(OKHTTP_GSON)
                 .setSchemaMappings(Map.of(
                         "A", "some.pkg.A",
@@ -3614,7 +3620,7 @@ public class JavaClientCodegenTest {
         Generator generator = new DefaultGenerator();
         CodegenConfigurator configurator = new CodegenConfigurator()
                 .setInputSpec("src/test/resources/3_1/issue_21051.yaml")
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setAdditionalProperties(properties)
                 .setOutputDir(output.getAbsolutePath());
         ClientOptInput clientOptInput = configurator.toClientOptInput();
@@ -3670,7 +3676,7 @@ public class JavaClientCodegenTest {
     public void testNativeClientWithUseSingleRequestParameter() {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(NATIVE)
                 .setAdditionalProperties(Map.of(
                         CodegenConstants.API_PACKAGE, "xyz.abcdef.api",
@@ -3710,7 +3716,7 @@ public class JavaClientCodegenTest {
         Generator generator = new DefaultGenerator();
         CodegenConfigurator configurator = new CodegenConfigurator()
                 .setInputSpec("src/test/resources/3_0/oneOf.yaml")
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(library.value)
                 .setAdditionalProperties(properties)
                 .setOutputDir(output.getAbsolutePath());
@@ -3770,7 +3776,7 @@ public class JavaClientCodegenTest {
     public void sealedInterfaceScenariosRestClient(String apiFile, Map<String, String> definitions) {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(RESTCLIENT)
                 .setAdditionalProperties(Map.of(
                         USE_ONE_OF_INTERFACES, "true",
@@ -3789,7 +3795,7 @@ public class JavaClientCodegenTest {
     public void sealedInterfaceScenariosWebClient(String apiFile, Map<String, String> definitions) {
         final Path output = newTempFolder();
         final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("java")
+                .setGeneratorName(JAVA_GENERATOR)
                 .setLibrary(WEBCLIENT)
                 .setAdditionalProperties(Map.of(
                         USE_ONE_OF_INTERFACES, "true",
@@ -3804,5 +3810,31 @@ public class JavaClientCodegenTest {
                 assertFileContains(output.resolve("src/main/java/org/openapitools/client/model/" + file), check));
         assertFileContains(output.resolve("pom.xml"), "<source>17</source>");
         assertFileNotContains(output.resolve("pom.xml"), "<source>1.8</source>");
+    }
+
+    @Test(dataProvider = "springClients")
+    public void queryParameterJsonSerialization(String library) {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(library)
+                .setInputSpec("src/test/resources/3_0/echo_api.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        assertFileContains(
+                output.resolve("src/main/java/org/openapitools/client/api/QueryApi.java"),
+                "queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, \"json_serialized_object_ref_string_query\", jsonSerializedObjectRefStringQuery));"
+        );
+        assertFileContains(
+                output.resolve("src/main/java/org/openapitools/client/api/QueryApi.java"),
+                "queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat" +
+                ".valueOf(\"csv\".toUpperCase(Locale.ROOT)), \"json_serialized_object_array_ref_string_query\", jsonSerializedObjectArrayRefStringQuery));"
+        );
+    }
+
+    @DataProvider(name = "springClients")
+    public static Object[] springClients() {
+        return new Object[]{RESTCLIENT, WEBCLIENT};
     }
 }

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -436,6 +437,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -66,7 +66,6 @@ public class HeaderApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-
         if (integerHeader != null)
         headerParams.add("integer_header", apiClient.parameterToString(integerHeader));
         if (booleanHeader != null)

--- a/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/restclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -71,7 +71,7 @@ public class QueryApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_nonref_string_query", enumNonrefStringQuery));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_ref_string_query", enumRefStringQuery));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -149,7 +149,7 @@ public class QueryApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "datetime_query", datetimeQuery));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "date_query", dateQuery));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_query", stringQuery));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -230,7 +230,7 @@ public class QueryApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "integer_query", integerQuery));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "boolean_query", booleanQuery));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_query", stringQuery));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -312,7 +312,7 @@ public class QueryApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -383,7 +383,7 @@ public class QueryApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_object", queryObject));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -454,7 +454,7 @@ public class QueryApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "query_object", queryObject));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -525,7 +525,7 @@ public class QueryApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "query_object", queryObject));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -596,7 +596,7 @@ public class QueryApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "values", queryObject.getValues()));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -672,7 +672,7 @@ public class QueryApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "photoUrls", queryObject.getPhotoUrls()));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "tags", queryObject.getTags()));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "status", queryObject.getStatus()));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -743,7 +743,7 @@ public class QueryApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_object", queryObject));
-        
+
         final String[] localVarAccepts = { 
             "text/plain"
         };
@@ -814,9 +814,9 @@ public class QueryApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-        queryParams.putAll(apiClient.parameterToMultiValueMap(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
-        queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
-        
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson(null, "json_serialized_object_ref_string_query", jsonSerializedObjectRefStringQuery));
+        queryParams.putAll(apiClient.parameterToMultiValueMapJson(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "json_serialized_object_array_ref_string_query", jsonSerializedObjectArrayRefStringQuery));
+
         final String[] localVarAccepts = { 
             "text/plain"
         };

--- a/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-enum-in-multipart/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -435,6 +436,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/restclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -434,6 +435,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-sealedInterface/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -413,6 +414,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -413,6 +414,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -434,6 +435,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -497,6 +498,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -212,7 +212,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -867,7 +866,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1193,7 +1192,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1318,7 +1316,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -1733,7 +1730,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -146,7 +146,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -226,7 +225,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -307,7 +306,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -442,7 +442,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -497,6 +498,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -303,7 +303,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -1038,7 +1037,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1739,7 +1738,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1988,7 +1986,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -2618,7 +2615,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/PetApi.java
@@ -229,7 +229,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -309,7 +308,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -390,7 +389,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter-static/src/main/java/org/openapitools/client/api/UserApi.java
@@ -527,7 +527,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -497,6 +498,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -248,7 +248,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -939,7 +938,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1343,7 +1342,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1504,7 +1502,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -1991,7 +1988,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
@@ -185,7 +185,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -265,7 +264,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -346,7 +345,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
@@ -483,7 +483,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -497,6 +498,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -212,7 +212,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -867,7 +866,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1193,7 +1192,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1318,7 +1316,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -1733,7 +1730,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -146,7 +146,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -226,7 +225,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -307,7 +306,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -442,7 +442,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -433,6 +434,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -214,7 +214,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -869,7 +868,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1195,7 +1194,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1320,7 +1318,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -1735,7 +1732,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/PetApi.java
@@ -148,7 +148,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -228,7 +227,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -309,7 +308,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/api/UserApi.java
@@ -444,7 +444,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -413,6 +414,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -433,6 +434,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -214,7 +214,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -869,7 +868,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1195,7 +1194,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1320,7 +1318,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -1735,7 +1732,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/PetApi.java
@@ -148,7 +148,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -228,7 +227,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -309,7 +308,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/api/UserApi.java
@@ -444,7 +444,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -433,6 +434,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -306,7 +306,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -1042,7 +1041,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1745,7 +1744,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1995,7 +1993,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -2627,7 +2624,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/PetApi.java
@@ -232,7 +232,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -312,7 +311,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -393,7 +392,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient-useSingleRequestParameter/src/main/java/org/openapitools/client/api/UserApi.java
@@ -530,7 +530,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -13,6 +13,7 @@
 
 package org.openapitools.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -433,6 +434,36 @@ public class ApiClient extends JavaTimeFormatter {
         } else {
             return String.valueOf(param);
         }
+    }
+
+    /**
+    * Converts a parameter to a {@link MultiValueMap} containing Json-serialized values for use in REST requests
+    * @param collectionFormat The format to convert to
+    * @param name The name of the parameter
+    * @param value The parameter's value
+    * @return a Map containing the Json-serialized String value(s) of the input parameter
+    */
+    public MultiValueMap<String, String> parameterToMultiValueMapJson(CollectionFormat collectionFormat, String name, Object value) {
+        Collection<?> valueCollection;
+        if (value instanceof Collection) {
+            valueCollection = (Collection<?>) value;
+        } else {
+            try {
+                return parameterToMultiValueMap(collectionFormat, name, objectMapper.writeValueAsString(value));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> values = new ArrayList<>();
+        for(Object o : valueCollection) {
+            try {
+                values.add(objectMapper.writeValueAsString(o));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return parameterToMultiValueMap(collectionFormat, name, "[" + StringUtils.collectionToDelimitedString(values, collectionFormat.separator) + "]");
     }
 
     /**

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -214,7 +214,6 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query_1", query1));
-        
 
         if (header1 != null)
         headerParams.add("header_1", apiClient.parameterToString(header1));
@@ -869,7 +868,7 @@ public class FakeApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "query", query));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { 
@@ -1195,7 +1194,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_integer", enumQueryInteger));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "enum_query_double", enumQueryDouble));
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "enum_query_model_array", enumQueryModelArray));
-        
 
         if (enumHeaderStringArray != null)
         headerParams.add("enum_header_string_array", apiClient.parameterToString(enumHeaderStringArray));
@@ -1320,7 +1318,6 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "required_int64_group", requiredInt64Group));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "string_group", stringGroup));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "int64_group", int64Group));
-        
 
         if (requiredBooleanGroup != null)
         headerParams.add("required_boolean_group", apiClient.parameterToString(requiredBooleanGroup));
@@ -1735,7 +1732,7 @@ public class FakeApi {
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("multi".toUpperCase(Locale.ROOT)), "context", context));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "language", language));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "allowEmpty", allowEmpty));
-        
+
         final String[] localVarAccepts = { };
         final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         final String[] localVarContentTypes = { };

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/PetApi.java
@@ -148,7 +148,6 @@ public class PetApi {
         final MultiValueMap<String, String> cookieParams = new LinkedMultiValueMap<String, String>();
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
-
         if (apiKey != null)
         headerParams.add("api_key", apiClient.parameterToString(apiKey));
         final String[] localVarAccepts = { };
@@ -228,7 +227,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "status", status));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };
@@ -309,7 +308,7 @@ public class PetApi {
         final MultiValueMap<String, Object> formParams = new LinkedMultiValueMap<String, Object>();
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(ApiClient.CollectionFormat.valueOf("csv".toUpperCase(Locale.ROOT)), "tags", tags));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/api/UserApi.java
@@ -444,7 +444,7 @@ public class UserApi {
 
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "username", username));
         queryParams.putAll(apiClient.parameterToMultiValueMap(null, "password", password));
-        
+
         final String[] localVarAccepts = { 
             "application/xml", "application/json"
         };


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Adds support for Json-serialized query parameters. 

A query parameter with an array/object/array of objects is most often serialized based upon the `explode` and `style` [settings](https://swagger.io/docs/specification/v3_0/describing-parameters/#query-parameters). Another less common way of formatting query parameters is by stating that they should be [Json-serialized]((https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content)).

Since the RestClient and WebClient were already using an ObjectMapper, I configured so that that is used to serialize any query parameter. This should also mean that it should be easy for a client to adjust a parameter's serialization if the case is that the server does not want the "standard" serialization format that one would expect for an object (i.e., you can inject a custom Json-serialization for any query-object you might have).

I have tested the basic case of a single object and an array of objects in a local project by mirroring the mustache-file changes that I have committed here.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
