### PR TITLE
test(golang): proof that enums can be dodged

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -376,6 +376,32 @@ public class GoClientCodegenTest {
     }
 
     @Test
+    public void testAdditionalPropertiesPrefixEnums() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_1/enum_collision.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .addAdditionalProperty("enumClassPrefix", "true")
+                .addInlineSchemaOption("RESOLVE_INLINE_ENUMS", "true");
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        System.out.println(files);
+        files.forEach(File::deleteOnExit);
+
+        Path petFile = Paths.get(output + "/model_pet_status.go");
+        TestUtils.assertFileExists(petFile);
+        TestUtils.assertFileContains(petFile, "PETSTATUS_SOLD");
+
+        Path machineFile = Paths.get(output + "/model_machine_status.go");
+        TestUtils.assertFileExists(machineFile);
+        TestUtils.assertFileContains(machineFile, "MACHINESTATUS_SOLD");
+    }
+
+    @Test
     public void testAdditionalPropertiesWithoutGoMod() throws Exception {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_1/enum_collision.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/enum_collision.yaml
@@ -1,0 +1,48 @@
+openapi: 3.1.0
+info:
+  title: TEST
+  description: |-
+    ## TEST
+  version: 1.0.0
+
+servers:
+  - url: /v3
+    description: Major version of service
+
+paths:
+  /agreements:
+    get:
+      operationId: readAPet
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      properties:
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+    Machine:
+      title: a Machine
+      description: A machine for sale in the pet store
+      type: object
+      properties:
+        status:
+          type: string
+          description: machine status in the store
+          enum:
+            - available
+            - pending
+            - sold


### PR DESCRIPTION
Closes #21895

As defined in #21895 this will add ~a option to prefix the enums constants with a type~ a test that proofs that inline enums in combination with enumClassPrefix is actually already doing the right thing

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
