### PR TITLE
[typescript-axios]: align jsdoc for `@deprecated`

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -11,20 +11,17 @@ export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#vars}}
     {{#description}}
     /**
-    * {{{description}}}
+     * {{{description}}}
     {{#deprecated}}
-    * @deprecated
+     * @deprecated
     {{/deprecated}}
-    */
+     */
     {{/description}}
     {{^description}}
     {{#deprecated}}
     /**
-    *
-    {{#deprecated}}
-    * @deprecated
-    {{/deprecated}}
-    */
+     * @deprecated
+     */
     {{/deprecated}}
     {{/description}}
     '{{baseName}}'{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{#isNullable}} | null{{/isNullable}};

--- a/samples/client/echo_api/typescript-axios/build/api.ts
+++ b/samples/client/echo_api/typescript-axios/build/api.ts
@@ -33,16 +33,16 @@ export interface Category {
 }
 export interface DataQuery extends Query {
     /**
-    * test suffix
-    */
+     * test suffix
+     */
     'suffix'?: string;
     /**
-    * Some text containing white spaces
-    */
+     * Some text containing white spaces
+     */
     'text'?: string;
     /**
-    * A date
-    */
+     * A date
+     */
     'date'?: string;
 }
 
@@ -81,8 +81,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -96,8 +96,8 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 
 export interface Query {
     /**
-    * Query
-    */
+     * Query
+     */
     'id'?: number;
     'outcomes'?: Array<QueryOutcomesEnum>;
 }

--- a/samples/client/petstore/typescript-axios/builds/default/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -71,8 +71,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -103,8 +103,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -71,8 +71,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -103,8 +103,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -31,8 +31,8 @@ export interface AdditionalPropertiesClass {
     'map_with_undeclared_properties_anytype_2'?: object;
     'map_with_undeclared_properties_anytype_3'?: { [key: string]: any; };
     /**
-    * an object with no declared properties and no undeclared properties, hence it\'s an empty map.
-    */
+     * an object with no declared properties and no undeclared properties, hence it\'s an empty map.
+     */
     'empty_map'?: object;
     'map_with_undeclared_properties_string'?: { [key: string]: string; };
 }
@@ -81,8 +81,8 @@ export interface Capitalization {
     'Capital_Snake'?: string;
     'SCA_ETH_Flow_Points'?: string;
     /**
-    * Name of the pet 
-    */
+     * Name of the pet 
+     */
     'ATT_NAME'?: string;
 }
 export interface Cat extends Animal {
@@ -236,12 +236,12 @@ export interface FormatTest {
     'uuid'?: string;
     'password': string;
     /**
-    * A string that is a 10 digit number. Can have leading zeros.
-    */
+     * A string that is a 10 digit number. Can have leading zeros.
+     */
     'pattern_with_digits'?: string;
     /**
-    * A string starting with \'image_\' (case insensitive) and one to three digits following i.e. Image_01.
-    */
+     * A string starting with \'image_\' (case insensitive) and one to three digits following i.e. Image_01.
+     */
     'pattern_with_digits_and_delimiter'?: string;
 }
 /**
@@ -331,8 +331,8 @@ export interface Model200Response {
  */
 export interface ModelFile {
     /**
-    * Test capitalization
-    */
+     * Test capitalization
+     */
     'sourceURI'?: string;
 }
 /**
@@ -372,19 +372,16 @@ export interface NumberOnly {
 export interface ObjectWithDeprecatedFields {
     'uuid'?: string;
     /**
-    *
-    * @deprecated
-    */
+     * @deprecated
+     */
     'id'?: number;
     /**
-    *
-    * @deprecated
-    */
+     * @deprecated
+     */
     'deprecatedRef'?: DeprecatedObject;
     /**
-    *
-    * @deprecated
-    */
+     * @deprecated
+     */
     'bars'?: Array<string>;
 }
 export interface Order {
@@ -393,8 +390,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -461,8 +458,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -549,24 +546,24 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
     /**
-    * test code generation for objects Value must be a map of strings to values. It cannot be the \'null\' value.
-    */
+     * test code generation for objects Value must be a map of strings to values. It cannot be the \'null\' value.
+     */
     'objectWithNoDeclaredProps'?: object;
     /**
-    * test code generation for nullable objects. Value must be a map of strings to values or the \'null\' value.
-    */
+     * test code generation for nullable objects. Value must be a map of strings to values or the \'null\' value.
+     */
     'objectWithNoDeclaredPropsNullable'?: object | null;
     /**
-    * test code generation for any type Here the \'type\' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
-    */
+     * test code generation for any type Here the \'type\' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
+     */
     'anyTypeProp'?: any;
     /**
-    * test code generation for any type Here the \'type\' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The \'nullable\' attribute does not change the allowed values.
-    */
+     * test code generation for any type Here the \'type\' attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The \'nullable\' attribute does not change the allowed values.
+     */
     'anyTypePropNullable'?: any | null;
 }
 export interface Whale {

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/api.ts
@@ -56,8 +56,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -80,8 +80,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -112,8 +112,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -70,8 +70,8 @@ export interface Capitalization {
     'Capital_Snake'?: string;
     'SCA_ETH_Flow_Points'?: string;
     /**
-    * Name of the pet 
-    */
+     * Name of the pet 
+     */
     'ATT_NAME'?: string;
 }
 export interface Cat extends Animal {
@@ -184,12 +184,12 @@ export interface FormatTest {
     'uuid'?: string;
     'password': string;
     /**
-    * A string that is a 10 digit number. Can have leading zeros.
-    */
+     * A string that is a 10 digit number. Can have leading zeros.
+     */
     'pattern_with_digits'?: string;
     /**
-    * A string starting with \'image_\' (case insensitive) and one to three digits following i.e. Image_01.
-    */
+     * A string starting with \'image_\' (case insensitive) and one to three digits following i.e. Image_01.
+     */
     'pattern_with_digits_and_delimiter'?: string;
 }
 /**
@@ -256,8 +256,8 @@ export interface Model200Response {
  */
 export interface ModelFile {
     /**
-    * Test capitalization
-    */
+     * Test capitalization
+     */
     'sourceURI'?: string;
 }
 /**
@@ -294,8 +294,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -360,9 +360,9 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    * @deprecated
-    */
+     * pet status in the store
+     * @deprecated
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -414,24 +414,24 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
     /**
-    * test code generation for objects Value must be a map of strings to values. It cannot be the \'null\' value.
-    */
+     * test code generation for objects Value must be a map of strings to values. It cannot be the \'null\' value.
+     */
     'arbitraryObject'?: object;
     /**
-    * test code generation for nullable objects. Value must be a map of strings to values or the \'null\' value.
-    */
+     * test code generation for nullable objects. Value must be a map of strings to values or the \'null\' value.
+     */
     'arbitraryNullableObject'?: object | null;
     /**
-    * test code generation for any type Value can be any type - string, number, boolean, array or object.
-    */
+     * test code generation for any type Value can be any type - string, number, boolean, array or object.
+     */
     'arbitraryTypeValue'?: any;
     /**
-    * test code generation for any type Value can be any type - string, number, boolean, array, object or the \'null\' value.
-    */
+     * test code generation for any type Value can be any type - string, number, boolean, array, object or the \'null\' value.
+     */
     'arbitraryNullableTypeValue'?: any | null;
 }
 export interface Whale {

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -71,8 +71,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -103,8 +103,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -71,8 +71,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -103,8 +103,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/api.ts
@@ -51,8 +51,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -75,8 +75,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -107,8 +107,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/order.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/order.ts
@@ -23,8 +23,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/pet.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/pet.ts
@@ -30,8 +30,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/user.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/user.ts
@@ -26,8 +26,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -71,8 +71,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -103,8 +103,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -71,8 +71,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -103,8 +103,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/api.ts
@@ -47,8 +47,8 @@ export interface Order {
     'quantity'?: number;
     'shipDate'?: string;
     /**
-    * Order Status
-    */
+     * Order Status
+     */
     'status'?: OrderStatusEnum;
     'complete'?: boolean;
 }
@@ -69,8 +69,8 @@ export interface Pet {
     'photoUrls': Array<string>;
     'tags'?: Array<Tag>;
     /**
-    * pet status in the store
-    */
+     * pet status in the store
+     */
     'status'?: PetStatusEnum;
 }
 
@@ -99,8 +99,8 @@ export interface User {
     'password'?: string;
     'phone'?: string;
     /**
-    * User Status
-    */
+     * User Status
+     */
     'userStatus'?: number;
 }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

followup to #21776, where i've accidently removed whitespace in the PR. this change now properly aligns whitespace, and also simplifies mustache template for `@deprecated`.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
