### PR TITLE
feat: add support for minimal-update option in maven plugin

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -322,6 +322,12 @@ public class CodeGenMojo extends AbstractMojo {
     private Boolean generateAliasAsModel;
 
     /**
+     * Only write output files that have changed.
+     */
+    @Parameter(name = "minimalUpdate", property = "openapi.generator.maven.plugin.minimalUpdate")
+    private Boolean minimalUpdate;
+
+    /**
      * A map of language-specific parameters as passed with the -c option to the command line
      */
     @Parameter(name = "configOptions")
@@ -696,6 +702,10 @@ public class CodeGenMojo extends AbstractMojo {
 
             if (generateAliasAsModel != null) {
                 configurator.setGenerateAliasAsModel(generateAliasAsModel);
+            }
+
+            if (minimalUpdate != null) {
+                configurator.setEnableMinimalUpdate(minimalUpdate);
             }
 
             if (isNotEmpty(generatorName)) {

--- a/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
+++ b/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -88,6 +89,17 @@ public class CodeGenMojoTest extends BaseTestCase {
         assertEquals("joda", configOptions.get("dateLibrary"));
     }
 
+    public void testMinimalUpdateConfiguration() throws Exception {
+        // GIVEN
+        CodeGenMojo mojo = loadMojo(newTempFolder(), "src/test/resources/minimal-update", null);
+
+        // WHEN
+        mojo.execute();
+
+        // THEN
+        assertEquals(Boolean.TRUE, getVariableValueFromObject(mojo, "minimalUpdate"));
+    }
+
     public void testHashGenerationFileContainsExecutionId() throws Exception {
         // GIVEN
         final Path tempDir = newTempFolder();
@@ -134,6 +146,50 @@ public class CodeGenMojoTest extends BaseTestCase {
         // THEN
         /* Verify that the source directory has not been repopulated. If it has then we generated code again */
         assertFalse("src directory should not have been regenerated", Files.exists(generatedDir.resolve("src")));
+    }
+
+    public void testMinimalUpdate() throws Exception {
+        //GIVEN
+        /* Set up the mojo */
+        final Path tempDir = newTempFolder();
+        final CodeGenMojo mojo = loadMojo(tempDir, "src/test/resources/minimal-update", null, "executionId");
+
+        /* Perform an initial generation */
+        mojo.execute();
+
+        /* Collect last modified times of generated files */
+        final Path generatedDir = tempDir.resolve("target/generated-sources/minimal-update");
+        assertTrue("Generated directory should exist", Files.exists(generatedDir));
+
+        Map<Path, Long> lastModifiedTimes = new HashMap<>();
+        try (Stream<Path> files = Files.walk(generatedDir)) {
+            files
+                .filter(Files::isRegularFile)
+                .filter(path -> !path.getFileName().toString().endsWith(".sha256"))
+                .filter(path -> !path.getFileName().toString().equals("FILES"))
+                .forEach(file -> {
+                    try {
+                        lastModifiedTimes.put(file, Files.getLastModifiedTime(file).toMillis());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        }
+        assertTrue("Should have recorded last modified times for more than 3 files", lastModifiedTimes.size() > 3);
+
+        // WHEN
+        /* Execute the mojo again */
+        mojo.execute();
+
+        // THEN
+        /* Verify that file modification times haven't changed (files weren't touched) */
+        for (Map.Entry<Path, Long> entry : lastModifiedTimes.entrySet()) {
+            Path file = entry.getKey();
+            Long originalTime = entry.getValue();
+            Long currentTime = Files.getLastModifiedTime(file).toMillis();
+            assertEquals("File " + file + " should not have been modified (minimal update should skip unchanged files)",
+                originalTime, currentTime);
+        }
     }
 
     /**
@@ -242,7 +298,7 @@ public class CodeGenMojoTest extends BaseTestCase {
         final Path generatedDir = tempDir.resolve("target/generated-sources/issue-16489");
         final Path hashFile = generatedDir.resolve(".openapi-generator/petstore.yaml-default.sha256");
         final CodeGenMojo mojo = loadMojo(tempDir, "src/test/resources/issue-16489", null);
-        mojo.execute(); // Perform an initial generation 
+        mojo.execute(); // Perform an initial generation
         var currentHash = Files.readString(hashFile);   // read hash
         FileUtils.deleteDirectory(generatedDir.resolve("src").toFile());    // Remove the generated source
         Files.writeString(  // change schema definition in external file

--- a/modules/openapi-generator-maven-plugin/src/test/resources/minimal-update/pom.xml
+++ b/modules/openapi-generator-maven-plugin/src/test/resources/minimal-update/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  ~ Copyright 2020, 2021 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>minimal.update.test</groupId>
+    <artifactId>minimal-update-test</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>OpenAPI Generator Minimal Update Test</name>
+    <url>https://openapi-generator.tech/</url>
+    <build>
+        <finalName>minimal-update-test</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <configuration>
+                    <inputSpec>petstore-on-classpath.yaml</inputSpec>
+                    <generatorName>spring</generatorName>
+                    <output>${basedir}/target/generated-sources/minimal-update</output>
+                    <minimalUpdate>true</minimalUpdate>
+                    <configOptions>
+                        <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                    </configOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>executionId</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
`--minimal-update` is an existing parameter of the OpenAPI Generator CLI tool.
This  PR adds support for the `minimalUpdate` parameter to the OpenAPI Generator Maven plugin, 
bringing feature parity with the CLI tool.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
