### PR TITLE
[rust] set useAsyncFileStream only for files in the body

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -708,9 +708,9 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                 }
             }
 
-            // If we use a file parameter, we need to include the imports and crates for it
+            // If we use a file body parameter, we need to include the imports and crates for it
             // But they should be added only once per file 
-            for (var param: operation.allParams) {
+            for (var param: operation.bodyParams) {
                 if (param.isFile && supportAsync && !useAsyncFileStream) {
                     useAsyncFileStream = true;
                     additionalProperties.put("useAsyncFileStream", Boolean.TRUE);

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/Cargo.toml
@@ -13,7 +13,5 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-tokio = { version = "^1.46.0", features = ["fs"] }
-tokio-util = { version = "^0.7", features = ["codec"] }
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 reqwest-middleware = { version = "^0.4", features = ["json", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
@@ -13,8 +13,6 @@ use reqwest;
 use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
-use tokio::fs::File as TokioFile;
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/Cargo.toml
@@ -13,9 +13,7 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-tokio = { version = "^1.46.0", features = ["fs"] }
-tokio-util = { version = "^0.7", features = ["codec"] }
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 async-trait = "^0.1"
 # TODO: propose to Yoshidan to externalize this as non google related crate, so that it can easily be extended for other cloud providers.
 google-cloud-token = "^0.1"

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
@@ -13,8 +13,6 @@ use reqwest;
 use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
-use tokio::fs::File as TokioFile;
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml
@@ -13,6 +13,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-tokio = { version = "^1.46.0", features = ["fs"] }
-tokio-util = { version = "^0.7", features = ["codec"] }
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
@@ -13,8 +13,6 @@ use reqwest;
 use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
-use tokio::fs::File as TokioFile;
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/Cargo.toml
@@ -13,6 +13,4 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-tokio = { version = "^1.46.0", features = ["fs"] }
-tokio-util = { version = "^0.7", features = ["codec"] }
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart", "stream"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
@@ -13,8 +13,6 @@ use reqwest;
 use serde::{Deserialize, Serialize, de::Error as _};
 use crate::{apis::ResponseContent, models};
 use super::{Error, configuration, ContentType};
-use tokio::fs::File as TokioFile;
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 /// struct for passing parameters to the method [`add_pet`]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
In a previous PR ([[Rust ]Add async file stream support for reqwest client](https://github.com/OpenAPITools/openapi-generator/pull/21771)): the `useAsyncFileStream` and `vendorExtensions.useAsyncFileStream` template variables are used in case there's at least one file uploaded in the body, but they are set as long as `supportAsync` is set and **any** parameter is a file (including if the file is in a form). So these variables are set more often than they should, introducing unused dependencies on `tokio`.

This explains why on `master`, these tests have the `tokio` dependency even though they don't use it:
- [samples/client/petstore/rust/reqwest/petstore-async-tokensource/Cargo.toml](https://github.com/OpenAPITools/openapi-generator/blob/bd0b81d26dcbbf104186e2c7630abe4ebc429c7e/samples/client/petstore/rust/reqwest/petstore-async-tokensource/Cargo.toml#L16)
- [samples/client/petstore/rust/reqwest/petstore-async-middleware/Cargo.toml](https://github.com/OpenAPITools/openapi-generator/blob/bd0b81d26dcbbf104186e2c7630abe4ebc429c7e/samples/client/petstore/rust/reqwest/petstore-async-middleware/Cargo.toml#L16)
- [samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml](https://github.com/OpenAPITools/openapi-generator/blob/bd0b81d26dcbbf104186e2c7630abe4ebc429c7e/samples/client/petstore/rust/reqwest/petstore-async/Cargo.toml#L16)
- [samples/client/petstore/rust/reqwest/petstore-avoid-box/Cargo.toml](https://github.com/OpenAPITools/openapi-generator/blob/bd0b81d26dcbbf104186e2c7630abe4ebc429c7e/samples/client/petstore/rust/reqwest/petstore-avoid-box/Cargo.toml#L16)

This PR sets the `useAsyncFileStream` and `vendorExtensions.useAsyncFileStream` template variables only when at least one body parameter is a file.

This PR doesn't break the feature introduced by [[Rust ]Add async file stream support for reqwest client](https://github.com/OpenAPITools/openapi-generator/pull/21771), as can be seen in the `samples/client/others/rust/reqwest/file-streaming` example.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10) @dsteeley (2025/07)
