### PR TITLE
[BUGFIX] scala-http4s fix bad encoding of form-urlencoded body in baseClient.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-http4s/baseClient.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-http4s/baseClient.mustache
@@ -66,7 +66,7 @@ abstract class BaseClient[F[*]: Concurrent](
         request.putHeaders(Header.Raw(CIString(name), value))
     }
     val formBody = formParameters.map { x =>
-      UrlForm(x.groupBy(_._1).map{case (k, v) => (k, v.mkString(","))}.toSeq*)
+      UrlForm(x.groupBy(_._1).map { case (k, v) => (k, v.map(_._2).mkString(",")) }.toSeq*)
     }
 
     import JsonSupports.*

--- a/samples/client/petstore/scala-http4s/src/main/scala/org/openapitools/client/apis/BaseClient.scala
+++ b/samples/client/petstore/scala-http4s/src/main/scala/org/openapitools/client/apis/BaseClient.scala
@@ -75,7 +75,7 @@ abstract class BaseClient[F[*]: Concurrent](
         request.putHeaders(Header.Raw(CIString(name), value))
     }
     val formBody = formParameters.map { x =>
-      UrlForm(x.groupBy(_._1).map{case (k, v) => (k, v.mkString(","))}.toSeq*)
+      UrlForm(x.groupBy(_._1).map { case (k, v) => (k, v.map(_._2).mkString(",")) }.toSeq*)
     }
 
     import JsonSupports.*


### PR DESCRIPTION
The code for setting the form body parameters were wrong,

e.g. the key value pair (id, 12345) would be encoded as id=%28id%2C12345%29

This commit adds a fix to the base client to correctly setting formBody values the previous pair will now be encoded as

id=12345

@clasnake (2017/07), @shijinkui (2018/01), @ramzimaalej (2018/03), @chameleon82 (2020/03), @Bouillie (2020/04) @fish86 (2023/06)

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
