### PR TITLE
Use Python uuid.UUID instead of StrictStr

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -2024,7 +2024,8 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         }
 
         private PythonType uuidType(IJsonSchemaValidationProperties cp) {
-            return new PythonType(cp.getDataType());
+            moduleImports.add("uuid", "UUID");
+            return new PythonType("UUID");
         }
 
         private PythonType modelType(IJsonSchemaValidationProperties cp) {
@@ -2051,6 +2052,8 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 return arrayType(cp);
             } else if (cp.getIsMap() || cp.getIsFreeFormObject()) {
                 return mapType(cp);
+            } else if (cp.getIsUuid()) {
+                return uuidType(cp);
             } else if (cp.getIsString()) {
                 return stringType(cp);
             } else if (cp.getIsNumber() || cp.getIsFloat() || cp.getIsDouble()) {
@@ -2067,8 +2070,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 return anyType(cp);
             } else if (cp.getIsDate() || cp.getIsDateTime()) {
                 return dateType(cp);
-            } else if (cp.getIsUuid()) {
-                return uuidType(cp);
             }
 
             return null;

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -12,6 +12,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import uuid
 
 from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
@@ -365,6 +366,8 @@ class ApiClient:
             return obj.get_secret_value()
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
+        elif isinstance(obj, uuid.UUID):
+            return str(obj)
         elif isinstance(obj, list):
             return [
                 self.sanitize_for_serialization(sub_obj) for sub_obj in obj

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -22,6 +22,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import uuid
 
 from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
@@ -357,6 +358,8 @@ class ApiClient:
             return obj.get_secret_value()
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
+        elif isinstance(obj, uuid.UUID):
+            return str(obj)
         elif isinstance(obj, list):
             return [
                 self.sanitize_for_serialization(sub_obj) for sub_obj in obj

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -22,6 +22,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import uuid
 
 from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
@@ -357,6 +358,8 @@ class ApiClient:
             return obj.get_secret_value()
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
+        elif isinstance(obj, uuid.UUID):
+            return str(obj)
         elif isinstance(obj, list):
             return [
                 self.sanitize_for_serialization(sub_obj) for sub_obj in obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -20,6 +20,7 @@ from datetime import date, datetime
 from pydantic import Field, StrictBool, StrictBytes, StrictInt, StrictStr, field_validator
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
+from uuid import UUID
 from petstore_api.models.client import Client
 from petstore_api.models.enum_class import EnumClass
 from petstore_api.models.file_schema_test_class import FileSchemaTestClass
@@ -4913,7 +4914,7 @@ class FakeApi:
     @validate_call
     async def fake_uuid_example(
         self,
-        uuid_example: Annotated[StrictStr, Field(description="uuid example")],
+        uuid_example: Annotated[UUID, Field(description="uuid example")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -4979,7 +4980,7 @@ class FakeApi:
     @validate_call
     async def fake_uuid_example_with_http_info(
         self,
-        uuid_example: Annotated[StrictStr, Field(description="uuid example")],
+        uuid_example: Annotated[UUID, Field(description="uuid example")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -5045,7 +5046,7 @@ class FakeApi:
     @validate_call
     async def fake_uuid_example_without_preload_content(
         self,
-        uuid_example: Annotated[StrictStr, Field(description="uuid example")],
+        uuid_example: Annotated[UUID, Field(description="uuid example")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -21,6 +21,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import uuid
 
 from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
@@ -359,6 +360,8 @@ class ApiClient:
             return obj.get_secret_value()
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
+        elif isinstance(obj, uuid.UUID):
+            return str(obj)
         elif isinstance(obj, list):
             return [
                 self.sanitize_for_serialization(sub_obj) for sub_obj in obj

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -22,6 +22,7 @@ from decimal import Decimal
 from pydantic import BaseModel, ConfigDict, Field, StrictBytes, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
+from uuid import UUID
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -42,7 +43,7 @@ class FormatTest(BaseModel):
     binary: Optional[Union[StrictBytes, StrictStr, Tuple[StrictStr, StrictBytes]]] = None
     var_date: date = Field(alias="date")
     date_time: Optional[datetime] = Field(default=None, alias="dateTime")
-    uuid: Optional[StrictStr] = None
+    uuid: Optional[UUID] = None
     password: Annotated[str, Field(min_length=10, strict=True, max_length=64)]
     pattern_with_digits: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="A string that is a 10 digit number. Can have leading zeros.")
     pattern_with_digits_and_delimiter: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Optional
+from uuid import UUID
 from petstore_api.models.animal import Animal
 from typing import Optional, Set
 from typing_extensions import Self
@@ -28,7 +29,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     """
     MixedPropertiesAndAdditionalPropertiesClass
     """ # noqa: E501
-    uuid: Optional[StrictStr] = None
+    uuid: Optional[UUID] = None
     date_time: Optional[datetime] = Field(default=None, alias="dateTime")
     map: Optional[Dict[str, Animal]] = None
     __properties: ClassVar[List[str]] = ["uuid", "dateTime", "map"]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/task.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/task.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List
+from uuid import UUID
 from petstore_api.models.task_activity import TaskActivity
 from typing import Optional, Set
 from typing_extensions import Self
@@ -27,7 +28,7 @@ class Task(BaseModel):
     """
     Used to test oneOf enums with only one string value.
     """ # noqa: E501
-    id: StrictStr
+    id: UUID
     activity: TaskActivity
     __properties: ClassVar[List[str]] = ["id", "activity"]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -20,6 +20,7 @@ from datetime import date, datetime
 from pydantic import Field, StrictBool, StrictBytes, StrictFloat, StrictInt, StrictStr, field_validator
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
+from uuid import UUID
 from petstore_api.models.client import Client
 from petstore_api.models.enum_class import EnumClass
 from petstore_api.models.file_schema_test_class import FileSchemaTestClass
@@ -4913,7 +4914,7 @@ class FakeApi:
     @validate_call
     def fake_uuid_example(
         self,
-        uuid_example: Annotated[StrictStr, Field(description="uuid example")],
+        uuid_example: Annotated[UUID, Field(description="uuid example")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -4979,7 +4980,7 @@ class FakeApi:
     @validate_call
     def fake_uuid_example_with_http_info(
         self,
-        uuid_example: Annotated[StrictStr, Field(description="uuid example")],
+        uuid_example: Annotated[UUID, Field(description="uuid example")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -5045,7 +5046,7 @@ class FakeApi:
     @validate_call
     def fake_uuid_example_without_preload_content(
         self,
-        uuid_example: Annotated[StrictStr, Field(description="uuid example")],
+        uuid_example: Annotated[UUID, Field(description="uuid example")],
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -21,6 +21,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import uuid
 
 from urllib.parse import quote
 from typing import Tuple, Optional, List, Dict, Union
@@ -356,6 +357,8 @@ class ApiClient:
             return obj.get_secret_value()
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
+        elif isinstance(obj, uuid.UUID):
+            return str(obj)
         elif isinstance(obj, list):
             return [
                 self.sanitize_for_serialization(sub_obj) for sub_obj in obj

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -22,6 +22,7 @@ from decimal import Decimal
 from pydantic import BaseModel, ConfigDict, Field, StrictBytes, StrictInt, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
+from uuid import UUID
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -42,7 +43,7 @@ class FormatTest(BaseModel):
     binary: Optional[Union[StrictBytes, StrictStr, Tuple[StrictStr, StrictBytes]]] = None
     var_date: date = Field(alias="date")
     date_time: Optional[datetime] = Field(default=None, alias="dateTime")
-    uuid: Optional[StrictStr] = None
+    uuid: Optional[UUID] = None
     password: Annotated[str, Field(min_length=10, strict=True, max_length=64)]
     pattern_with_digits: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="A string that is a 10 digit number. Can have leading zeros.")
     pattern_with_digits_and_delimiter: Optional[Annotated[str, Field(strict=True)]] = Field(default=None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Optional
+from uuid import UUID
 from petstore_api.models.animal import Animal
 from typing import Optional, Set
 from typing_extensions import Self
@@ -28,7 +29,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     """
     MixedPropertiesAndAdditionalPropertiesClass
     """ # noqa: E501
-    uuid: Optional[StrictStr] = None
+    uuid: Optional[UUID] = None
     date_time: Optional[datetime] = Field(default=None, alias="dateTime")
     map: Optional[Dict[str, Animal]] = None
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/task.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/task.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict
 from typing import Any, ClassVar, Dict, List
+from uuid import UUID
 from petstore_api.models.task_activity import TaskActivity
 from typing import Optional, Set
 from typing_extensions import Self
@@ -27,7 +28,7 @@ class Task(BaseModel):
     """
     Used to test oneOf enums with only one string value.
     """ # noqa: E501
-    id: StrictStr
+    id: UUID
     activity: TaskActivity
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["id", "activity"]


### PR DESCRIPTION
This PR will change the Python type hint for uuid fields from `StrictStr` to `uuid.UUID`.

Solves #19485. 

I essentially just copied the changes suggested by @to-bee in this comment: https://github.com/OpenAPITools/openapi-generator/issues/19485#issuecomment-2569940124 .

Since this will be a breaking change, should it be hidden behind some flag or option? I opened the pull request against the 8.0.x branch, please change this if it is wrong.

@cbornet @tomplus @krjakbrjak @fa0311 @multani

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
