### PR TITLE
Fix MergedSpecBuilder not passing auth

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -567,7 +567,7 @@ public class CodeGenMojo extends AbstractMojo {
             inputSpecRootDirectory = inputSpecRootDirectory.replaceAll("\\\\", "/");
 
             inputSpec = new MergedSpecBuilder(inputSpecRootDirectory, mergedFileName,
-                    mergedFileInfoName, mergedFileInfoDescription, mergedFileInfoVersion)
+                    mergedFileInfoName, mergedFileInfoDescription, mergedFileInfoVersion, auth)
                     .buildMergedSpec();
             LOGGER.info("Merge input spec would be used - {}", inputSpec);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/MergedSpecBuilder.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/MergedSpecBuilder.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.ParseOptions;
+import org.openapitools.codegen.auth.AuthParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,18 +29,20 @@ public class MergedSpecBuilder {
     private final String mergedFileInfoName;
     private final String mergedFileInfoDescription;
     private final String mergedFileInfoVersion;
+    private final String auth;
 
     public MergedSpecBuilder(final String rootDirectory, final String mergeFileName) {
-        this(rootDirectory, mergeFileName, "merged spec", "merged spec", "1.0.0");
+        this(rootDirectory, mergeFileName, "merged spec", "merged spec", "1.0.0", null);
     }
 
     public MergedSpecBuilder(final String rootDirectory, final String mergeFileName,
-                             final String mergedFileInfoName, final String mergedFileInfoDescription, final String mergedFileInfoVersion) {
+                             final String mergedFileInfoName, final String mergedFileInfoDescription, final String mergedFileInfoVersion, final String auth) {
         this.inputSpecRootDirectory = rootDirectory;
         this.mergeFileName = mergeFileName;
         this.mergedFileInfoName = mergedFileInfoName;
         this.mergedFileInfoDescription = mergedFileInfoDescription;
         this.mergedFileInfoVersion = mergedFileInfoVersion;
+        this.auth = auth;
     }
 
     public String buildMergedSpec() {
@@ -62,7 +65,7 @@ public class MergedSpecBuilder {
                 LOGGER.info("Reading spec: {}", specPath);
 
                 OpenAPI result = new OpenAPIParser()
-                        .readLocation(specPath, new ArrayList<>(), options)
+                        .readLocation(specPath, AuthParser.parse(auth), options)
                         .getOpenAPI();
 
                 if (openapiVersion == null) {


### PR DESCRIPTION
`MergedSpecBuilder` never passed the `auth` configuration parameter to the underlying `RemoteUrl` unlike the `inputSpec`.

This PR fixes the issue.

No tests were effected.

I testet it manually since I need this feature 😊

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
