### PR TITLE
[Java] Models derived from inline schemas no longer overwrite top-level schemas with the same resolved name (Issue #20889)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1002,7 +1002,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
 
         // camelize the model name
         // phone_number => PhoneNumber
-        final String camelizedName = camelize(nameWithPrefixSuffix);
+        String camelizedName = camelize(nameWithPrefixSuffix);
 
         // model name cannot use reserved keyword, e.g. return
         if (isReservedWord(camelizedName)) {
@@ -1021,6 +1021,15 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             return modelName;
         }
 
+        Map<String, Schema> allDefinitions = ModelUtils.getSchemas(this.openAPI);
+        if(!camelizedName.equals(origName)) {
+            int count = 0;
+            String augmentedName = camelizedName;
+            while(allDefinitions.containsKey(augmentedName) || schemaKeyToModelNameCache.containsValue(augmentedName)) {
+                augmentedName = camelizedName + count++;
+            }
+            camelizedName = augmentedName;
+        }
         schemaKeyToModelNameCache.put(origName, camelizedName);
 
         return camelizedName;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -172,8 +172,8 @@ public class AbstractJavaCodegenTest {
     @Test
     public void convertModelName() {
         Assert.assertEquals(codegen.toModelName("name"), "Name");
-        Assert.assertEquals(codegen.toModelName("$name"), "Name");
-        Assert.assertEquals(codegen.toModelName("nam#e"), "Name");
+        Assert.assertEquals(codegen.toModelName("$name"), "Name0");
+        Assert.assertEquals(codegen.toModelName("nam#e"), "Name1");
         Assert.assertEquals(codegen.toModelName("$another-fake?"), "AnotherFake");
         Assert.assertEquals(codegen.toModelName("1a"), "Model1a");
         Assert.assertEquals(codegen.toModelName("1A"), "Model1A");
@@ -181,11 +181,11 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.toModelName("aBB"), "ABB");
         Assert.assertEquals(codegen.toModelName("AaBBa"), "AaBBa");
         Assert.assertEquals(codegen.toModelName("A_B"), "AB");
-        Assert.assertEquals(codegen.toModelName("A-B"), "AB");
+        Assert.assertEquals(codegen.toModelName("A-B"), "AB0");
         Assert.assertEquals(codegen.toModelName("Aa_Bb"), "AaBb");
-        Assert.assertEquals(codegen.toModelName("Aa-Bb"), "AaBb");
-        Assert.assertEquals(codegen.toModelName("Aa_bb"), "AaBb");
-        Assert.assertEquals(codegen.toModelName("Aa-bb"), "AaBb");
+        Assert.assertEquals(codegen.toModelName("Aa-Bb"), "AaBb0");
+        Assert.assertEquals(codegen.toModelName("Aa_bb"), "AaBb1");
+        Assert.assertEquals(codegen.toModelName("Aa-bb"), "AaBb2");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/JavaFileAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/JavaFileAssert.java
@@ -201,4 +201,16 @@ public class JavaFileAssert extends AbstractAssert<JavaFileAssert, CompilationUn
 
         return this;
     }
+
+    public JavaFileAssert hasNoProperty(final String propertyName) {
+        Optional<FieldDeclaration> fieldOptional = actual.getType(0).getMembers().stream()
+                .filter(FieldDeclaration.class::isInstance)
+                .map(FieldDeclaration.class::cast)
+                .filter(field -> field.getVariables().getFirst().map(var -> var.getNameAsString().equals(propertyName)).orElse(Boolean.FALSE))
+                .findFirst();
+        Assertions.assertThat(fieldOptional)
+                .withFailMessage("Should not have property %s", propertyName)
+                .isNotPresent();
+        return this;
+    }
 }

--- a/modules/openapi-generator/src/test/resources/bugs/issue_20889.json
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_20889.json
@@ -1,0 +1,220 @@
+{
+  "components": {
+    "schemas": {
+      "Org": {
+        "additionalProperties": false,
+        "properties": {
+          "attributes": {
+            "additionalProperties": false,
+            "properties": {
+              "group_id": {
+                "description": "The ID of a Group.",
+                "example": "59d6d97e-3106-4ebb-b608-352fad9c5b34",
+                "format": "uuid",
+                "type": "string"
+              },
+              "is_personal": {
+                "description": "Whether this organization belongs to an individual, rather than a Group.",
+                "example": true,
+                "type": "boolean"
+              },
+              "name": {
+                "description": "Friendly name of the organization.",
+                "example": "My Org",
+                "type": "string"
+              },
+              "slug": {
+                "description": "Unique URL sanitized name of the organization for accessing it in Snyk.",
+                "example": "my-org",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "slug",
+              "is_personal"
+            ],
+            "type": "object"
+          },
+          "id": {
+            "description": "The Snyk ID corresponding to this org",
+            "example": "59d6d97e-3106-4ebb-b608-352fad9c5b34",
+            "format": "uuid",
+            "type": "string"
+          },
+          "type": {
+            "description": "Content type.",
+            "example": "org",
+            "type": "string"
+          },
+          "branch": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "basicDescription": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "Org20230529": {
+        "additionalProperties": false,
+        "properties": {
+          "attributes": {
+            "$ref": "#/components/schemas/OrgAttributes20230529"
+          },
+          "id": {
+            "description": "The Snyk ID of the organization.",
+            "example": "59d6d97e-3106-4ebb-b608-352fad9c5b34",
+            "format": "uuid",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Types"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "attributes"
+        ],
+        "type": "object"
+      },
+      "OrgAttributes": {
+        "additionalProperties": false,
+        "properties": {
+          "access_requests_enabled": {
+            "description": "Whether the organization permits access requests from users who are not members of the organization.",
+            "example": false,
+            "type": "boolean"
+          },
+          "created_at": {
+            "description": "The time the organization was created.",
+            "example": "2022-03-16T00:00:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "group_id": {
+            "description": "The Snyk ID of the group to which the organization belongs.",
+            "example": "59d6d97e-3106-4ebb-b608-352fad9c5b34",
+            "format": "uuid",
+            "type": "string"
+          },
+          "is_personal": {
+            "description": "Whether the organization is independent (that is, not part of a group).",
+            "example": true,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The display name of the organization.",
+            "example": "My Org",
+            "type": "string"
+          },
+          "slug": {
+            "description": "The canonical (unique and URL-friendly) name of the organization.",
+            "example": "my-org",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "The time the organization was last modified.",
+            "example": "2022-03-16T00:00:00Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "is_personal"
+        ],
+        "type": "object"
+      },
+      "OrgAttributes20230529": {
+        "additionalProperties": false,
+        "properties": {
+          "created_at": {
+            "description": "The time the organization was created.",
+            "example": "2022-03-16T00:00:00Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "group_id": {
+            "description": "The Snyk ID of the group to which the organization belongs.",
+            "example": "59d6d97e-3106-4ebb-b608-352fad9c5b34",
+            "format": "uuid",
+            "type": "string"
+          },
+          "is_personal": {
+            "description": "Whether the organization is independent (that is, not part of a group).",
+            "example": true,
+            "type": "boolean"
+          },
+          "name": {
+            "description": "The display name of the organization.",
+            "example": "My Org",
+            "type": "string"
+          },
+          "slug": {
+            "description": "The canonical (unique and URL-friendly) name of the organization.",
+            "example": "my-org",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "The time the organization was last modified.",
+            "example": "2022-03-16T00:00:00Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "slug",
+          "is_personal"
+        ],
+        "type": "object"
+      },
+      "OrgBranch": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "uuid": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
+        }
+      },
+      "OrgBranchAttributes": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "detailedDescription": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "info": {
+    "title": "Snyk API",
+    "version": "REST"
+  },
+  "openapi": "3.0.3"
+
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Fixes #20889 
@martin-mfg @Zomzog , please help review for Java