### PR TITLE
[Java][HttpClient] Fix memory leak with virtual threads (#21729)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.function.Supplier;
 import java.util.TimeZone;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -127,8 +126,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
   protected Map<String, Authentication> authentications;
 
-  protected Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
-  protected Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
+  protected ThreadLocal<Integer> lastStatusCode = new ThreadLocal<>();
+  protected ThreadLocal<Map<String, List<String>>> lastResponseHeaders = new ThreadLocal<>();
 
   protected DateFormat dateFormat;
 
@@ -284,7 +283,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    */
   @Deprecated
   public int getStatusCode() {
-    return lastStatusCodeByThread.get(Thread.currentThread().getId());
+    return lastStatusCode.get();
   }
 
   /**
@@ -293,7 +292,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    */
   @Deprecated
   public Map<String, List<String>> getResponseHeaders() {
-    return lastResponseHeadersByThread.get(Thread.currentThread().getId());
+    return lastResponseHeaders.get();
   }
 
   /**
@@ -1015,13 +1014,13 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
   protected <T> T processResponse(CloseableHttpResponse response, TypeReference<T> returnType) throws ApiException, IOException, ParseException {
     int statusCode = response.getCode();
-    lastStatusCodeByThread.put(Thread.currentThread().getId(), statusCode);
+    lastStatusCode.set(statusCode);
     if (statusCode == HttpStatus.SC_NO_CONTENT) {
       return null;
     }
 
     Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
-    lastResponseHeadersByThread.put(Thread.currentThread().getId(), responseHeaders);
+    lastResponseHeaders.set(responseHeaders);
 
     if (isSuccessfulStatus(statusCode)) {
       return this.deserialize(response, returnType);

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.function.Supplier;
 import java.util.TimeZone;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -104,8 +103,8 @@ public class ApiClient extends JavaTimeFormatter {
 
   protected Map<String, Authentication> authentications;
 
-  protected Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
-  protected Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
+  protected ThreadLocal<Integer> lastStatusCode = new ThreadLocal<>();
+  protected ThreadLocal<Map<String, List<String>>> lastResponseHeaders = new ThreadLocal<>();
 
   protected DateFormat dateFormat;
 
@@ -254,7 +253,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
   @Deprecated
   public int getStatusCode() {
-    return lastStatusCodeByThread.get(Thread.currentThread().getId());
+    return lastStatusCode.get();
   }
 
   /**
@@ -263,7 +262,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
   @Deprecated
   public Map<String, List<String>> getResponseHeaders() {
-    return lastResponseHeadersByThread.get(Thread.currentThread().getId());
+    return lastResponseHeaders.get();
   }
 
   /**
@@ -932,13 +931,13 @@ public class ApiClient extends JavaTimeFormatter {
 
   protected <T> T processResponse(CloseableHttpResponse response, TypeReference<T> returnType) throws ApiException, IOException, ParseException {
     int statusCode = response.getCode();
-    lastStatusCodeByThread.put(Thread.currentThread().getId(), statusCode);
+    lastStatusCode.set(statusCode);
     if (statusCode == HttpStatus.SC_NO_CONTENT) {
       return null;
     }
 
     Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
-    lastResponseHeadersByThread.put(Thread.currentThread().getId(), responseHeaders);
+    lastResponseHeaders.set(responseHeaders);
 
     if (isSuccessfulStatus(statusCode)) {
       return this.deserialize(response, returnType);

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.function.Supplier;
 import java.util.TimeZone;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -149,8 +148,8 @@ public class ApiClient extends JavaTimeFormatter {
 
   protected Map<String, Authentication> authentications;
 
-  protected Map<Long, Integer> lastStatusCodeByThread = new ConcurrentHashMap<>();
-  protected Map<Long, Map<String, List<String>>> lastResponseHeadersByThread = new ConcurrentHashMap<>();
+  protected ThreadLocal<Integer> lastStatusCode = new ThreadLocal<>();
+  protected ThreadLocal<Map<String, List<String>>> lastResponseHeaders = new ThreadLocal<>();
 
   protected DateFormat dateFormat;
 
@@ -302,7 +301,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
   @Deprecated
   public int getStatusCode() {
-    return lastStatusCodeByThread.get(Thread.currentThread().getId());
+    return lastStatusCode.get();
   }
 
   /**
@@ -311,7 +310,7 @@ public class ApiClient extends JavaTimeFormatter {
    */
   @Deprecated
   public Map<String, List<String>> getResponseHeaders() {
-    return lastResponseHeadersByThread.get(Thread.currentThread().getId());
+    return lastResponseHeaders.get();
   }
 
   /**
@@ -1025,13 +1024,13 @@ public class ApiClient extends JavaTimeFormatter {
 
   protected <T> T processResponse(CloseableHttpResponse response, TypeReference<T> returnType) throws ApiException, IOException, ParseException {
     int statusCode = response.getCode();
-    lastStatusCodeByThread.put(Thread.currentThread().getId(), statusCode);
+    lastStatusCode.set(statusCode);
     if (statusCode == HttpStatus.SC_NO_CONTENT) {
       return null;
     }
 
     Map<String, List<String>> responseHeaders = transformResponseHeaders(response.getHeaders());
-    lastResponseHeadersByThread.put(Thread.currentThread().getId(), responseHeaders);
+    lastResponseHeaders.set(responseHeaders);
 
     if (isSuccessfulStatus(statusCode)) {
       return this.deserialize(response, returnType);


### PR DESCRIPTION
Fixes #21729 - memory leak in Apache HttpClient when the result (status code and headers) were stored under the thread id. In a setup when virtual thread executor is used, each execution uses a different thread, and so the map grows without limit.

The fix replaces ConcurrentHashMap with ThreadLocal, which should assure that once the Thread ends, the result is deallocated. It solution should be as thread-safe as before.

@wing328 - you reviewed the PR adding the memory leak, would you care to take a look at this fix?

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
