### PR TITLE
fix(java): validation of UUIDs in oneOf and anyOf schemas

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/anyof_model.mustache
@@ -134,7 +134,12 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     {{/isNumber}}
                     {{^isNumber}}
                     {{^isPrimitiveType}}
+                    {{#isUuid}}
+                        UUID.fromString(jsonElement.getAsString());
+                    {{/isUuid}}
+                    {{^isUuid}}
                         {{{dataType}}}.validateJsonElement(jsonElement);
+                    {{/isUuid}}
                         actualAdapter = adapter{{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}};
                     {{/isPrimitiveType}}
                     {{/isNumber}}
@@ -328,7 +333,12 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         {{/isNumber}}
         {{^isNumber}}
         {{^isPrimitiveType}}
+        {{#isUuid}}
+            UUID.fromString(jsonElement.getAsString());
+        {{/isUuid}}
+        {{^isUuid}}
             {{{dataType}}}.validateJsonElement(jsonElement);
+        {{/isUuid}}
         {{/isPrimitiveType}}
         {{/isNumber}}
         {{/isArray}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/oneof_model.mustache
@@ -175,7 +175,12 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
                     {{/isNumber}}
                     {{^isNumber}}
                     {{^isPrimitiveType}}
+                    {{#isUuid}}
+                        UUID.fromString(jsonElement.getAsString());
+                    {{/isUuid}}
+                    {{^isUuid}}
                         {{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}}.validateJsonElement(jsonElement);
+                    {{/isUuid}}
                         actualAdapter = adapter{{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}};
                     {{/isPrimitiveType}}
                     {{/isNumber}}
@@ -408,7 +413,12 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
         {{/isNumber}}
         {{^isNumber}}
         {{^isPrimitiveType}}
+        {{#isUuid}}
+            UUID.fromString(jsonElement.getAsString());
+        {{/isUuid}}
+        {{^isUuid}}
             {{#sanitizeDataType}}{{{dataType}}}{{/sanitizeDataType}}.validateJsonElement(jsonElement);
+        {{/isUuid}}
         {{/isPrimitiveType}}
         {{/isNumber}}
         {{/isArray}}


### PR DESCRIPTION
relates to OpenAPITools/openapi-generator#16868

---

I found out that the same thing described in #16868 also happens for one of schemas. Here's an example with both, one of and any of.

```yaml
openapi: 3.1.0
info:
  version: 0.1.0
  title: ''
  description: ''
paths:
  /foo/:
    post:
      operationId: foo
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/OneOfExample'
        required: true
      responses:
        '200':
          content:
            application/json:
              schema:
                type: string
          description: ''
  /bar/:
    post:
      operationId: bar
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/AnyOfExample'
        required: true
      responses:
        '200':
          content:
            application/json:
              schema:
                type: string
          description: ''
components:
  schemas:
    OneOfExample:
      oneOf:
      - type: string
        format: uuid
      - type: string
        enum:
        - delete
    AnyOfExample:
      anyOf:
      - type: string
        format: uuid
      - type: string
        enum:
        - delete
```

When generating the java code for the example, I will run into compile errors. With my fix they should be gone.

```bash
# generate
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate --generator-name java --input-spec uuid-fix-spec.yaml --output "uuid-fix-output"

# run the tests
cd uuid-fix-output
chmod +x gradlew
./gradlew test
```

Compile error output (without this fix):

```> Task :compileJava
/home/<USER>/Developer/openapi-generator/uuid-fix-output/src/main/java/org/openapitools/client/model/AnyOfExample.java:103: error: cannot find symbol
                        UUID.validateJsonElement(jsonElement);
                            ^
  symbol:   method validateJsonElement(JsonElement)
  location: class UUID
/home/<USER>/Developer/openapi-generator/uuid-fix-output/src/main/java/org/openapitools/client/model/AnyOfExample.java:224: error: cannot find symbol
            UUID.validateJsonElement(jsonElement);
                ^
  symbol:   method validateJsonElement(JsonElement)
  location: class UUID
/home/<USER>/Developer/openapi-generator/uuid-fix-output/src/main/java/org/openapitools/client/model/OneOfExample.java:104: error: cannot find symbol
                        UUID.validateJsonElement(jsonElement);
                            ^
  symbol:   method validateJsonElement(JsonElement)
  location: class UUID
/home/<USER>/Developer/openapi-generator/uuid-fix-output/src/main/java/org/openapitools/client/model/OneOfExample.java:230: error: cannot find symbol
            UUID.validateJsonElement(jsonElement);
                ^
  symbol:   method validateJsonElement(JsonElement)
  location: class UUID
4 errors

> Task :compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --info option to get more log output.
> Run with --scan to get full insights.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 1m 52s
1 actionable task: 1 executed
```

---

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
