### PR TITLE
[Java] Remove unnecessary String.format from jersey2, jersey3, native

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/anyof_model.mustache
@@ -95,7 +95,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
             {{/anyOf}}
             {{/composedSchemas}}
-            throw new IOException(String.format("Failed deserialization for {{classname}}: no match found"));
+            throw new IOException("Failed deserialization for {{classname}}: no match found");
         }
 
         /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/anyof_model.mustache
@@ -95,7 +95,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
 
             {{/anyOf}}
             {{/composedSchemas}}
-            throw new IOException(String.format("Failed deserialization for {{classname}}: no match found"));
+            throw new IOException("Failed deserialization for {{classname}}: no match found");
         }
 
         /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/anyof_model.mustache
@@ -79,7 +79,7 @@ public class {{classname}} extends AbstractOpenApiSchema{{#vendorExtensions.x-im
             }
 
             {{/anyOf}}
-            throw new IOException(String.format("Failed deserialization for {{classname}}: no match found"));
+            throw new IOException("Failed deserialization for {{classname}}: no match found");
         }
 
         /**

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -113,7 +113,7 @@ public class GmFruit extends AbstractOpenApiSchema {
                 log.log(Level.FINER, "Input data does not match 'GmFruit'", e);
             }
 
-            throw new IOException(String.format("Failed deserialization for GmFruit: no match found"));
+            throw new IOException("Failed deserialization for GmFruit: no match found");
         }
 
         /**

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/MammalAnyof.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/model/MammalAnyof.java
@@ -141,7 +141,7 @@ public class MammalAnyof extends AbstractOpenApiSchema {
                 log.log(Level.FINER, "Input data does not match 'MammalAnyof'", e);
             }
 
-            throw new IOException(String.format("Failed deserialization for MammalAnyof: no match found"));
+            throw new IOException("Failed deserialization for MammalAnyof: no match found");
         }
 
         /**

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -109,7 +109,7 @@ public class GmFruit extends AbstractOpenApiSchema {
                 log.log(Level.FINER, "Input data does not match 'GmFruit'", e);
             }
 
-            throw new IOException(String.format("Failed deserialization for GmFruit: no match found"));
+            throw new IOException("Failed deserialization for GmFruit: no match found");
         }
 
         /**

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -111,7 +111,7 @@ public class GmFruit extends AbstractOpenApiSchema {
                 log.log(Level.FINER, "Input data does not match 'GmFruit'", e);
             }
 
-            throw new IOException(String.format("Failed deserialization for GmFruit: no match found"));
+            throw new IOException("Failed deserialization for GmFruit: no match found");
         }
 
         /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/GmFruit.java
@@ -111,7 +111,7 @@ public class GmFruit extends AbstractOpenApiSchema {
                 log.log(Level.FINER, "Input data does not match 'GmFruit'", e);
             }
 
-            throw new IOException(String.format("Failed deserialization for GmFruit: no match found"));
+            throw new IOException("Failed deserialization for GmFruit: no match found");
         }
 
         /**

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MammalAnyof.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/model/MammalAnyof.java
@@ -139,7 +139,7 @@ public class MammalAnyof extends AbstractOpenApiSchema {
                 log.log(Level.FINER, "Input data does not match 'MammalAnyof'", e);
             }
 
-            throw new IOException(String.format("Failed deserialization for MammalAnyof: no match found"));
+            throw new IOException("Failed deserialization for MammalAnyof: no match found");
         }
 
         /**


### PR DESCRIPTION
The generators for Java clients `jersey2`, `jersey3`, and `native` are unnecessarily using a `String.format()` call when throwing an `IOException`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- ~[x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)~
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg