### PR TITLE
[typscript] change @export to @exports

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/modelOneOf.mustache
@@ -9,14 +9,14 @@ import {
 /**
  * @type {{classname}}
  * Type
- * @export
+ * @exports
  */
 export type {{classname}} = {{#oneOf}}{{{.}}}{{^-last}} | {{/-last}}{{/oneOf}};
 
 /**
 * @type {{classname}}Class{{#description}}
     * {{{.}}}{{/description}}
-* @export
+* @exports
 */
 export class {{classname}}Class {
     {{#discriminator}}

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/PetsPatchRequest.ts
@@ -17,13 +17,13 @@ import { HttpFile } from '../http/http';
 /**
  * @type PetsPatchRequest
  * Type
- * @export
+ * @exports
  */
 export type PetsPatchRequest = Cat | Dog | any;
 
 /**
 * @type PetsPatchRequestClass
-* @export
+* @exports
 */
 export class PetsPatchRequestClass {
     static readonly discriminator: string | undefined = "petType";


### PR DESCRIPTION
one of the typescript templates uses a `@export` tag which is incorrect - the right form is `@exports` (see https://jsdoc.app/tags-exports). As a result, the generated code may trigger linters. 

This PR corrects the syntax. 

fixes #21753 

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka  @joscha 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
