### PR TITLE
[typescript-fetch] Remove returns in oneOf serialization code which short circuit additional type checks

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -56,12 +56,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     if (Array.isArray(json)) {
         if (json.every(item => typeof item === 'object')) {
     {{/-first}}
-            if (json.every(item => instanceOf{{{.}}}(item))) {
-                return json.map(value => {{{.}}}FromJSONTyped(value, true));
+            if (json.every(item => instanceOf{{{.}}}(item as object))) {
+                return json.map(item => {{{.}}}FromJSONTyped(item, true));
             }
     {{#-last}}
         }
-        return json;
     }
     {{/-last}}
     {{/oneOfArrays}}
@@ -70,15 +69,15 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{#items}}
     {{#isDateType}}
     if (Array.isArray(json)) {
-        if (json.every(item => !(isNaN(new Date(json).getTime()))) {
-            return json.map(value => new Date(json);
+        if (json.every(item => !(isNaN(new Date(item).getTime())))) {
+            return json.map(item => new Date(item));
         }
     }
     {{/isDateType}}
     {{#isDateTimeType}}
     if (Array.isArray(json)) {
-        if (json.every(item => !(isNaN(new Date(json).getTime()))) {
-            return json.map(value => new Date(json);
+        if (json.every(item => !(isNaN(new Date(item).getTime())))) {
+            return json.map(item => new Date(item));
         }
     }
     {{/isDateTimeType}}
@@ -161,12 +160,11 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     if (Array.isArray(value)) {
         if (value.every(item => typeof item === 'object')) {
     {{/-first}}
-            if (value.every(item => instanceOf{{{.}}}(item))) {
-                return value.map(value => {{{.}}}ToJSON(value as {{{.}}}));
+            if (value.every(item => instanceOf{{{.}}}(item as object))) {
+                return value.map(item => {{{.}}}ToJSON(item as {{{.}}}));
             }
     {{#-last}}
         }
-        return value;
     }
     {{/-last}}
     {{/oneOfArrays}}
@@ -175,15 +173,15 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     {{#items}}
     {{#isDateType}}
     if (Array.isArray(value)) {
-        if (value.every(item => item instanceof Date) {
-            return value.map(value => value.toISOString().substring(0,10)));
+        if (value.every(item => item instanceof Date)) {
+            return value.map(item => item.toISOString().substring(0,10));
         }
     }
     {{/isDateType}}
     {{#isDateTimeType}}
     if (Array.isArray(value)) {
-        if (value.every(item => item instanceof Date) {
-            return value.map(value => value.toISOString();
+        if (value.every(item => item instanceof Date)) {
+            return value.map(item => item.toISOString());
         }
     }
     {{/isDateTimeType}}

--- a/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestArrayResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/oneOf/models/TestArrayResponse.ts
@@ -44,14 +44,13 @@ export function TestArrayResponseFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     if (Array.isArray(json)) {
         if (json.every(item => typeof item === 'object')) {
-            if (json.every(item => instanceOfTestA(item))) {
-                return json.map(value => TestAFromJSONTyped(value, true));
+            if (json.every(item => instanceOfTestA(item as object))) {
+                return json.map(item => TestAFromJSONTyped(item, true));
             }
-            if (json.every(item => instanceOfTestB(item))) {
-                return json.map(value => TestBFromJSONTyped(value, true));
+            if (json.every(item => instanceOfTestB(item as object))) {
+                return json.map(item => TestBFromJSONTyped(item, true));
             }
         }
-        return json;
     }
     if (Array.isArray(json)) {
         if (json.every(item => typeof item === 'string')) {
@@ -71,14 +70,13 @@ export function TestArrayResponseToJSONTyped(value?: TestArrayResponse | null, i
     }
     if (Array.isArray(value)) {
         if (value.every(item => typeof item === 'object')) {
-            if (value.every(item => instanceOfTestA(item))) {
-                return value.map(value => TestAToJSON(value as TestA));
+            if (value.every(item => instanceOfTestA(item as object))) {
+                return value.map(item => TestAToJSON(item as TestA));
             }
-            if (value.every(item => instanceOfTestB(item))) {
-                return value.map(value => TestBToJSON(value as TestB));
+            if (value.every(item => instanceOfTestB(item as object))) {
+                return value.map(item => TestBToJSON(item as TestB));
             }
         }
-        return value;
     }
     if (Array.isArray(value)) {
         if (value.every(item => typeof item === 'string')) {


### PR DESCRIPTION
Fixes #21811

The JSON serialization/deserialization code generated for `oneOf` schemas which do not use a discriminator follows a pattern of validating & serializing first the model schemas, then arrays of non-primitive objects, then primitive objects (including arrays).

The area of the template which validates & serializes / deserializes arrays of non-primitive objects includes a `return value;` or `return json;` statement if it does not find a matching object.  For example:

```typescript
    if (Array.isArray(value)) {
        if (value.every(item => typeof item === 'object')) {
            if (value.every(item => instanceOfTestA(item))) {
                return value.map(value => TestAToJSON(value as TestA));
            }
            if (value.every(item => instanceOfTestB(item))) {
                return value.map(value => TestBToJSON(value as TestB));
            }
        }
        return value;
    }
```

This return short circuits further validation / serialization that should happen if the schema is an array of a primitive type.

Additionally there are a couple of other fixes for:

* Code which is deserializing arrays of Dates is using the entire json string instead of deserializing each item in the array.
* Variable name duplication in the lambdas for some calls to `.map` (e.g. `value.map(value => value.toISOString())`)
* Not casting array items as `object` when calling `instanceOf` methods
* Several paces where the code which has unbalanced parenthesis

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
