### PR TITLE
fix(kotlin): set isVoid to true for Unit datatypes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -1119,6 +1119,8 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     }
 
     protected interface DataTypeAssigner {
+        void setIsVoid(Boolean isVoid);
+
         void setReturnType(String returnType);
 
         void setReturnContainer(String returnContainer);
@@ -1131,6 +1133,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
     protected void doDataTypeAssignment(final String returnType, DataTypeAssigner dataTypeAssigner) {
         if (returnType == null) {
             dataTypeAssigner.setReturnType("Unit");
+            dataTypeAssigner.setIsVoid(true);
         } else if (returnType.startsWith("kotlin.collections.List")) {
             int end = returnType.lastIndexOf(">");
             if (end > 0) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinServerCodegen.java
@@ -419,6 +419,11 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
 
                         doDataTypeAssignment(resp.dataType, new DataTypeAssigner() {
                             @Override
+                            public void setIsVoid(Boolean isVoid) {
+                                resp.isVoid = isVoid;
+                            }
+
+                            @Override
                             public void setReturnType(final String returnType) {
                                 resp.dataType = returnType;
                             }
@@ -432,6 +437,10 @@ public class KotlinServerCodegen extends AbstractKotlinCodegen implements BeanVa
                 }
 
                 doDataTypeAssignment(operation.returnType, new DataTypeAssigner() {
+                    @Override
+                    public void setIsVoid(Boolean isVoid) {
+                        operation.isVoid = isVoid;
+                    }
 
                     @Override
                     public void setReturnType(final String returnType) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinSpringServerCodegen.java
@@ -881,6 +881,11 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
 
                         doDataTypeAssignment(resp.dataType, new DataTypeAssigner() {
                             @Override
+                            public void setIsVoid(Boolean isVoid) {
+                                resp.isVoid = isVoid;
+                            }
+
+                            @Override
                             public void setReturnType(final String returnType) {
                                 resp.dataType = returnType;
                             }
@@ -904,6 +909,10 @@ public class KotlinSpringServerCodegen extends AbstractKotlinCodegen
                 }
 
                 doDataTypeAssignment(operation.returnType, new DataTypeAssigner() {
+                    @Override
+                    public void setIsVoid(Boolean isVoid) {
+                        operation.isVoid = isVoid;
+                    }
 
                     @Override
                     public void setReturnType(final String returnType) {


### PR DESCRIPTION
Sets the isVoid to true for `CodegenResponses` and `CodegenOperation` when the type is `Unit` (java void) so that `isVoid` can be used in mustache templates.

> Unit
> The type with only one value: the Unit object. This type corresponds to the void type in Java.
> https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-unit/

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)
