### PR TITLE
Setup void type for PHP Symfony CompilerpassInterface

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/ApiPass.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/ApiPass.mustache
@@ -40,7 +40,7 @@ class {{bundleName}}ApiPass implements CompilerPassInterface
      *
      * @param ContainerBuilder $container
      */
-    public function process(ContainerBuilder $container) {
+    public function process(ContainerBuilder $container) : void {
         // always first check if the primary service is defined
         if (!$container->has('{{bundleAlias}}.api.api_server')) {
             return;


### PR DESCRIPTION
Using the generator, i receive following error:

  1x: Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "xx\xxx\DependencyInjection\Compiler\OpenAPIServerApiPass" now to avoid errors or add an explicit @return annotation to suppress this message.
    1x in xxx::setUp from Tests\Application\Connector\xxx

i fixxed this error

