### PR TITLE
Add skipCopyWith option for dart-dio

### DIFF
--- a/docs/generators/dart-dio.md
+++ b/docs/generators/dart-dio.md
@@ -37,6 +37,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |pubRepository|Repository in generated pubspec| |null|
 |pubVersion|Version in generated pubspec| |1.0.0|
 |serializationLibrary|Specify serialization library|<dl><dt>**built_value**</dt><dd>[DEFAULT] built_value</dd><dt>**json_serializable**</dt><dd>[BETA] json_serializable</dd></dl>|built_value|
+|skipCopyWith|Skip CopyWith when using Json Serializable for serialization| |false|
 |sortModelPropertiesByRequiredFlag|Sort model properties to place required parameters before optional parameters.| |true|
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |sourceFolder|source folder for generated code| |src|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -69,7 +69,9 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
 
     private static final String DIO_IMPORT = "package:dio/dio.dart";
     public static final String FINAL_PROPERTIES = "finalProperties";
+    public static final String SKIP_COPY_WITH = "skipCopyWith";
     public static final String FINAL_PROPERTIES_DEFAULT_VALUE = "true";
+    public static final String SKIP_COPY_WITH_DEFAULT_VALUE = "false";
 
     private static final String CLIENT_NAME = "clientName";
 
@@ -138,6 +140,11 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
         final CliOption finalProperties = CliOption.newBoolean(FINAL_PROPERTIES, "Whether properties are marked as final when using Json Serializable for serialization");
         finalProperties.setDefault("true");
         cliOptions.add(finalProperties);
+
+        // skip CopyWith option
+        final CliOption skipCopyWith = CliOption.newBoolean(SKIP_COPY_WITH, "Skip CopyWith when using Json Serializable for serialization");
+        skipCopyWith.setDefault("false");
+        cliOptions.add(skipCopyWith);
     }
 
     @Override
@@ -180,6 +187,13 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
             LOGGER.debug("finalProperties not set, using default {}", FINAL_PROPERTIES_DEFAULT_VALUE);
         } else {
             additionalProperties.put(FINAL_PROPERTIES, Boolean.parseBoolean(additionalProperties.get(FINAL_PROPERTIES).toString()));
+        }
+
+        if (!additionalProperties.containsKey(SKIP_COPY_WITH)) {
+            additionalProperties.put(SKIP_COPY_WITH, Boolean.parseBoolean(SKIP_COPY_WITH_DEFAULT_VALUE));
+            LOGGER.debug("skipCopyWith not set, using default {}", SKIP_COPY_WITH_DEFAULT_VALUE);
+        } else {
+            additionalProperties.put(SKIP_COPY_WITH, Boolean.parseBoolean(additionalProperties.get(SKIP_COPY_WITH).toString()));
         }
 
         if (!additionalProperties.containsKey(CLIENT_NAME)) {

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/pubspec.mustache
@@ -25,7 +25,9 @@ dependencies:
   equatable: '^2.0.7'
 {{/useEquatable}}
 {{#useJsonSerializable}}
+  {{^skipCopyWith}}
   copy_with_extension: '^7.1.0'
+  {{/skipCopyWith}}
   json_annotation: '^4.9.0'
 {{/useJsonSerializable}}
 {{#useDateLibTimeMachine}}
@@ -39,7 +41,9 @@ dev_dependencies:
 {{/useBuiltValue}}
 {{#useJsonSerializable}}
   build_runner: any
+  {{^skipCopyWith}}
   copy_with_extension_gen: ^7.1.0
+  {{/skipCopyWith}}
   json_serializable: '^6.9.3'
 {{/useJsonSerializable}}
   test: '^1.16.0'

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/json_serializable/class.mustache
@@ -1,4 +1,6 @@
+{{^skipCopyWith}}
 import 'package:copy_with_extension/copy_with_extension.dart';
+{{/skipCopyWith}}
 import 'package:json_annotation/json_annotation.dart';
 {{#useEquatable}}
 import 'package:equatable/src/equatable_utils.dart';
@@ -18,7 +20,9 @@ part '{{classFilename}}.g.dart';
 {{#isDeprecated}}
 @Deprecated('{{{classname}}} has been deprecated')
 {{/isDeprecated}}
+{{^skipCopyWith}}
 @CopyWith()
+{{/skipCopyWith}}
 @JsonSerializable(
   checked: true,
   createToJson: true,

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/DartDioClientOptionsProvider.java
@@ -72,6 +72,7 @@ public class DartDioClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.ENUM_UNKNOWN_DEFAULT_CASE, ENUM_UNKNOWN_DEFAULT_CASE_VALUE)
+                .put(DartDioClientCodegen.SKIP_COPY_WITH, DartDioClientCodegen.SKIP_COPY_WITH_DEFAULT_VALUE)
                 .build();
     }
 


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator/issues/21815

related: 

https://github.com/OpenAPITools/openapi-generator/pull/21667
https://github.com/OpenAPITools/openapi-generator/issues/21665

tested locally to confirm the fix

will add more tests as part of the work later to revamp testing for dart generators

cc 
@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
