### PR TITLE
[jaxsrs-spec] Support additional properties with composed schema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -242,6 +242,7 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
         }
 
         convertPropertyToBooleanAndWriteBack(USE_GZIP_FEATURE, this::setUseGzipFeature);
+        supportsAdditionalPropertiesWithComposedSchema = true;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/additionalProperties.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/additionalProperties.mustache
@@ -1,0 +1,39 @@
+{{#additionalPropertiesType}}
+    /**
+    * A container for additional, undeclared properties.
+    * This is a holder for any undeclared properties as specified with
+    * the 'additionalProperties' keyword in the OAS document.
+    */
+    private Map<String, {{{.}}}> additionalProperties;
+
+    /**
+    * Set the additional (undeclared) property with the specified name and value.
+    * If the property does not already exist, create it otherwise replace it.
+    */
+    @JsonAnySetter
+    public {{classname}} putAdditionalProperty(String key, {{{.}}} value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<String, {{{.}}}>();
+        }
+        this.additionalProperties.put(key, value);
+        return this;
+    }
+
+    /**
+    * Return the additional (undeclared) property.
+    */
+    @JsonAnyGetter
+    public Map<String, {{{.}}}> getAdditionalProperties() {
+        return additionalProperties;
+    }
+
+    /**
+    * Return the additional (undeclared) property with the specified name.
+    */
+    public {{{.}}} getAdditionalProperty(String key) {
+        if (this.additionalProperties == null) {
+            return null;
+        }
+        return this.additionalProperties.get(key);
+    }
+{{/additionalPropertiesType}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -1,6 +1,12 @@
 {{#useSwaggerAnnotations}}
 import io.swagger.annotations.*;
 {{/useSwaggerAnnotations}}
+{{#additionalPropertiesType}}
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+{{/additionalPropertiesType}}
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -143,6 +149,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
   }
   {{/isMap}}
   {{/vars}}
+  {{>additionalProperties}}
 
   @Override
   public boolean equals(Object o) {
@@ -155,13 +162,13 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
     {{classname}} {{classVarName}} = ({{classname}}) o;
     return {{#vars}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{^-last}} &&
         {{/-last}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+        super.equals(o){{/parent}}{{#additionalPropertiesType}} && Objects.equals(this.additionalProperties, {{classVarName}}.additionalProperties){{/additionalPropertiesType}};{{/hasVars}}{{^hasVars}}
     return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash({{#vars}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+    return Objects.hash({{#vars}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{^-last}}, {{/-last}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}}{{#additionalPropertiesType}}{{#hasVars}}, {{/hasVars}}{{^hasVars}}{{#parent}}, {{/parent}}{{/hasVars}}additionalProperties{{/additionalPropertiesType}});
   }
 
   @Override
@@ -171,6 +178,8 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
     {{#parent}}sb.append("    ").append(toIndentedString(super.toString())).append("\n");{{/parent}}
     {{#vars}}sb.append("    {{name}}: ").append({{#isPassword}}"*"{{/isPassword}}{{^isPassword}}toIndentedString({{name}}){{/isPassword}}).append("\n");
     {{/vars}}sb.append("}");
+    {{#additionalPropertiesType}}sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
+    {{/additionalPropertiesType}}sb.append("}");
     return sb.toString();
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
+public class AdditionalPropertiesAnyType  implements Serializable {
   private String name;
 
   public AdditionalPropertiesAnyType() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesAnyType putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesAnyType.name) && Objects.equals(this.additionalProperties, additionalPropertiesAnyType.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesAnyType {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -2,14 +2,16 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
+public class AdditionalPropertiesArray  implements Serializable {
   private String name;
 
   public AdditionalPropertiesArray() {
@@ -45,6 +47,43 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, List> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesArray putAdditionalProperty(String key, List value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, List>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, List> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public List getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesArray.name) && Objects.equals(this.additionalProperties, additionalPropertiesArray.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesArray {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
+public class AdditionalPropertiesBoolean  implements Serializable {
   private String name;
 
   public AdditionalPropertiesBoolean() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Boolean> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesBoolean putAdditionalProperty(String key, Boolean value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Boolean>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Boolean> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Boolean getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesBoolean.name) && Objects.equals(this.additionalProperties, additionalPropertiesBoolean.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesBoolean {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -374,7 +374,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     this.anytype3 = anytype3;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -418,6 +418,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     sb.append("    anytype1: ").append(toIndentedString(anytype1)).append("\n");
     sb.append("    anytype2: ").append(toIndentedString(anytype2)).append("\n");
     sb.append("    anytype3: ").append(toIndentedString(anytype3)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
+public class AdditionalPropertiesInteger  implements Serializable {
   private String name;
 
   public AdditionalPropertiesInteger() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Integer> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesInteger putAdditionalProperty(String key, Integer value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Integer>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Integer> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Integer getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesInteger.name) && Objects.equals(this.additionalProperties, additionalPropertiesInteger.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesInteger {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -3,13 +3,15 @@ package org.openapitools.model;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
+public class AdditionalPropertiesNumber  implements Serializable {
   private String name;
 
   public AdditionalPropertiesNumber() {
@@ -45,6 +47,43 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, BigDecimal> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesNumber putAdditionalProperty(String key, BigDecimal value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, BigDecimal>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, BigDecimal> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public BigDecimal getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesNumber.name) && Objects.equals(this.additionalProperties, additionalPropertiesNumber.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesNumber {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -2,13 +2,16 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
 import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
+public class AdditionalPropertiesObject  implements Serializable {
   private String name;
 
   public AdditionalPropertiesObject() {
@@ -44,6 +47,43 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Map> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesObject putAdditionalProperty(String key, Map value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Map>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Map> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Map getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +94,22 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesObject.name) && Objects.equals(this.additionalProperties, additionalPropertiesObject.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesObject {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
+public class AdditionalPropertiesString  implements Serializable {
   private String name;
 
   public AdditionalPropertiesString() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, String> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesString putAdditionalProperty(String key, String value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, String>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, String> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public String getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesString.name) && Objects.equals(this.additionalProperties, additionalPropertiesString.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesString {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Animal.java
@@ -78,7 +78,7 @@ public class Animal  implements Serializable {
     this.color = color;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -104,6 +104,7 @@ public class Animal  implements Serializable {
     
     sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -62,7 +62,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -86,6 +86,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfArrayOfNumberOnly {\n");
     
     sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -62,7 +62,7 @@ public class ArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -86,6 +86,7 @@ public class ArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfNumberOnly {\n");
     
     sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -134,7 +134,7 @@ public class ArrayTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -162,6 +162,7 @@ public class ArrayTest  implements Serializable {
     sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
     sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
     sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/BigCat.java
@@ -99,7 +99,7 @@ public class BigCat extends Cat implements Serializable {
     this.kind = kind;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -124,6 +124,7 @@ public class BigCat extends Cat implements Serializable {
     sb.append("class BigCat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Capitalization.java
@@ -143,7 +143,7 @@ public class Capitalization  implements Serializable {
     this.ATT_NAME = ATT_NAME;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -177,6 +177,7 @@ public class Capitalization  implements Serializable {
     sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
     sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
     sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Cat.java
@@ -52,7 +52,7 @@ public class Cat extends Animal implements Serializable {
     this.declawed = declawed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -77,6 +77,7 @@ public class Cat extends Animal implements Serializable {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Category.java
@@ -69,7 +69,7 @@ public class Category  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -95,6 +95,7 @@ public class Category  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ClassModel.java
@@ -44,7 +44,7 @@ public class ClassModel  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,6 +68,7 @@ public class ClassModel  implements Serializable {
     sb.append("class ClassModel {\n");
     
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Client.java
@@ -42,7 +42,7 @@ public class Client  implements Serializable {
     this.client = client;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -66,6 +66,7 @@ public class Client  implements Serializable {
     sb.append("class Client {\n");
     
     sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Dog.java
@@ -52,7 +52,7 @@ public class Dog extends Animal implements Serializable {
     this.breed = breed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -77,6 +77,7 @@ public class Dog extends Animal implements Serializable {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -175,7 +175,7 @@ public class EnumArrays  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -201,6 +201,7 @@ public class EnumArrays  implements Serializable {
     
     sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumTest.java
@@ -319,7 +319,7 @@ public class EnumTest  implements Serializable {
     this.outerEnum = outerEnum;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -351,6 +351,7 @@ public class EnumTest  implements Serializable {
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -82,7 +82,7 @@ public class FileSchemaTestClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -108,6 +108,7 @@ public class FileSchemaTestClass  implements Serializable {
     
     sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
     sb.append("    files: ").append(toIndentedString(files)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FormatTest.java
@@ -332,7 +332,7 @@ public class FormatTest  implements Serializable {
     this.bigDecimal = bigDecimal;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -382,6 +382,7 @@ public class FormatTest  implements Serializable {
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append("*").append("\n");
     sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -63,7 +63,7 @@ public class HasOnlyReadOnly  implements Serializable {
     this.foo = foo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -89,6 +89,7 @@ public class HasOnlyReadOnly  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MapTest.java
@@ -215,7 +215,7 @@ public class MapTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -245,6 +245,7 @@ public class MapTest  implements Serializable {
     sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
     sb.append("    directMap: ").append(toIndentedString(directMap)).append("\n");
     sb.append("    indirectMap: ").append(toIndentedString(indirectMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -103,7 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -131,6 +131,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Model200Response.java
@@ -65,7 +65,7 @@ public class Model200Response  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,6 +91,7 @@ public class Model200Response  implements Serializable {
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -83,7 +83,7 @@ public class ModelApiResponse  implements Serializable {
     this.message = message;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class ModelApiResponse  implements Serializable {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelFile.java
@@ -46,7 +46,7 @@ public class ModelFile  implements Serializable {
     this.sourceURI = sourceURI;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class ModelFile  implements Serializable {
     sb.append("class ModelFile {\n");
     
     sb.append("    sourceURI: ").append(toIndentedString(sourceURI)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelList.java
@@ -43,7 +43,7 @@ public class ModelList  implements Serializable {
     this._123list = _123list;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -67,6 +67,7 @@ public class ModelList  implements Serializable {
     sb.append("class ModelList {\n");
     
     sb.append("    _123list: ").append(toIndentedString(_123list)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -45,7 +45,7 @@ public class ModelReturn  implements Serializable {
     this._return = _return;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class ModelReturn  implements Serializable {
     sb.append("class ModelReturn {\n");
     
     sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Name.java
@@ -111,7 +111,7 @@ public class Name  implements Serializable {
     this._123number = _123number;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -141,6 +141,7 @@ public class Name  implements Serializable {
     sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
     sb.append("    property: ").append(toIndentedString(property)).append("\n");
     sb.append("    _123number: ").append(toIndentedString(_123number)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -43,7 +43,7 @@ public class NumberOnly  implements Serializable {
     this.justNumber = justNumber;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -67,6 +67,7 @@ public class NumberOnly  implements Serializable {
     sb.append("class NumberOnly {\n");
     
     sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Order.java
@@ -191,7 +191,7 @@ public class Order  implements Serializable {
     this.complete = complete;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -225,6 +225,7 @@ public class Order  implements Serializable {
     sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -83,7 +83,7 @@ public class OuterComposite  implements Serializable {
     this.myBoolean = myBoolean;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class OuterComposite  implements Serializable {
     sb.append("    myNumber: ").append(toIndentedString(myNumber)).append("\n");
     sb.append("    myString: ").append(toIndentedString(myString)).append("\n");
     sb.append("    myBoolean: ").append(toIndentedString(myBoolean)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Pet.java
@@ -240,7 +240,7 @@ public class Pet  implements Serializable {
     this.status = status;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -274,6 +274,7 @@ public class Pet  implements Serializable {
     sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -62,7 +62,7 @@ public class ReadOnlyFirst  implements Serializable {
     this.baz = baz;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class ReadOnlyFirst  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -43,7 +43,7 @@ public class SpecialModelName  implements Serializable {
     this.$specialPropertyName = $specialPropertyName;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -67,6 +67,7 @@ public class SpecialModelName  implements Serializable {
     sb.append("class SpecialModelName {\n");
     
     sb.append("    $specialPropertyName: ").append(toIndentedString($specialPropertyName)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Tag.java
@@ -62,7 +62,7 @@ public class Tag  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class Tag  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -157,7 +157,7 @@ public class TypeHolderDefault  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -189,6 +189,7 @@ public class TypeHolderDefault  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -179,7 +179,7 @@ public class TypeHolderExample  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -213,6 +213,7 @@ public class TypeHolderExample  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/User.java
@@ -183,7 +183,7 @@ public class User  implements Serializable {
     this.userStatus = userStatus;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -221,6 +221,7 @@ public class User  implements Serializable {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
     sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/XmlItem.java
@@ -750,7 +750,7 @@ public class XmlItem  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -830,6 +830,7 @@ public class XmlItem  implements Serializable {
     sb.append("    prefixNsBoolean: ").append(toIndentedString(prefixNsBoolean)).append("\n");
     sb.append("    prefixNsArray: ").append(toIndentedString(prefixNsArray)).append("\n");
     sb.append("    prefixNsWrappedArray: ").append(toIndentedString(prefixNsWrappedArray)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
+public class AdditionalPropertiesAnyType  implements Serializable {
   private String name;
 
   public AdditionalPropertiesAnyType() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesAnyType putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesAnyType.name) && Objects.equals(this.additionalProperties, additionalPropertiesAnyType.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesAnyType {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -2,14 +2,16 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
+public class AdditionalPropertiesArray  implements Serializable {
   private String name;
 
   public AdditionalPropertiesArray() {
@@ -45,6 +47,43 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, List> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesArray putAdditionalProperty(String key, List value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, List>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, List> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public List getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesArray.name) && Objects.equals(this.additionalProperties, additionalPropertiesArray.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesArray {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
+public class AdditionalPropertiesBoolean  implements Serializable {
   private String name;
 
   public AdditionalPropertiesBoolean() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Boolean> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesBoolean putAdditionalProperty(String key, Boolean value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Boolean>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Boolean> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Boolean getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesBoolean.name) && Objects.equals(this.additionalProperties, additionalPropertiesBoolean.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesBoolean {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -374,7 +374,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     this.anytype3 = anytype3;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -418,6 +418,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     sb.append("    anytype1: ").append(toIndentedString(anytype1)).append("\n");
     sb.append("    anytype2: ").append(toIndentedString(anytype2)).append("\n");
     sb.append("    anytype3: ").append(toIndentedString(anytype3)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
+public class AdditionalPropertiesInteger  implements Serializable {
   private String name;
 
   public AdditionalPropertiesInteger() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Integer> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesInteger putAdditionalProperty(String key, Integer value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Integer>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Integer> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Integer getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesInteger.name) && Objects.equals(this.additionalProperties, additionalPropertiesInteger.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesInteger {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -3,13 +3,15 @@ package org.openapitools.model;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
+public class AdditionalPropertiesNumber  implements Serializable {
   private String name;
 
   public AdditionalPropertiesNumber() {
@@ -45,6 +47,43 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, BigDecimal> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesNumber putAdditionalProperty(String key, BigDecimal value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, BigDecimal>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, BigDecimal> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public BigDecimal getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesNumber.name) && Objects.equals(this.additionalProperties, additionalPropertiesNumber.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesNumber {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -2,13 +2,16 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
 import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
+public class AdditionalPropertiesObject  implements Serializable {
   private String name;
 
   public AdditionalPropertiesObject() {
@@ -44,6 +47,43 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Map> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesObject putAdditionalProperty(String key, Map value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Map>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Map> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Map getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +94,22 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesObject.name) && Objects.equals(this.additionalProperties, additionalPropertiesObject.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesObject {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
+public class AdditionalPropertiesString  implements Serializable {
   private String name;
 
   public AdditionalPropertiesString() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, String> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesString putAdditionalProperty(String key, String value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, String>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, String> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public String getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesString.name) && Objects.equals(this.additionalProperties, additionalPropertiesString.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesString {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
@@ -78,7 +78,7 @@ public class Animal  implements Serializable {
     this.color = color;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -104,6 +104,7 @@ public class Animal  implements Serializable {
     
     sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -62,7 +62,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -86,6 +86,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfArrayOfNumberOnly {\n");
     
     sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -62,7 +62,7 @@ public class ArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -86,6 +86,7 @@ public class ArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfNumberOnly {\n");
     
     sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -134,7 +134,7 @@ public class ArrayTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -162,6 +162,7 @@ public class ArrayTest  implements Serializable {
     sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
     sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
     sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
@@ -99,7 +99,7 @@ public class BigCat extends Cat implements Serializable {
     this.kind = kind;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -124,6 +124,7 @@ public class BigCat extends Cat implements Serializable {
     sb.append("class BigCat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
@@ -143,7 +143,7 @@ public class Capitalization  implements Serializable {
     this.ATT_NAME = ATT_NAME;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -177,6 +177,7 @@ public class Capitalization  implements Serializable {
     sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
     sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
     sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
@@ -52,7 +52,7 @@ public class Cat extends Animal implements Serializable {
     this.declawed = declawed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -77,6 +77,7 @@ public class Cat extends Animal implements Serializable {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
@@ -69,7 +69,7 @@ public class Category  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -95,6 +95,7 @@ public class Category  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
@@ -44,7 +44,7 @@ public class ClassModel  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,6 +68,7 @@ public class ClassModel  implements Serializable {
     sb.append("class ClassModel {\n");
     
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
@@ -42,7 +42,7 @@ public class Client  implements Serializable {
     this.client = client;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -66,6 +66,7 @@ public class Client  implements Serializable {
     sb.append("class Client {\n");
     
     sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
@@ -52,7 +52,7 @@ public class Dog extends Animal implements Serializable {
     this.breed = breed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -77,6 +77,7 @@ public class Dog extends Animal implements Serializable {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -175,7 +175,7 @@ public class EnumArrays  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -201,6 +201,7 @@ public class EnumArrays  implements Serializable {
     
     sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -319,7 +319,7 @@ public class EnumTest  implements Serializable {
     this.outerEnum = outerEnum;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -351,6 +351,7 @@ public class EnumTest  implements Serializable {
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -82,7 +82,7 @@ public class FileSchemaTestClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -108,6 +108,7 @@ public class FileSchemaTestClass  implements Serializable {
     
     sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
     sb.append("    files: ").append(toIndentedString(files)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
@@ -332,7 +332,7 @@ public class FormatTest  implements Serializable {
     this.bigDecimal = bigDecimal;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -382,6 +382,7 @@ public class FormatTest  implements Serializable {
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append("*").append("\n");
     sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -63,7 +63,7 @@ public class HasOnlyReadOnly  implements Serializable {
     this.foo = foo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -89,6 +89,7 @@ public class HasOnlyReadOnly  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -215,7 +215,7 @@ public class MapTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -245,6 +245,7 @@ public class MapTest  implements Serializable {
     sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
     sb.append("    directMap: ").append(toIndentedString(directMap)).append("\n");
     sb.append("    indirectMap: ").append(toIndentedString(indirectMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -103,7 +103,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -131,6 +131,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
@@ -65,7 +65,7 @@ public class Model200Response  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,6 +91,7 @@ public class Model200Response  implements Serializable {
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -83,7 +83,7 @@ public class ModelApiResponse  implements Serializable {
     this.message = message;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class ModelApiResponse  implements Serializable {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelFile.java
@@ -46,7 +46,7 @@ public class ModelFile  implements Serializable {
     this.sourceURI = sourceURI;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class ModelFile  implements Serializable {
     sb.append("class ModelFile {\n");
     
     sb.append("    sourceURI: ").append(toIndentedString(sourceURI)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelList.java
@@ -43,7 +43,7 @@ public class ModelList  implements Serializable {
     this._123list = _123list;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -67,6 +67,7 @@ public class ModelList  implements Serializable {
     sb.append("class ModelList {\n");
     
     sb.append("    _123list: ").append(toIndentedString(_123list)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -45,7 +45,7 @@ public class ModelReturn  implements Serializable {
     this._return = _return;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class ModelReturn  implements Serializable {
     sb.append("class ModelReturn {\n");
     
     sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
@@ -111,7 +111,7 @@ public class Name  implements Serializable {
     this._123number = _123number;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -141,6 +141,7 @@ public class Name  implements Serializable {
     sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
     sb.append("    property: ").append(toIndentedString(property)).append("\n");
     sb.append("    _123number: ").append(toIndentedString(_123number)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -43,7 +43,7 @@ public class NumberOnly  implements Serializable {
     this.justNumber = justNumber;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -67,6 +67,7 @@ public class NumberOnly  implements Serializable {
     sb.append("class NumberOnly {\n");
     
     sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -191,7 +191,7 @@ public class Order  implements Serializable {
     this.complete = complete;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -225,6 +225,7 @@ public class Order  implements Serializable {
     sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -83,7 +83,7 @@ public class OuterComposite  implements Serializable {
     this.myBoolean = myBoolean;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class OuterComposite  implements Serializable {
     sb.append("    myNumber: ").append(toIndentedString(myNumber)).append("\n");
     sb.append("    myString: ").append(toIndentedString(myString)).append("\n");
     sb.append("    myBoolean: ").append(toIndentedString(myBoolean)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -240,7 +240,7 @@ public class Pet  implements Serializable {
     this.status = status;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -274,6 +274,7 @@ public class Pet  implements Serializable {
     sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -62,7 +62,7 @@ public class ReadOnlyFirst  implements Serializable {
     this.baz = baz;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class ReadOnlyFirst  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -43,7 +43,7 @@ public class SpecialModelName  implements Serializable {
     this.$specialPropertyName = $specialPropertyName;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -67,6 +67,7 @@ public class SpecialModelName  implements Serializable {
     sb.append("class SpecialModelName {\n");
     
     sb.append("    $specialPropertyName: ").append(toIndentedString($specialPropertyName)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
@@ -62,7 +62,7 @@ public class Tag  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class Tag  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -157,7 +157,7 @@ public class TypeHolderDefault  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -189,6 +189,7 @@ public class TypeHolderDefault  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -179,7 +179,7 @@ public class TypeHolderExample  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -213,6 +213,7 @@ public class TypeHolderExample  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
@@ -183,7 +183,7 @@ public class User  implements Serializable {
     this.userStatus = userStatus;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -221,6 +221,7 @@ public class User  implements Serializable {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
     sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
@@ -750,7 +750,7 @@ public class XmlItem  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -830,6 +830,7 @@ public class XmlItem  implements Serializable {
     sb.append("    prefixNsBoolean: ").append(toIndentedString(prefixNsBoolean)).append("\n");
     sb.append("    prefixNsArray: ").append(toIndentedString(prefixNsArray)).append("\n");
     sb.append("    prefixNsWrappedArray: ").append(toIndentedString(prefixNsWrappedArray)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesAnyType")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
+public class AdditionalPropertiesAnyType  implements Serializable {
   private String name;
 
   public AdditionalPropertiesAnyType() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesAnyType putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesAnyType.name) && Objects.equals(this.additionalProperties, additionalPropertiesAnyType.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesAnyType {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -2,14 +2,16 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesArray")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
+public class AdditionalPropertiesArray  implements Serializable {
   private String name;
 
   public AdditionalPropertiesArray() {
@@ -45,6 +47,43 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, List> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesArray putAdditionalProperty(String key, List value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, List>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, List> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public List getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesArray.name) && Objects.equals(this.additionalProperties, additionalPropertiesArray.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesArray {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesBoolean")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
+public class AdditionalPropertiesBoolean  implements Serializable {
   private String name;
 
   public AdditionalPropertiesBoolean() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Boolean> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesBoolean putAdditionalProperty(String key, Boolean value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Boolean>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Boolean> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Boolean getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesBoolean.name) && Objects.equals(this.additionalProperties, additionalPropertiesBoolean.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesBoolean {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -388,7 +388,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     this.anytype3 = anytype3;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -432,6 +432,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     sb.append("    anytype1: ").append(toIndentedString(anytype1)).append("\n");
     sb.append("    anytype2: ").append(toIndentedString(anytype2)).append("\n");
     sb.append("    anytype3: ").append(toIndentedString(anytype3)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesInteger")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
+public class AdditionalPropertiesInteger  implements Serializable {
   private String name;
 
   public AdditionalPropertiesInteger() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Integer> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesInteger putAdditionalProperty(String key, Integer value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Integer>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Integer> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Integer getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesInteger.name) && Objects.equals(this.additionalProperties, additionalPropertiesInteger.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesInteger {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -3,13 +3,15 @@ package org.openapitools.model;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesNumber")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
+public class AdditionalPropertiesNumber  implements Serializable {
   private String name;
 
   public AdditionalPropertiesNumber() {
@@ -45,6 +47,43 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, BigDecimal> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesNumber putAdditionalProperty(String key, BigDecimal value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, BigDecimal>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, BigDecimal> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public BigDecimal getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesNumber.name) && Objects.equals(this.additionalProperties, additionalPropertiesNumber.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesNumber {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -2,13 +2,16 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
 import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesObject")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
+public class AdditionalPropertiesObject  implements Serializable {
   private String name;
 
   public AdditionalPropertiesObject() {
@@ -44,6 +47,43 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Map> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesObject putAdditionalProperty(String key, Map value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Map>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Map> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Map getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +94,22 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesObject.name) && Objects.equals(this.additionalProperties, additionalPropertiesObject.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesObject {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -2,13 +2,15 @@ package org.openapitools.model;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("AdditionalPropertiesString")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
+public class AdditionalPropertiesString  implements Serializable {
   private String name;
 
   public AdditionalPropertiesString() {
@@ -44,6 +46,43 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, String> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesString putAdditionalProperty(String key, String value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, String>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, String> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public String getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -54,21 +93,22 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesString.name) && Objects.equals(this.additionalProperties, additionalPropertiesString.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesString {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Animal.java
@@ -83,7 +83,7 @@ public class Animal  implements Serializable {
     this.color = color;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -109,6 +109,7 @@ public class Animal  implements Serializable {
     
     sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -90,6 +90,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfArrayOfNumberOnly {\n");
     
     sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -66,7 +66,7 @@ public class ArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -90,6 +90,7 @@ public class ArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfNumberOnly {\n");
     
     sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -140,7 +140,7 @@ public class ArrayTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -168,6 +168,7 @@ public class ArrayTest  implements Serializable {
     sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
     sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
     sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/BigCat.java
@@ -104,7 +104,7 @@ public class BigCat extends Cat implements Serializable {
     this.kind = kind;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -129,6 +129,7 @@ public class BigCat extends Cat implements Serializable {
     sb.append("class BigCat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Capitalization.java
@@ -152,7 +152,7 @@ public class Capitalization  implements Serializable {
     this.ATT_NAME = ATT_NAME;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -186,6 +186,7 @@ public class Capitalization  implements Serializable {
     sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
     sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
     sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Cat.java
@@ -57,7 +57,7 @@ public class Cat extends Animal implements Serializable {
     this.declawed = declawed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -82,6 +82,7 @@ public class Cat extends Animal implements Serializable {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Category.java
@@ -74,7 +74,7 @@ public class Category  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -100,6 +100,7 @@ public class Category  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ClassModel.java
@@ -48,7 +48,7 @@ public class ClassModel  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +72,7 @@ public class ClassModel  implements Serializable {
     sb.append("class ClassModel {\n");
     
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Client.java
@@ -46,7 +46,7 @@ public class Client  implements Serializable {
     this.client = client;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class Client  implements Serializable {
     sb.append("class Client {\n");
     
     sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Dog.java
@@ -57,7 +57,7 @@ public class Dog extends Animal implements Serializable {
     this.breed = breed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -82,6 +82,7 @@ public class Dog extends Animal implements Serializable {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -180,7 +180,7 @@ public class EnumArrays  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -206,6 +206,7 @@ public class EnumArrays  implements Serializable {
     
     sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumTest.java
@@ -327,7 +327,7 @@ public class EnumTest  implements Serializable {
     this.outerEnum = outerEnum;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -359,6 +359,7 @@ public class EnumTest  implements Serializable {
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -87,7 +87,7 @@ public class FileSchemaTestClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -113,6 +113,7 @@ public class FileSchemaTestClass  implements Serializable {
     
     sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
     sb.append("    files: ").append(toIndentedString(files)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FormatTest.java
@@ -349,7 +349,7 @@ public class FormatTest  implements Serializable {
     this.bigDecimal = bigDecimal;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -399,6 +399,7 @@ public class FormatTest  implements Serializable {
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append("*").append("\n");
     sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -68,7 +68,7 @@ public class HasOnlyReadOnly  implements Serializable {
     this.foo = foo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,6 +94,7 @@ public class HasOnlyReadOnly  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MapTest.java
@@ -222,7 +222,7 @@ public class MapTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -252,6 +252,7 @@ public class MapTest  implements Serializable {
     sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
     sb.append("    directMap: ").append(toIndentedString(directMap)).append("\n");
     sb.append("    indirectMap: ").append(toIndentedString(indirectMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -109,7 +109,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -137,6 +137,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Model200Response.java
@@ -70,7 +70,7 @@ public class Model200Response  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -96,6 +96,7 @@ public class Model200Response  implements Serializable {
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -89,7 +89,7 @@ public class ModelApiResponse  implements Serializable {
     this.message = message;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -117,6 +117,7 @@ public class ModelApiResponse  implements Serializable {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelFile.java
@@ -50,7 +50,7 @@ public class ModelFile  implements Serializable {
     this.sourceURI = sourceURI;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -74,6 +74,7 @@ public class ModelFile  implements Serializable {
     sb.append("class ModelFile {\n");
     
     sb.append("    sourceURI: ").append(toIndentedString(sourceURI)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelList.java
@@ -47,7 +47,7 @@ public class ModelList  implements Serializable {
     this._123list = _123list;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class ModelList  implements Serializable {
     sb.append("class ModelList {\n");
     
     sb.append("    _123list: ").append(toIndentedString(_123list)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -49,7 +49,7 @@ public class ModelReturn  implements Serializable {
     this._return = _return;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -73,6 +73,7 @@ public class ModelReturn  implements Serializable {
     sb.append("class ModelReturn {\n");
     
     sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Name.java
@@ -118,7 +118,7 @@ public class Name  implements Serializable {
     this._123number = _123number;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -148,6 +148,7 @@ public class Name  implements Serializable {
     sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
     sb.append("    property: ").append(toIndentedString(property)).append("\n");
     sb.append("    _123number: ").append(toIndentedString(_123number)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -47,7 +47,7 @@ public class NumberOnly  implements Serializable {
     this.justNumber = justNumber;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class NumberOnly  implements Serializable {
     sb.append("class NumberOnly {\n");
     
     sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Order.java
@@ -200,7 +200,7 @@ public class Order  implements Serializable {
     this.complete = complete;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -234,6 +234,7 @@ public class Order  implements Serializable {
     sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -89,7 +89,7 @@ public class OuterComposite  implements Serializable {
     this.myBoolean = myBoolean;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -117,6 +117,7 @@ public class OuterComposite  implements Serializable {
     sb.append("    myNumber: ").append(toIndentedString(myNumber)).append("\n");
     sb.append("    myString: ").append(toIndentedString(myString)).append("\n");
     sb.append("    myBoolean: ").append(toIndentedString(myBoolean)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Pet.java
@@ -249,7 +249,7 @@ public class Pet  implements Serializable {
     this.status = status;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -283,6 +283,7 @@ public class Pet  implements Serializable {
     sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -67,7 +67,7 @@ public class ReadOnlyFirst  implements Serializable {
     this.baz = baz;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -93,6 +93,7 @@ public class ReadOnlyFirst  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -47,7 +47,7 @@ public class SpecialModelName  implements Serializable {
     this.$specialPropertyName = $specialPropertyName;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class SpecialModelName  implements Serializable {
     sb.append("class SpecialModelName {\n");
     
     sb.append("    $specialPropertyName: ").append(toIndentedString($specialPropertyName)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Tag.java
@@ -67,7 +67,7 @@ public class Tag  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -93,6 +93,7 @@ public class Tag  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -165,7 +165,7 @@ public class TypeHolderDefault  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -197,6 +197,7 @@ public class TypeHolderDefault  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -188,7 +188,7 @@ public class TypeHolderExample  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -222,6 +222,7 @@ public class TypeHolderExample  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/User.java
@@ -194,7 +194,7 @@ public class User  implements Serializable {
     this.userStatus = userStatus;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -232,6 +232,7 @@ public class User  implements Serializable {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
     sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/XmlItem.java
@@ -782,7 +782,7 @@ public class XmlItem  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -862,6 +862,7 @@ public class XmlItem  implements Serializable {
     sb.append("    prefixNsBoolean: ").append(toIndentedString(prefixNsBoolean)).append("\n");
     sb.append("    prefixNsArray: ").append(toIndentedString(prefixNsArray)).append("\n");
     sb.append("    prefixNsWrappedArray: ").append(toIndentedString(prefixNsWrappedArray)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -1,11 +1,13 @@
 package org.openapitools.model;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
+public class AdditionalPropertiesAnyType  implements Serializable {
   private String name;
 
   public AdditionalPropertiesAnyType() {
@@ -42,6 +44,43 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesAnyType putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -52,21 +91,22 @@ public class AdditionalPropertiesAnyType extends HashMap<String, Object> impleme
       return false;
     }
     AdditionalPropertiesAnyType additionalPropertiesAnyType = (AdditionalPropertiesAnyType) o;
-    return Objects.equals(this.name, additionalPropertiesAnyType.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesAnyType.name) && Objects.equals(this.additionalProperties, additionalPropertiesAnyType.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesAnyType {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -1,12 +1,14 @@
 package org.openapitools.model;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -18,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
+public class AdditionalPropertiesArray  implements Serializable {
   private String name;
 
   public AdditionalPropertiesArray() {
@@ -43,6 +45,43 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, List> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesArray putAdditionalProperty(String key, List value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, List>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, List> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public List getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -53,21 +92,22 @@ public class AdditionalPropertiesArray extends HashMap<String, List> implements 
       return false;
     }
     AdditionalPropertiesArray additionalPropertiesArray = (AdditionalPropertiesArray) o;
-    return Objects.equals(this.name, additionalPropertiesArray.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesArray.name) && Objects.equals(this.additionalProperties, additionalPropertiesArray.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesArray {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -1,11 +1,13 @@
 package org.openapitools.model;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
+public class AdditionalPropertiesBoolean  implements Serializable {
   private String name;
 
   public AdditionalPropertiesBoolean() {
@@ -42,6 +44,43 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Boolean> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesBoolean putAdditionalProperty(String key, Boolean value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Boolean>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Boolean> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Boolean getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -52,21 +91,22 @@ public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implem
       return false;
     }
     AdditionalPropertiesBoolean additionalPropertiesBoolean = (AdditionalPropertiesBoolean) o;
-    return Objects.equals(this.name, additionalPropertiesBoolean.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesBoolean.name) && Objects.equals(this.additionalProperties, additionalPropertiesBoolean.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesBoolean {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -386,7 +386,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     this.anytype3 = anytype3;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -430,6 +430,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     sb.append("    anytype1: ").append(toIndentedString(anytype1)).append("\n");
     sb.append("    anytype2: ").append(toIndentedString(anytype2)).append("\n");
     sb.append("    anytype3: ").append(toIndentedString(anytype3)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -1,11 +1,13 @@
 package org.openapitools.model;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
+public class AdditionalPropertiesInteger  implements Serializable {
   private String name;
 
   public AdditionalPropertiesInteger() {
@@ -42,6 +44,43 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Integer> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesInteger putAdditionalProperty(String key, Integer value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Integer>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Integer> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Integer getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -52,21 +91,22 @@ public class AdditionalPropertiesInteger extends HashMap<String, Integer> implem
       return false;
     }
     AdditionalPropertiesInteger additionalPropertiesInteger = (AdditionalPropertiesInteger) o;
-    return Objects.equals(this.name, additionalPropertiesInteger.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesInteger.name) && Objects.equals(this.additionalProperties, additionalPropertiesInteger.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesInteger {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -1,12 +1,14 @@
 package org.openapitools.model;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -18,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
+public class AdditionalPropertiesNumber  implements Serializable {
   private String name;
 
   public AdditionalPropertiesNumber() {
@@ -43,6 +45,43 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, BigDecimal> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesNumber putAdditionalProperty(String key, BigDecimal value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, BigDecimal>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, BigDecimal> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public BigDecimal getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -53,21 +92,22 @@ public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> impl
       return false;
     }
     AdditionalPropertiesNumber additionalPropertiesNumber = (AdditionalPropertiesNumber) o;
-    return Objects.equals(this.name, additionalPropertiesNumber.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesNumber.name) && Objects.equals(this.additionalProperties, additionalPropertiesNumber.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesNumber {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -1,11 +1,14 @@
 package org.openapitools.model;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
+public class AdditionalPropertiesObject  implements Serializable {
   private String name;
 
   public AdditionalPropertiesObject() {
@@ -42,6 +45,43 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Map> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesObject putAdditionalProperty(String key, Map value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Map>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Map> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Map getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -52,21 +92,22 @@ public class AdditionalPropertiesObject extends HashMap<String, Map> implements 
       return false;
     }
     AdditionalPropertiesObject additionalPropertiesObject = (AdditionalPropertiesObject) o;
-    return Objects.equals(this.name, additionalPropertiesObject.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesObject.name) && Objects.equals(this.additionalProperties, additionalPropertiesObject.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesObject {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -1,11 +1,13 @@
 package org.openapitools.model;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
+public class AdditionalPropertiesString  implements Serializable {
   private String name;
 
   public AdditionalPropertiesString() {
@@ -42,6 +44,43 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
     this.name = name;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, String> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public AdditionalPropertiesString putAdditionalProperty(String key, String value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, String>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, String> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public String getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -52,21 +91,22 @@ public class AdditionalPropertiesString extends HashMap<String, String> implemen
       return false;
     }
     AdditionalPropertiesString additionalPropertiesString = (AdditionalPropertiesString) o;
-    return Objects.equals(this.name, additionalPropertiesString.name) &&
-        super.equals(o);
+    return Objects.equals(this.name, additionalPropertiesString.name) && Objects.equals(this.additionalProperties, additionalPropertiesString.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, super.hashCode());
+    return Objects.hash(name, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AdditionalPropertiesString {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Animal.java
@@ -81,7 +81,7 @@ public class Animal  implements Serializable {
     this.color = color;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -107,6 +107,7 @@ public class Animal  implements Serializable {
     
     sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -64,7 +64,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfArrayOfNumberOnly {\n");
     
     sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -64,7 +64,7 @@ public class ArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class ArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfNumberOnly {\n");
     
     sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -138,7 +138,7 @@ public class ArrayTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -166,6 +166,7 @@ public class ArrayTest  implements Serializable {
     sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
     sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
     sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/BigCat.java
@@ -102,7 +102,7 @@ public class BigCat extends Cat implements Serializable {
     this.kind = kind;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -127,6 +127,7 @@ public class BigCat extends Cat implements Serializable {
     sb.append("class BigCat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Capitalization.java
@@ -150,7 +150,7 @@ public class Capitalization  implements Serializable {
     this.ATT_NAME = ATT_NAME;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -184,6 +184,7 @@ public class Capitalization  implements Serializable {
     sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
     sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
     sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Cat.java
@@ -55,7 +55,7 @@ public class Cat extends Animal implements Serializable {
     this.declawed = declawed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -80,6 +80,7 @@ public class Cat extends Animal implements Serializable {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Category.java
@@ -72,7 +72,7 @@ public class Category  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -98,6 +98,7 @@ public class Category  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ClassModel.java
@@ -46,7 +46,7 @@ public class ClassModel  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class ClassModel  implements Serializable {
     sb.append("class ClassModel {\n");
     
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Client.java
@@ -44,7 +44,7 @@ public class Client  implements Serializable {
     this.client = client;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,6 +68,7 @@ public class Client  implements Serializable {
     sb.append("class Client {\n");
     
     sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Dog.java
@@ -55,7 +55,7 @@ public class Dog extends Animal implements Serializable {
     this.breed = breed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -80,6 +80,7 @@ public class Dog extends Animal implements Serializable {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -178,7 +178,7 @@ public class EnumArrays  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -204,6 +204,7 @@ public class EnumArrays  implements Serializable {
     
     sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumTest.java
@@ -325,7 +325,7 @@ public class EnumTest  implements Serializable {
     this.outerEnum = outerEnum;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -357,6 +357,7 @@ public class EnumTest  implements Serializable {
     sb.append("    enumInteger: ").append(toIndentedString(enumInteger)).append("\n");
     sb.append("    enumNumber: ").append(toIndentedString(enumNumber)).append("\n");
     sb.append("    outerEnum: ").append(toIndentedString(outerEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -85,7 +85,7 @@ public class FileSchemaTestClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class FileSchemaTestClass  implements Serializable {
     
     sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
     sb.append("    files: ").append(toIndentedString(files)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FormatTest.java
@@ -347,7 +347,7 @@ public class FormatTest  implements Serializable {
     this.bigDecimal = bigDecimal;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -397,6 +397,7 @@ public class FormatTest  implements Serializable {
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    password: ").append("*").append("\n");
     sb.append("    bigDecimal: ").append(toIndentedString(bigDecimal)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -66,7 +66,7 @@ public class HasOnlyReadOnly  implements Serializable {
     this.foo = foo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -92,6 +92,7 @@ public class HasOnlyReadOnly  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MapTest.java
@@ -220,7 +220,7 @@ public class MapTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -250,6 +250,7 @@ public class MapTest  implements Serializable {
     sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
     sb.append("    directMap: ").append(toIndentedString(directMap)).append("\n");
     sb.append("    indirectMap: ").append(toIndentedString(indirectMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -107,7 +107,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -135,6 +135,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Model200Response.java
@@ -68,7 +68,7 @@ public class Model200Response  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,6 +94,7 @@ public class Model200Response  implements Serializable {
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -87,7 +87,7 @@ public class ModelApiResponse  implements Serializable {
     this.message = message;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -115,6 +115,7 @@ public class ModelApiResponse  implements Serializable {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelFile.java
@@ -48,7 +48,7 @@ public class ModelFile  implements Serializable {
     this.sourceURI = sourceURI;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +72,7 @@ public class ModelFile  implements Serializable {
     sb.append("class ModelFile {\n");
     
     sb.append("    sourceURI: ").append(toIndentedString(sourceURI)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelList.java
@@ -45,7 +45,7 @@ public class ModelList  implements Serializable {
     this._123list = _123list;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class ModelList  implements Serializable {
     sb.append("class ModelList {\n");
     
     sb.append("    _123list: ").append(toIndentedString(_123list)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -47,7 +47,7 @@ public class ModelReturn  implements Serializable {
     this._return = _return;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class ModelReturn  implements Serializable {
     sb.append("class ModelReturn {\n");
     
     sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Name.java
@@ -116,7 +116,7 @@ public class Name  implements Serializable {
     this._123number = _123number;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -146,6 +146,7 @@ public class Name  implements Serializable {
     sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
     sb.append("    property: ").append(toIndentedString(property)).append("\n");
     sb.append("    _123number: ").append(toIndentedString(_123number)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -45,7 +45,7 @@ public class NumberOnly  implements Serializable {
     this.justNumber = justNumber;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class NumberOnly  implements Serializable {
     sb.append("class NumberOnly {\n");
     
     sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Order.java
@@ -198,7 +198,7 @@ public class Order  implements Serializable {
     this.complete = complete;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -232,6 +232,7 @@ public class Order  implements Serializable {
     sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -87,7 +87,7 @@ public class OuterComposite  implements Serializable {
     this.myBoolean = myBoolean;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -115,6 +115,7 @@ public class OuterComposite  implements Serializable {
     sb.append("    myNumber: ").append(toIndentedString(myNumber)).append("\n");
     sb.append("    myString: ").append(toIndentedString(myString)).append("\n");
     sb.append("    myBoolean: ").append(toIndentedString(myBoolean)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Pet.java
@@ -247,7 +247,7 @@ public class Pet  implements Serializable {
     this.status = status;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -281,6 +281,7 @@ public class Pet  implements Serializable {
     sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -65,7 +65,7 @@ public class ReadOnlyFirst  implements Serializable {
     this.baz = baz;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,6 +91,7 @@ public class ReadOnlyFirst  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -45,7 +45,7 @@ public class SpecialModelName  implements Serializable {
     this.$specialPropertyName = $specialPropertyName;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class SpecialModelName  implements Serializable {
     sb.append("class SpecialModelName {\n");
     
     sb.append("    $specialPropertyName: ").append(toIndentedString($specialPropertyName)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Tag.java
@@ -65,7 +65,7 @@ public class Tag  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,6 +91,7 @@ public class Tag  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -163,7 +163,7 @@ public class TypeHolderDefault  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -195,6 +195,7 @@ public class TypeHolderDefault  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -186,7 +186,7 @@ public class TypeHolderExample  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -220,6 +220,7 @@ public class TypeHolderExample  implements Serializable {
     sb.append("    integerItem: ").append(toIndentedString(integerItem)).append("\n");
     sb.append("    boolItem: ").append(toIndentedString(boolItem)).append("\n");
     sb.append("    arrayItem: ").append(toIndentedString(arrayItem)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/User.java
@@ -192,7 +192,7 @@ public class User  implements Serializable {
     this.userStatus = userStatus;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -230,6 +230,7 @@ public class User  implements Serializable {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
     sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/XmlItem.java
@@ -780,7 +780,7 @@ public class XmlItem  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -860,6 +860,7 @@ public class XmlItem  implements Serializable {
     sb.append("    prefixNsBoolean: ").append(toIndentedString(prefixNsBoolean)).append("\n");
     sb.append("    prefixNsArray: ").append(toIndentedString(prefixNsArray)).append("\n");
     sb.append("    prefixNsWrappedArray: ").append(toIndentedString(prefixNsWrappedArray)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -99,7 +99,7 @@ public class AdditionalPropertiesClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -125,6 +125,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     
     sb.append("    mapProperty: ").append(toIndentedString(mapProperty)).append("\n");
     sb.append("    mapOfMapProperty: ").append(toIndentedString(mapOfMapProperty)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/AllOfWithSingleRef.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/AllOfWithSingleRef.java
@@ -66,7 +66,7 @@ public class AllOfWithSingleRef  implements Serializable {
     this.singleRefType = singleRefType;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -92,6 +92,7 @@ public class AllOfWithSingleRef  implements Serializable {
     
     sb.append("    username: ").append(toIndentedString(username)).append("\n");
     sb.append("    singleRefType: ").append(toIndentedString(singleRefType)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Animal.java
@@ -80,7 +80,7 @@ public class Animal  implements Serializable {
     this.color = color;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -106,6 +106,7 @@ public class Animal  implements Serializable {
     
     sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -64,7 +64,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfArrayOfNumberOnly {\n");
     
     sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -64,7 +64,7 @@ public class ArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -88,6 +88,7 @@ public class ArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfNumberOnly {\n");
     
     sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -138,7 +138,7 @@ public class ArrayTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -166,6 +166,7 @@ public class ArrayTest  implements Serializable {
     sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
     sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
     sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Capitalization.java
@@ -150,7 +150,7 @@ public class Capitalization  implements Serializable {
     this.ATT_NAME = ATT_NAME;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -184,6 +184,7 @@ public class Capitalization  implements Serializable {
     sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
     sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
     sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Cat.java
@@ -55,7 +55,7 @@ public class Cat extends Animal implements Serializable {
     this.declawed = declawed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -80,6 +80,7 @@ public class Cat extends Animal implements Serializable {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Category.java
@@ -72,7 +72,7 @@ public class Category  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -98,6 +98,7 @@ public class Category  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ChildWithNullable.java
@@ -47,7 +47,7 @@ public class ChildWithNullable extends ParentWithNullable implements Serializabl
     this.otherProperty = otherProperty;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +72,7 @@ public class ChildWithNullable extends ParentWithNullable implements Serializabl
     sb.append("class ChildWithNullable {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    otherProperty: ").append(toIndentedString(otherProperty)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ClassModel.java
@@ -46,7 +46,7 @@ public class ClassModel  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class ClassModel  implements Serializable {
     sb.append("class ClassModel {\n");
     
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Client.java
@@ -44,7 +44,7 @@ public class Client  implements Serializable {
     this.client = client;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,6 +68,7 @@ public class Client  implements Serializable {
     sb.append("class Client {\n");
     
     sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/DeprecatedObject.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/DeprecatedObject.java
@@ -44,7 +44,7 @@ public class DeprecatedObject  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,6 +68,7 @@ public class DeprecatedObject  implements Serializable {
     sb.append("class DeprecatedObject {\n");
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Dog.java
@@ -55,7 +55,7 @@ public class Dog extends Animal implements Serializable {
     this.breed = breed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -80,6 +80,7 @@ public class Dog extends Animal implements Serializable {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -178,7 +178,7 @@ public class EnumArrays  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -204,6 +204,7 @@ public class EnumArrays  implements Serializable {
     
     sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/EnumTest.java
@@ -392,7 +392,7 @@ public class EnumTest  implements Serializable {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -430,6 +430,7 @@ public class EnumTest  implements Serializable {
     sb.append("    outerEnumInteger: ").append(toIndentedString(outerEnumInteger)).append("\n");
     sb.append("    outerEnumDefaultValue: ").append(toIndentedString(outerEnumDefaultValue)).append("\n");
     sb.append("    outerEnumIntegerDefaultValue: ").append(toIndentedString(outerEnumIntegerDefaultValue)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FakeBigDecimalMap200Response.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FakeBigDecimalMap200Response.java
@@ -85,7 +85,7 @@ public class FakeBigDecimalMap200Response  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class FakeBigDecimalMap200Response  implements Serializable {
     
     sb.append("    someId: ").append(toIndentedString(someId)).append("\n");
     sb.append("    someMap: ").append(toIndentedString(someMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -85,7 +85,7 @@ public class FileSchemaTestClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -111,6 +111,7 @@ public class FileSchemaTestClass  implements Serializable {
     
     sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
     sb.append("    files: ").append(toIndentedString(files)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Foo.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Foo.java
@@ -44,7 +44,7 @@ public class Foo  implements Serializable {
     this.bar = bar;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -68,6 +68,7 @@ public class Foo  implements Serializable {
     sb.append("class Foo {\n");
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FooGetDefaultResponse.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FooGetDefaultResponse.java
@@ -46,7 +46,7 @@ public class FooGetDefaultResponse  implements Serializable {
     this.string = string;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class FooGetDefaultResponse  implements Serializable {
     sb.append("class FooGetDefaultResponse {\n");
     
     sb.append("    string: ").append(toIndentedString(string)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/FormatTest.java
@@ -391,7 +391,7 @@ public class FormatTest  implements Serializable {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -445,6 +445,7 @@ public class FormatTest  implements Serializable {
     sb.append("    password: ").append("*").append("\n");
     sb.append("    patternWithDigits: ").append(toIndentedString(patternWithDigits)).append("\n");
     sb.append("    patternWithDigitsAndDelimiter: ").append(toIndentedString(patternWithDigitsAndDelimiter)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -66,7 +66,7 @@ public class HasOnlyReadOnly  implements Serializable {
     this.foo = foo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -92,6 +92,7 @@ public class HasOnlyReadOnly  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/HealthCheckResult.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/HealthCheckResult.java
@@ -47,7 +47,7 @@ public class HealthCheckResult  implements Serializable {
     this.nullableMessage = nullableMessage;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class HealthCheckResult  implements Serializable {
     sb.append("class HealthCheckResult {\n");
     
     sb.append("    nullableMessage: ").append(toIndentedString(nullableMessage)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/MapTest.java
@@ -220,7 +220,7 @@ public class MapTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -250,6 +250,7 @@ public class MapTest  implements Serializable {
     sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
     sb.append("    directMap: ").append(toIndentedString(directMap)).append("\n");
     sb.append("    indirectMap: ").append(toIndentedString(indirectMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -107,7 +107,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -135,6 +135,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Model200Response.java
@@ -68,7 +68,7 @@ public class Model200Response  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,6 +94,7 @@ public class Model200Response  implements Serializable {
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -87,7 +87,7 @@ public class ModelApiResponse  implements Serializable {
     this.message = message;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -115,6 +115,7 @@ public class ModelApiResponse  implements Serializable {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelFile.java
@@ -48,7 +48,7 @@ public class ModelFile  implements Serializable {
     this.sourceURI = sourceURI;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +72,7 @@ public class ModelFile  implements Serializable {
     sb.append("class ModelFile {\n");
     
     sb.append("    sourceURI: ").append(toIndentedString(sourceURI)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelList.java
@@ -45,7 +45,7 @@ public class ModelList  implements Serializable {
     this._123list = _123list;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class ModelList  implements Serializable {
     sb.append("class ModelList {\n");
     
     sb.append("    _123list: ").append(toIndentedString(_123list)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -47,7 +47,7 @@ public class ModelReturn  implements Serializable {
     this._return = _return;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class ModelReturn  implements Serializable {
     sb.append("class ModelReturn {\n");
     
     sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Name.java
@@ -116,7 +116,7 @@ public class Name  implements Serializable {
     this._123number = _123number;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -146,6 +146,7 @@ public class Name  implements Serializable {
     sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
     sb.append("    property: ").append(toIndentedString(property)).append("\n");
     sb.append("    _123number: ").append(toIndentedString(_123number)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/NullableClass.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/NullableClass.java
@@ -13,6 +13,10 @@ import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -24,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("NullableClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class NullableClass extends HashMap<String, Object> implements Serializable {
+public class NullableClass  implements Serializable {
   private Integer integerProp;
   private BigDecimal numberProp;
   private Boolean booleanProp;
@@ -365,6 +369,43 @@ public class NullableClass extends HashMap<String, Object> implements Serializab
 
     return this;
   }
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public NullableClass putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -386,20 +427,19 @@ public class NullableClass extends HashMap<String, Object> implements Serializab
         Objects.equals(this.arrayItemsNullable, nullableClass.arrayItemsNullable) &&
         Objects.equals(this.objectNullableProp, nullableClass.objectNullableProp) &&
         Objects.equals(this.objectAndItemsNullableProp, nullableClass.objectAndItemsNullableProp) &&
-        Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) &&
-        super.equals(o);
+        Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) && Objects.equals(this.additionalProperties, nullableClass.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integerProp, numberProp, booleanProp, stringProp, dateProp, datetimeProp, arrayNullableProp, arrayAndItemsNullableProp, arrayItemsNullable, objectNullableProp, objectAndItemsNullableProp, objectItemsNullable, super.hashCode());
+    return Objects.hash(integerProp, numberProp, booleanProp, stringProp, dateProp, datetimeProp, arrayNullableProp, arrayAndItemsNullableProp, arrayItemsNullable, objectNullableProp, objectAndItemsNullableProp, objectItemsNullable, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class NullableClass {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    integerProp: ").append(toIndentedString(integerProp)).append("\n");
     sb.append("    numberProp: ").append(toIndentedString(numberProp)).append("\n");
     sb.append("    booleanProp: ").append(toIndentedString(booleanProp)).append("\n");
@@ -412,6 +452,8 @@ public class NullableClass extends HashMap<String, Object> implements Serializab
     sb.append("    objectNullableProp: ").append(toIndentedString(objectNullableProp)).append("\n");
     sb.append("    objectAndItemsNullableProp: ").append(toIndentedString(objectAndItemsNullableProp)).append("\n");
     sb.append("    objectItemsNullable: ").append(toIndentedString(objectItemsNullable)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -45,7 +45,7 @@ public class NumberOnly  implements Serializable {
     this.justNumber = justNumber;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class NumberOnly  implements Serializable {
     sb.append("class NumberOnly {\n");
     
     sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ObjectWithDeprecatedFields.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ObjectWithDeprecatedFields.java
@@ -128,7 +128,7 @@ public class ObjectWithDeprecatedFields  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -158,6 +158,7 @@ public class ObjectWithDeprecatedFields  implements Serializable {
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    deprecatedRef: ").append(toIndentedString(deprecatedRef)).append("\n");
     sb.append("    bars: ").append(toIndentedString(bars)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Order.java
@@ -198,7 +198,7 @@ public class Order  implements Serializable {
     this.complete = complete;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -232,6 +232,7 @@ public class Order  implements Serializable {
     sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -87,7 +87,7 @@ public class OuterComposite  implements Serializable {
     this.myBoolean = myBoolean;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -115,6 +115,7 @@ public class OuterComposite  implements Serializable {
     sb.append("    myNumber: ").append(toIndentedString(myNumber)).append("\n");
     sb.append("    myString: ").append(toIndentedString(myString)).append("\n");
     sb.append("    myBoolean: ").append(toIndentedString(myBoolean)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/OuterObjectWithEnumProperty.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/OuterObjectWithEnumProperty.java
@@ -52,7 +52,7 @@ public class OuterObjectWithEnumProperty  implements Serializable {
     this.value = value;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -76,6 +76,7 @@ public class OuterObjectWithEnumProperty  implements Serializable {
     sb.append("class OuterObjectWithEnumProperty {\n");
     
     sb.append("    value: ").append(toIndentedString(value)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ParentWithNullable.java
@@ -120,7 +120,7 @@ public class ParentWithNullable  implements Serializable {
     this.nullableProperty = nullableProperty;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -146,6 +146,7 @@ public class ParentWithNullable  implements Serializable {
     
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    nullableProperty: ").append(toIndentedString(nullableProperty)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Pet.java
@@ -247,7 +247,7 @@ public class Pet  implements Serializable {
     this.status = status;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -281,6 +281,7 @@ public class Pet  implements Serializable {
     sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -65,7 +65,7 @@ public class ReadOnlyFirst  implements Serializable {
     this.baz = baz;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,6 +91,7 @@ public class ReadOnlyFirst  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -45,7 +45,7 @@ public class SpecialModelName  implements Serializable {
     this.$specialPropertyName = $specialPropertyName;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -69,6 +69,7 @@ public class SpecialModelName  implements Serializable {
     sb.append("class SpecialModelName {\n");
     
     sb.append("    $specialPropertyName: ").append(toIndentedString($specialPropertyName)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/Tag.java
@@ -65,7 +65,7 @@ public class Tag  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -91,6 +91,7 @@ public class Tag  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -1,12 +1,14 @@
 package org.openapitools.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -18,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @org.eclipse.microprofile.openapi.annotations.media.Schema(description="")
 @JsonTypeName("testInlineFreeformAdditionalProperties_request")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<String, Object> implements Serializable {
+public class TestInlineFreeformAdditionalPropertiesRequest  implements Serializable {
   private String someProperty;
 
   public TestInlineFreeformAdditionalPropertiesRequest() {
@@ -43,6 +45,43 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
     this.someProperty = someProperty;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public TestInlineFreeformAdditionalPropertiesRequest putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -53,21 +92,22 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
       return false;
     }
     TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest = (TestInlineFreeformAdditionalPropertiesRequest) o;
-    return Objects.equals(this.someProperty, testInlineFreeformAdditionalPropertiesRequest.someProperty) &&
-        super.equals(o);
+    return Objects.equals(this.someProperty, testInlineFreeformAdditionalPropertiesRequest.someProperty) && Objects.equals(this.additionalProperties, testInlineFreeformAdditionalPropertiesRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(someProperty, super.hashCode());
+    return Objects.hash(someProperty, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TestInlineFreeformAdditionalPropertiesRequest {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    someProperty: ").append(toIndentedString(someProperty)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/User.java
@@ -192,7 +192,7 @@ public class User  implements Serializable {
     this.userStatus = userStatus;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -230,6 +230,7 @@ public class User  implements Serializable {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
     sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/model/ReadonlyAndRequiredProperties.java
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/model/ReadonlyAndRequiredProperties.java
@@ -118,7 +118,7 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     this.requiredNoReadonlyNo = requiredNoReadonlyNo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -148,6 +148,7 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
     sb.append("    requiredYesReadonlyNo: ").append(toIndentedString(requiredYesReadonlyNo)).append("\n");
     sb.append("    requiredNoReadonlyYes: ").append(toIndentedString(requiredNoReadonlyYes)).append("\n");
     sb.append("    requiredNoReadonlyNo: ").append(toIndentedString(requiredNoReadonlyNo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -101,7 +101,7 @@ public class AdditionalPropertiesClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -127,6 +127,7 @@ public class AdditionalPropertiesClass  implements Serializable {
     
     sb.append("    mapProperty: ").append(toIndentedString(mapProperty)).append("\n");
     sb.append("    mapOfMapProperty: ").append(toIndentedString(mapOfMapProperty)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AllOfWithSingleRef.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AllOfWithSingleRef.java
@@ -68,7 +68,7 @@ public class AllOfWithSingleRef  implements Serializable {
     this.singleRefType = singleRefType;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,6 +94,7 @@ public class AllOfWithSingleRef  implements Serializable {
     
     sb.append("    username: ").append(toIndentedString(username)).append("\n");
     sb.append("    singleRefType: ").append(toIndentedString(singleRefType)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
@@ -82,7 +82,7 @@ public class Animal  implements Serializable {
     this.color = color;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -108,6 +108,7 @@ public class Animal  implements Serializable {
     
     sb.append("    className: ").append(toIndentedString(className)).append("\n");
     sb.append("    color: ").append(toIndentedString(color)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -66,7 +66,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -90,6 +90,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfArrayOfNumberOnly {\n");
     
     sb.append("    arrayArrayNumber: ").append(toIndentedString(arrayArrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -66,7 +66,7 @@ public class ArrayOfNumberOnly  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -90,6 +90,7 @@ public class ArrayOfNumberOnly  implements Serializable {
     sb.append("class ArrayOfNumberOnly {\n");
     
     sb.append("    arrayNumber: ").append(toIndentedString(arrayNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -140,7 +140,7 @@ public class ArrayTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -168,6 +168,7 @@ public class ArrayTest  implements Serializable {
     sb.append("    arrayOfString: ").append(toIndentedString(arrayOfString)).append("\n");
     sb.append("    arrayArrayOfInteger: ").append(toIndentedString(arrayArrayOfInteger)).append("\n");
     sb.append("    arrayArrayOfModel: ").append(toIndentedString(arrayArrayOfModel)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
@@ -152,7 +152,7 @@ public class Capitalization  implements Serializable {
     this.ATT_NAME = ATT_NAME;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -186,6 +186,7 @@ public class Capitalization  implements Serializable {
     sb.append("    capitalSnake: ").append(toIndentedString(capitalSnake)).append("\n");
     sb.append("    scAETHFlowPoints: ").append(toIndentedString(scAETHFlowPoints)).append("\n");
     sb.append("    ATT_NAME: ").append(toIndentedString(ATT_NAME)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -57,7 +57,7 @@ public class Cat extends Animal implements Serializable {
     this.declawed = declawed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -82,6 +82,7 @@ public class Cat extends Animal implements Serializable {
     sb.append("class Cat {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    declawed: ").append(toIndentedString(declawed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
@@ -74,7 +74,7 @@ public class Category  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -100,6 +100,7 @@ public class Category  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ChildWithNullable.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ChildWithNullable.java
@@ -49,7 +49,7 @@ public class ChildWithNullable extends ParentWithNullable implements Serializabl
     this.otherProperty = otherProperty;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -74,6 +74,7 @@ public class ChildWithNullable extends ParentWithNullable implements Serializabl
     sb.append("class ChildWithNullable {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    otherProperty: ").append(toIndentedString(otherProperty)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
@@ -48,7 +48,7 @@ public class ClassModel  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +72,7 @@ public class ClassModel  implements Serializable {
     sb.append("class ClassModel {\n");
     
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
@@ -46,7 +46,7 @@ public class Client  implements Serializable {
     this.client = client;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class Client  implements Serializable {
     sb.append("class Client {\n");
     
     sb.append("    client: ").append(toIndentedString(client)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/DeprecatedObject.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/DeprecatedObject.java
@@ -46,7 +46,7 @@ public class DeprecatedObject  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class DeprecatedObject  implements Serializable {
     sb.append("class DeprecatedObject {\n");
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
@@ -57,7 +57,7 @@ public class Dog extends Animal implements Serializable {
     this.breed = breed;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -82,6 +82,7 @@ public class Dog extends Animal implements Serializable {
     sb.append("class Dog {\n");
     sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    breed: ").append(toIndentedString(breed)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -180,7 +180,7 @@ public class EnumArrays  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -206,6 +206,7 @@ public class EnumArrays  implements Serializable {
     
     sb.append("    justSymbol: ").append(toIndentedString(justSymbol)).append("\n");
     sb.append("    arrayEnum: ").append(toIndentedString(arrayEnum)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -394,7 +394,7 @@ public class EnumTest  implements Serializable {
     this.outerEnumIntegerDefaultValue = outerEnumIntegerDefaultValue;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -432,6 +432,7 @@ public class EnumTest  implements Serializable {
     sb.append("    outerEnumInteger: ").append(toIndentedString(outerEnumInteger)).append("\n");
     sb.append("    outerEnumDefaultValue: ").append(toIndentedString(outerEnumDefaultValue)).append("\n");
     sb.append("    outerEnumIntegerDefaultValue: ").append(toIndentedString(outerEnumIntegerDefaultValue)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FakeBigDecimalMap200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FakeBigDecimalMap200Response.java
@@ -87,7 +87,7 @@ public class FakeBigDecimalMap200Response  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -113,6 +113,7 @@ public class FakeBigDecimalMap200Response  implements Serializable {
     
     sb.append("    someId: ").append(toIndentedString(someId)).append("\n");
     sb.append("    someMap: ").append(toIndentedString(someMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FakeTestsDefaultsDefaultResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FakeTestsDefaultsDefaultResponse.java
@@ -206,7 +206,7 @@ public class FakeTestsDefaultsDefaultResponse  implements Serializable {
     this.integerEnumInline = integerEnumInline;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -236,6 +236,7 @@ public class FakeTestsDefaultsDefaultResponse  implements Serializable {
     sb.append("    integerEnum: ").append(toIndentedString(integerEnum)).append("\n");
     sb.append("    stringEnumInline: ").append(toIndentedString(stringEnumInline)).append("\n");
     sb.append("    integerEnumInline: ").append(toIndentedString(integerEnumInline)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -87,7 +87,7 @@ public class FileSchemaTestClass  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -113,6 +113,7 @@ public class FileSchemaTestClass  implements Serializable {
     
     sb.append("    _file: ").append(toIndentedString(_file)).append("\n");
     sb.append("    files: ").append(toIndentedString(files)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Foo.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Foo.java
@@ -46,7 +46,7 @@ public class Foo  implements Serializable {
     this.bar = bar;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,6 +70,7 @@ public class Foo  implements Serializable {
     sb.append("class Foo {\n");
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FooGetDefaultResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FooGetDefaultResponse.java
@@ -48,7 +48,7 @@ public class FooGetDefaultResponse  implements Serializable {
     this.string = string;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -72,6 +72,7 @@ public class FooGetDefaultResponse  implements Serializable {
     sb.append("class FooGetDefaultResponse {\n");
     
     sb.append("    string: ").append(toIndentedString(string)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
@@ -393,7 +393,7 @@ public class FormatTest  implements Serializable {
     this.patternWithDigitsAndDelimiter = patternWithDigitsAndDelimiter;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -447,6 +447,7 @@ public class FormatTest  implements Serializable {
     sb.append("    password: ").append("*").append("\n");
     sb.append("    patternWithDigits: ").append(toIndentedString(patternWithDigits)).append("\n");
     sb.append("    patternWithDigitsAndDelimiter: ").append(toIndentedString(patternWithDigitsAndDelimiter)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -68,7 +68,7 @@ public class HasOnlyReadOnly  implements Serializable {
     this.foo = foo;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,6 +94,7 @@ public class HasOnlyReadOnly  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    foo: ").append(toIndentedString(foo)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HealthCheckResult.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HealthCheckResult.java
@@ -49,7 +49,7 @@ public class HealthCheckResult  implements Serializable {
     this.nullableMessage = nullableMessage;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -73,6 +73,7 @@ public class HealthCheckResult  implements Serializable {
     sb.append("class HealthCheckResult {\n");
     
     sb.append("    nullableMessage: ").append(toIndentedString(nullableMessage)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -222,7 +222,7 @@ public class MapTest  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -252,6 +252,7 @@ public class MapTest  implements Serializable {
     sb.append("    mapOfEnumString: ").append(toIndentedString(mapOfEnumString)).append("\n");
     sb.append("    directMap: ").append(toIndentedString(directMap)).append("\n");
     sb.append("    indirectMap: ").append(toIndentedString(indirectMap)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -109,7 +109,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -137,6 +137,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
     sb.append("    uuid: ").append(toIndentedString(uuid)).append("\n");
     sb.append("    dateTime: ").append(toIndentedString(dateTime)).append("\n");
     sb.append("    map: ").append(toIndentedString(map)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
@@ -70,7 +70,7 @@ public class Model200Response  implements Serializable {
     this.propertyClass = propertyClass;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -96,6 +96,7 @@ public class Model200Response  implements Serializable {
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    propertyClass: ").append(toIndentedString(propertyClass)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -89,7 +89,7 @@ public class ModelApiResponse  implements Serializable {
     this.message = message;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -117,6 +117,7 @@ public class ModelApiResponse  implements Serializable {
     sb.append("    code: ").append(toIndentedString(code)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelFile.java
@@ -50,7 +50,7 @@ public class ModelFile  implements Serializable {
     this.sourceURI = sourceURI;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -74,6 +74,7 @@ public class ModelFile  implements Serializable {
     sb.append("class ModelFile {\n");
     
     sb.append("    sourceURI: ").append(toIndentedString(sourceURI)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelList.java
@@ -47,7 +47,7 @@ public class ModelList  implements Serializable {
     this._123list = _123list;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class ModelList  implements Serializable {
     sb.append("class ModelList {\n");
     
     sb.append("    _123list: ").append(toIndentedString(_123list)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -49,7 +49,7 @@ public class ModelReturn  implements Serializable {
     this._return = _return;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -73,6 +73,7 @@ public class ModelReturn  implements Serializable {
     sb.append("class ModelReturn {\n");
     
     sb.append("    _return: ").append(toIndentedString(_return)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
@@ -118,7 +118,7 @@ public class Name  implements Serializable {
     this._123number = _123number;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -148,6 +148,7 @@ public class Name  implements Serializable {
     sb.append("    snakeCase: ").append(toIndentedString(snakeCase)).append("\n");
     sb.append("    property: ").append(toIndentedString(property)).append("\n");
     sb.append("    _123number: ").append(toIndentedString(_123number)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NullableClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NullableClass.java
@@ -16,6 +16,10 @@ import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -26,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("NullableClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class NullableClass extends HashMap<String, Object> implements Serializable {
+public class NullableClass  implements Serializable {
   private Integer integerProp;
   private BigDecimal numberProp;
   private Boolean booleanProp;
@@ -367,6 +371,43 @@ public class NullableClass extends HashMap<String, Object> implements Serializab
 
     return this;
   }
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public NullableClass putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -388,20 +429,19 @@ public class NullableClass extends HashMap<String, Object> implements Serializab
         Objects.equals(this.arrayItemsNullable, nullableClass.arrayItemsNullable) &&
         Objects.equals(this.objectNullableProp, nullableClass.objectNullableProp) &&
         Objects.equals(this.objectAndItemsNullableProp, nullableClass.objectAndItemsNullableProp) &&
-        Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) &&
-        super.equals(o);
+        Objects.equals(this.objectItemsNullable, nullableClass.objectItemsNullable) && Objects.equals(this.additionalProperties, nullableClass.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(integerProp, numberProp, booleanProp, stringProp, dateProp, datetimeProp, arrayNullableProp, arrayAndItemsNullableProp, arrayItemsNullable, objectNullableProp, objectAndItemsNullableProp, objectItemsNullable, super.hashCode());
+    return Objects.hash(integerProp, numberProp, booleanProp, stringProp, dateProp, datetimeProp, arrayNullableProp, arrayAndItemsNullableProp, arrayItemsNullable, objectNullableProp, objectAndItemsNullableProp, objectItemsNullable, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class NullableClass {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    integerProp: ").append(toIndentedString(integerProp)).append("\n");
     sb.append("    numberProp: ").append(toIndentedString(numberProp)).append("\n");
     sb.append("    booleanProp: ").append(toIndentedString(booleanProp)).append("\n");
@@ -414,6 +454,8 @@ public class NullableClass extends HashMap<String, Object> implements Serializab
     sb.append("    objectNullableProp: ").append(toIndentedString(objectNullableProp)).append("\n");
     sb.append("    objectAndItemsNullableProp: ").append(toIndentedString(objectAndItemsNullableProp)).append("\n");
     sb.append("    objectItemsNullable: ").append(toIndentedString(objectItemsNullable)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -47,7 +47,7 @@ public class NumberOnly  implements Serializable {
     this.justNumber = justNumber;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class NumberOnly  implements Serializable {
     sb.append("class NumberOnly {\n");
     
     sb.append("    justNumber: ").append(toIndentedString(justNumber)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ObjectWithDeprecatedFields.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ObjectWithDeprecatedFields.java
@@ -130,7 +130,7 @@ public class ObjectWithDeprecatedFields  implements Serializable {
 
     return this;
   }
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -160,6 +160,7 @@ public class ObjectWithDeprecatedFields  implements Serializable {
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    deprecatedRef: ").append(toIndentedString(deprecatedRef)).append("\n");
     sb.append("    bars: ").append(toIndentedString(bars)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -200,7 +200,7 @@ public class Order  implements Serializable {
     this.complete = complete;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -234,6 +234,7 @@ public class Order  implements Serializable {
     sb.append("    shipDate: ").append(toIndentedString(shipDate)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    complete: ").append(toIndentedString(complete)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -89,7 +89,7 @@ public class OuterComposite  implements Serializable {
     this.myBoolean = myBoolean;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -117,6 +117,7 @@ public class OuterComposite  implements Serializable {
     sb.append("    myNumber: ").append(toIndentedString(myNumber)).append("\n");
     sb.append("    myString: ").append(toIndentedString(myString)).append("\n");
     sb.append("    myBoolean: ").append(toIndentedString(myBoolean)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterObjectWithEnumProperty.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterObjectWithEnumProperty.java
@@ -54,7 +54,7 @@ public class OuterObjectWithEnumProperty  implements Serializable {
     this.value = value;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -78,6 +78,7 @@ public class OuterObjectWithEnumProperty  implements Serializable {
     sb.append("class OuterObjectWithEnumProperty {\n");
     
     sb.append("    value: ").append(toIndentedString(value)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ParentWithNullable.java
@@ -122,7 +122,7 @@ public class ParentWithNullable  implements Serializable {
     this.nullableProperty = nullableProperty;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -148,6 +148,7 @@ public class ParentWithNullable  implements Serializable {
     
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    nullableProperty: ").append(toIndentedString(nullableProperty)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -249,7 +249,7 @@ public class Pet  implements Serializable {
     this.status = status;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -283,6 +283,7 @@ public class Pet  implements Serializable {
     sb.append("    photoUrls: ").append(toIndentedString(photoUrls)).append("\n");
     sb.append("    tags: ").append(toIndentedString(tags)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -67,7 +67,7 @@ public class ReadOnlyFirst  implements Serializable {
     this.baz = baz;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -93,6 +93,7 @@ public class ReadOnlyFirst  implements Serializable {
     
     sb.append("    bar: ").append(toIndentedString(bar)).append("\n");
     sb.append("    baz: ").append(toIndentedString(baz)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -47,7 +47,7 @@ public class SpecialModelName  implements Serializable {
     this.$specialPropertyName = $specialPropertyName;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,6 +71,7 @@ public class SpecialModelName  implements Serializable {
     sb.append("class SpecialModelName {\n");
     
     sb.append("    $specialPropertyName: ").append(toIndentedString($specialPropertyName)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
@@ -67,7 +67,7 @@ public class Tag  implements Serializable {
     this.name = name;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -93,6 +93,7 @@ public class Tag  implements Serializable {
     
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TestInlineFreeformAdditionalPropertiesRequest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TestInlineFreeformAdditionalPropertiesRequest.java
@@ -3,13 +3,15 @@ package org.openapitools.model;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.Map;
 import java.io.Serializable;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
 import io.swagger.annotations.*;
+import java.util.Map;
+import java.util.HashMap;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("testInlineFreeformAdditionalProperties_request")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.16.0-SNAPSHOT")
-public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<String, Object> implements Serializable {
+public class TestInlineFreeformAdditionalPropertiesRequest  implements Serializable {
   private String someProperty;
 
   public TestInlineFreeformAdditionalPropertiesRequest() {
@@ -45,6 +47,43 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
     this.someProperty = someProperty;
   }
 
+      /**
+      * A container for additional, undeclared properties.
+      * This is a holder for any undeclared properties as specified with
+      * the 'additionalProperties' keyword in the OAS document.
+      */
+      private Map<String, Object> additionalProperties;
+  
+      /**
+      * Set the additional (undeclared) property with the specified name and value.
+      * If the property does not already exist, create it otherwise replace it.
+      */
+      @JsonAnySetter
+      public TestInlineFreeformAdditionalPropertiesRequest putAdditionalProperty(String key, Object value) {
+          if (this.additionalProperties == null) {
+              this.additionalProperties = new HashMap<String, Object>();
+          }
+          this.additionalProperties.put(key, value);
+          return this;
+      }
+  
+      /**
+      * Return the additional (undeclared) property.
+      */
+      @JsonAnyGetter
+      public Map<String, Object> getAdditionalProperties() {
+          return additionalProperties;
+      }
+  
+      /**
+      * Return the additional (undeclared) property with the specified name.
+      */
+      public Object getAdditionalProperty(String key) {
+          if (this.additionalProperties == null) {
+              return null;
+          }
+          return this.additionalProperties.get(key);
+      }
 
   @Override
   public boolean equals(Object o) {
@@ -55,21 +94,22 @@ public class TestInlineFreeformAdditionalPropertiesRequest extends HashMap<Strin
       return false;
     }
     TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest = (TestInlineFreeformAdditionalPropertiesRequest) o;
-    return Objects.equals(this.someProperty, testInlineFreeformAdditionalPropertiesRequest.someProperty) &&
-        super.equals(o);
+    return Objects.equals(this.someProperty, testInlineFreeformAdditionalPropertiesRequest.someProperty) && Objects.equals(this.additionalProperties, testInlineFreeformAdditionalPropertiesRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(someProperty, super.hashCode());
+    return Objects.hash(someProperty, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TestInlineFreeformAdditionalPropertiesRequest {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    
     sb.append("    someProperty: ").append(toIndentedString(someProperty)).append("\n");
+    sb.append("}");
+    sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
@@ -194,7 +194,7 @@ public class User  implements Serializable {
     this.userStatus = userStatus;
   }
 
-
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -232,6 +232,7 @@ public class User  implements Serializable {
     sb.append("    password: ").append(toIndentedString(password)).append("\n");
     sb.append("    phone: ").append(toIndentedString(phone)).append("\n");
     sb.append("    userStatus: ").append(toIndentedString(userStatus)).append("\n");
+    sb.append("}");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #21584 

When `additionalProperties` is set to true, use an `additionalProperties` attribute and `@JsonAnySetter` and `@JsonAnyGetter` annotations instead of extending `HashMap`.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
