### PR TITLE
Resolve large int overflow, issue21805 

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -1941,7 +1941,7 @@ public class ModelUtils {
         if (multipleOf != null) target.setMultipleOf(multipleOf);
         if (minimum != null) {
             if (isIntegerSchema(schema)) {
-                target.setMinimum(String.valueOf(minimum.longValue()));
+                target.setMinimum(String.valueOf(minimum.toBigInteger()));
             } else {
                 target.setMinimum(String.valueOf(minimum));
             }
@@ -1949,7 +1949,7 @@ public class ModelUtils {
         }
         if (maximum != null) {
             if (isIntegerSchema(schema)) {
-                target.setMaximum(String.valueOf(maximum.longValue()));
+                target.setMaximum(String.valueOf(maximum.toBigInteger()));
             } else {
                 target.setMaximum(String.valueOf(maximum));
             }

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -312,15 +312,15 @@ pub struct {{{classname}}} {
         {{/pattern}}
         {{#maximum}}
             {{#minimum}}
-            range(min = {{minimum}}, max = {{maximum}}),
+            range(min = {{minimum}}{{dataType}}, max = {{maximum}}{{dataType}}),
             {{/minimum}}
             {{^minimum}}
-            range(max = {{maximum}}),
+            range(max = {{maximum}}{{dataType}}),
             {{/minimum}}
         {{/maximum}}
         {{#minimum}}
             {{^maximum}}
-            range(min = {{minimum}}),
+            range(min = {{minimum}}{{dataType}}),
             {{/maximum}}
         {{/minimum}}
         {{#maxItems}}

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -693,6 +693,9 @@ components:
           type: boolean
         optionalParam:
           type: integer
+          minimum: 1
+          maximum: 10000000000000000000
+          example: 100
     ObjectHeader:
       type: object
       required:

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/api/openapi.yaml
@@ -735,11 +735,14 @@ components:
     ObjectParam:
       example:
         requiredParam: true
-        optionalParam: 0
+        optionalParam: 100
       properties:
         requiredParam:
           type: boolean
         optionalParam:
+          example: 100
+          maximum: 10000000000000000000
+          minimum: 1
           type: integer
       required:
       - requiredParam

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/ObjectParam.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/ObjectParam.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **required_param** | **bool** |  | 
-**optional_param** | **i32** |  | [optional] [default to None]
+**optional_param** | **u64** |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/models.rs
@@ -3597,8 +3597,11 @@ pub struct ObjectParam {
     pub required_param: bool,
 
     #[serde(rename = "optionalParam")]
+    #[validate(
+            range(min = 1, max = 10000000000000000000),
+        )]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub optional_param: Option<i32>,
+    pub optional_param: Option<u64>,
 
 }
 
@@ -3645,7 +3648,7 @@ impl std::str::FromStr for ObjectParam {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub required_param: Vec<bool>,
-            pub optional_param: Vec<i32>,
+            pub optional_param: Vec<u64>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -3666,7 +3669,7 @@ impl std::str::FromStr for ObjectParam {
                     #[allow(clippy::redundant_clone)]
                     "requiredParam" => intermediate_rep.required_param.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optionalParam" => intermediate_rep.optional_param.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "optionalParam" => intermediate_rep.optional_param.push(<u64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     _ => return std::result::Result::Err("Unexpected key while parsing ObjectParam".to_string())
                 }
             }

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -735,11 +735,14 @@ components:
     ObjectParam:
       example:
         requiredParam: true
-        optionalParam: 0
+        optionalParam: 100
       properties:
         requiredParam:
           type: boolean
         optionalParam:
+          example: 100
+          maximum: 10000000000000000000
+          minimum: 1
           type: integer
       required:
       - requiredParam

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/ObjectParam.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/ObjectParam.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **required_param** | **bool** |  | 
-**optional_param** | **i32** |  | [optional] [default to None]
+**optional_param** | **u64** |  | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -3597,8 +3597,11 @@ pub struct ObjectParam {
     pub required_param: bool,
 
     #[serde(rename = "optionalParam")]
+    #[validate(
+            range(min = 1u64, max = 10000000000000000000u64),
+        )]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub optional_param: Option<i32>,
+    pub optional_param: Option<u64>,
 
 }
 
@@ -3645,7 +3648,7 @@ impl std::str::FromStr for ObjectParam {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub required_param: Vec<bool>,
-            pub optional_param: Vec<i32>,
+            pub optional_param: Vec<u64>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -3666,7 +3669,7 @@ impl std::str::FromStr for ObjectParam {
                     #[allow(clippy::redundant_clone)]
                     "requiredParam" => intermediate_rep.required_param.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "optionalParam" => intermediate_rep.optional_param.push(<i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "optionalParam" => intermediate_rep.optional_param.push(<u64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     _ => return std::result::Result::Err("Unexpected key while parsing ObjectParam".to_string())
                 }
             }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -3857,14 +3857,14 @@ impl FindPetsByStatusStatusParameterInner {
 pub struct FormatTest {
     #[serde(rename = "integer")]
     #[validate(
-            range(min = 10, max = 100),
+            range(min = 10u8, max = 100u8),
         )]
     #[serde(skip_serializing_if="Option::is_none")]
     pub integer: Option<u8>,
 
     #[serde(rename = "int32")]
     #[validate(
-            range(min = 20, max = 200),
+            range(min = 20u32, max = 200u32),
         )]
     #[serde(skip_serializing_if="Option::is_none")]
     pub int32: Option<u32>,
@@ -3875,20 +3875,20 @@ pub struct FormatTest {
 
     #[serde(rename = "number")]
     #[validate(
-            range(min = 32.1, max = 543.2),
+            range(min = 32.1f64, max = 543.2f64),
         )]
     pub number: f64,
 
     #[serde(rename = "float")]
     #[validate(
-            range(min = 54.3, max = 987.6),
+            range(min = 54.3f32, max = 987.6f32),
         )]
     #[serde(skip_serializing_if="Option::is_none")]
     pub float: Option<f32>,
 
     #[serde(rename = "double")]
     #[validate(
-            range(min = 67.8, max = 123.4),
+            range(min = 67.8f64, max = 123.4f64),
         )]
     #[serde(skip_serializing_if="Option::is_none")]
     pub double: Option<f64>,


### PR DESCRIPTION
fixes #21805 

rust-server compilation failed with large maximums. Resolved by handling minimum and maximum using BigInt instead of longValue.
Tested by updating and regenerating samples and validating that the updated example compiles. 


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. cc @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)
