### PR TITLE
[protobuf] fix generation of enums with UNSPECIFIED values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ProtobufSchemaCodegen.java
@@ -272,7 +272,7 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
         if (additionalProperties.containsKey(CUSTOM_OPTIONS_MODEL)) {
             this.setCustomOptionsModel((String) additionalProperties.get(CUSTOM_OPTIONS_MODEL));
         }
-          
+
         if (additionalProperties.containsKey(this.SUPPORT_MULTIPLE_RESPONSES)) {
             this.supportMultipleResponses = convertPropertyToBooleanAndWriteBack(SUPPORT_MULTIPLE_RESPONSES);
         } else {
@@ -546,22 +546,32 @@ public class ProtobufSchemaCodegen extends DefaultCodegen implements CodegenConf
      * @param allowableValues allowable values
      */
     public void addUnspecifiedToAllowableValues(Map<String, Object> allowableValues) {
+
+        final String UNSPECIFIED = "UNSPECIFIED";
+
         if (startEnumsWithUnspecified) {
             if (allowableValues.containsKey("enumVars")) {
                 List<Map<String, Object>> enumVars = (List<Map<String, Object>>) allowableValues.get("enumVars");
-
-                HashMap<String, Object> unspecified = new HashMap<String, Object>();
-                unspecified.put("name", "UNSPECIFIED");
-                unspecified.put("isString", "false");
-                unspecified.put("value", "\"UNSPECIFIED\"");
-                enumVars.add(0, unspecified);
+                boolean unspecifiedPresent = enumVars.stream()
+                        .anyMatch(e -> {
+                            return UNSPECIFIED.equals(e.get("name"));
+                        });
+                if (!unspecifiedPresent) {
+                    HashMap<String, Object> unspecifiedEnum = new HashMap<String, Object>();
+                    unspecifiedEnum.put("name", UNSPECIFIED);
+                    unspecifiedEnum.put("isString", "false");
+                    unspecifiedEnum.put("value", "\"" + UNSPECIFIED + "\"");
+                    enumVars.add(0, unspecifiedEnum);
+                }
             }
 
             if (allowableValues.containsKey("values")) {
                 List<String> values = (List<String>) allowableValues.get("values");
-                List<String> modifiableValues = new ArrayList<>(values);
-                modifiableValues.add(0, "UNSPECIFIED");
-                allowableValues.put("values", modifiableValues);
+                if (!values.contains(UNSPECIFIED)) {
+                    List<String> modifiableValues = new ArrayList<>(values);
+                    modifiableValues.add(0, UNSPECIFIED);
+                    allowableValues.put("values", modifiableValues);
+                }
             }
         }
     }


### PR DESCRIPTION
When adding a default UNSPECIFIED value ([introduced here](https://github.com/OpenAPITools/openapi-generator/pull/20473/files)), if an UNSPECIFIED enum value is already present the generator currently duplicates the UNSPECIFIED enum value, generating broken code. This PR fix that by simply checking if an UNSPECIFIED enum value is already present and only adding one if it's not yet defined.

@wing328 and @lucy66hw FYI :)


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
