### PR TITLE
[BUG][rust-axum] Fix duplicate route operations when supplying multiple tags on a path with a camelCase param

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustAxumServerCodegen.java
@@ -450,7 +450,15 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
 
         String underscoredOperationId = underscore(op.operationId);
-        ArrayList<MethodOperation> pathMethods = pathMethodOpMap.get(path);
+        String axumPath = op.path;
+        for (CodegenParameter param : op.pathParams) {
+            // Replace {baseName} with {paramName} for format string
+            String paramSearch = "{" + param.baseName + "}";
+            String paramReplace = "{" + param.paramName + "}";
+
+            axumPath = axumPath.replace(paramSearch, paramReplace);
+        }
+        ArrayList<MethodOperation> pathMethods = pathMethodOpMap.get(axumPath);
 
         // Prevent multiple declarations of the same operation
         if (pathMethods != null && pathMethods.stream().anyMatch(pathMethod ->
@@ -463,14 +471,6 @@ public class RustAxumServerCodegen extends AbstractRustCodegen implements Codege
 
         if (!op.isCallbackRequest) {
             // group route by path
-            String axumPath = op.path;
-            for (CodegenParameter param : op.pathParams) {
-                // Replace {baseName} with {paramName} for format string
-                String paramSearch = "{" + param.baseName + "}";
-                String paramReplace = "{" + param.paramName + "}";
-
-                axumPath = axumPath.replace(paramSearch, paramReplace);
-            }
             pathMethodOpMap
                     .computeIfAbsent(axumPath, (key) -> new ArrayList<>())
                     .add(new MethodOperation(

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustAxumServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustAxumServerCodegenTest.java
@@ -28,6 +28,8 @@ public class RustAxumServerCodegenTest {
         String routerSpec = linearize("Router::new() " +
                 ".route(\"/api/test\", " +
                 "delete(test_delete::<I, A, E, C>).post(test_post::<I, A, E, C>) ) " +
+                ".route(\"/api/test/{test_id}\", " +
+                "get(test_get::<I, A, E, C>) ) " +
                 ".with_state(api_impl)");
         TestUtils.assertFileExists(outputPath);
         TestUtils.assertFileContains(outputPath, routerSpec);

--- a/modules/openapi-generator/src/test/resources/3_1/issue_21144.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_21144.yaml
@@ -25,6 +25,25 @@ paths:
           description: "post"
       security:
         - apiKey: []
+  /api/test/{testId}:
+    get:
+      tags:
+        - firsttag
+        - secondtag
+        - thirdtag
+      operationId: "testGet"
+      description: "Get method"
+      parameters:
+        - name: testId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: "get"
+      security:
+        - apiKey: [ ]
 components:
   securitySchemes:
     apiKey:


### PR DESCRIPTION
Same issue as #21144 but the fix for that issue did not take into account path names that are normalized for Rust conventions (camelCase param names turning into snake_case). This fixes that check to account for that difference.

Rust Committee: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro @dsteeley

I didn't see a sample YAML file for rust-axum in the `bin/configs/` directory. Let me know if there's something else I should do for that item in the PR checklist.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
