### PR TITLE
fix(cpp-qt): Fix enum query parameter serialization for both inline and referenced enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -344,6 +344,21 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         else
             fullPath.append("?");
         {{^isPrimitiveType}}
+        {{#isEnum}}
+        // For enum parameters, use direct string serialization instead of object iteration
+        QString enumValue = {{paramName}}{{^required}}.value(){{/required}}.asJson();
+        if (!enumValue.isEmpty()) {
+            fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append("=").append(QUrl::toPercentEncoding(enumValue));
+        }
+        {{/isEnum}}
+        {{#isEnumRef}}
+        // For enum reference parameters, use direct string serialization instead of object iteration
+        QString enumValue = {{paramName}}{{^required}}.value(){{/required}}.asJson();
+        if (!enumValue.isEmpty()) {
+            fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append("=").append(QUrl::toPercentEncoding(enumValue));
+        }
+        {{/isEnumRef}}
+        {{^isEnum}}{{^isEnumRef}}
         QString paramString = (queryStyle == "form" && {{isExplode}}) ? "" : (queryStyle == "form" && !({{isExplode}})) ? "{{baseName}}"+querySuffix : "";
         QJsonObject parameter = {{paramName}}{{^required}}.value(){{/required}}.asJsonObject();
         qint32 count = 0;
@@ -390,6 +405,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
             count++;
         }
         fullPath.append(paramString);
+        {{/isEnumRef}}{{/isEnum}}
         {{/isPrimitiveType}}{{#isPrimitiveType}}
         fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.stringValue(){{/required}})));
 {{/isPrimitiveType}}


### PR DESCRIPTION
Fixes enum query parameter serialization for cpp-qt-client generator.

### Problem
For enum query parameters, the template was incorrectly using `asJsonObject()` which returns `{"value": "enumValue"} ` and then iterating over keys, using "value" as the parameter name instead of the actual parameter name.

This resulted in incorrect URLs like: `?value=property instead of ?scope=property`

### Solution
Added special handling for both inline enums (isEnum) and referenced enums (isEnumRef) in the `api-body.mustache template` to use `asJson()` directly, which returns the correct enum string value for URL serialization.

### Changes
Modified modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache to detect both enum types and use direct string serialization
Updated cpp-qt-client samples (though petstore samples don't contain enum query parameter tests to demonstrate this specific fix)
Context
Completes the fix started in PR #21211 which added the `asJsonObject()` method to make enum code compile, but the template logic was still incorrect for URL query parameter serialization.

### Testing
✅ Built OpenAPI Generator successfully
✅ Generated cpp-qt-client samples without errors
✅ Verified enum parameters now serialize correctly in generated code

### Note
The petstore samples don't contain enum query parameter examples to showcase this functionality. Future contributors may want to add enum query parameter tests to better demonstrate this fix.

### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
