### PR TITLE
Fix visibility for enum in C# generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/modelEnum.mustache
@@ -46,14 +46,14 @@
     /// <summary>
     /// Converts <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/> to and from the JSON value
     /// </summary>
-    public static class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}ValueConverter
+    {{>visibility}} static class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}ValueConverter
     {
         /// <summary>
         /// Parses a given value to <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} FromString(string value)
+        {{>visibility}} static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} FromString(string value)
         {
             {{#allowableValues}}
             {{#enumVars}}
@@ -70,7 +70,7 @@
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? FromStringOrDefault(string value)
+        {{>visibility}} static {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}? FromStringOrDefault(string value)
         {
             {{#allowableValues}}
             {{#enumVars}}
@@ -88,7 +88,7 @@
         /// <param name="value"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public static {{>EnumValueDataType}} ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
+        {{>visibility}} static {{>EnumValueDataType}} ToJsonValue({{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} value)
         {
             {{^isString}}
             return ({{>EnumValueDataType}}) value;
@@ -110,7 +110,7 @@
     /// A Json converter for type <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
     /// </summary>
     /// <exception cref="NotImplementedException"></exception>
-    public class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}JsonConverter : JsonConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}>
+    {{>visibility}} class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}JsonConverter : JsonConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}>
     {
         /// <summary>
         /// Returns a {{datatypeWithEnum}} from the Json object
@@ -148,7 +148,7 @@
     /// <summary>
     /// A Json converter for type <see cref="{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}"/>
     /// </summary>
-    public class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}NullableJsonConverter : JsonConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}?>
+    {{>visibility}} class {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}NullableJsonConverter : JsonConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}?>
     {
         /// <summary>
         /// Returns a {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} from the Json object


### PR DESCRIPTION
The visibility of enums in the C# generator is wrong, and results in build errors with `nonPublicApi=true`.

Here are sanitized build error logs before the fix:

```
Client\Model\DeviceTypeEnum.cs(54,38): error CS0050: Inconsistent accessibility: return type 'DeviceTypeEnum' is less accessible than method 'DeviceTypeEnumValueConverter.FromString(string)' 
Client\Model\DeviceTypeEnum.cs(70,39): error CS0050: Inconsistent accessibility: return type 'DeviceTypeEnum?' is less accessible than method 'DeviceTypeEnumValueConverter.FromStringOrDefault(string)' 
Client\Model\DeviceTypeEnum.cs(87,30): error CS0051: Inconsistent accessibility: parameter type 'DeviceTypeEnum' is less accessible than method 'DeviceTypeEnumValueConverter.ToJsonValue(DeviceTypeEnum)' 
Client\Model\DeviceTypeEnum.cs(103,18): error CS0060: Inconsistent accessibility: base class 'JsonConverter<DeviceTypeEnum>' is less accessible than class 'DeviceTypeEnumJsonConverter' 
Client\Model\DeviceTypeEnum.cs(112,40): error CS0050: Inconsistent accessibility: return type 'DeviceTypeEnum' is less accessible than method 'DeviceTypeEnumJsonConverter.Read(ref Utf8JsonReader, Type, JsonSerializerOptions)'   
Client\Model\DeviceTypeEnum.cs(132,30): error CS0051: Inconsistent accessibility: parameter type 'DeviceTypeEnum' is less accessible than method 'DeviceTypeEnumJsonConverter.Write(Utf8JsonWriter, DeviceTypeEnum, JsonSerializerOptions)' 
Client\Model\DeviceTypeEnum.cs(141,18): error CS0060: Inconsistent accessibility: base class 'JsonConverter<DeviceTypeEnum?>' is less accessible than class 'DeviceTypeEnumNullableJsonConverter' 
Client\Model\DeviceTypeEnum.cs(150,41): error CS0050: Inconsistent accessibility: return type 'DeviceTypeEnum?' is less accessible than method 'DeviceTypeEnumNullableJsonConverter.Read(ref Utf8JsonReader, Type, JsonSerializerOptions)' 
Client\Model\DeviceTypeEnum.cs(170,30): error CS0051: Inconsistent accessibility: parameter type 'DeviceTypeEnum?' is less accessible than method 'DeviceTypeEnumNullableJsonConverter.Write(Utf8JsonWriter, DeviceTypeEnum?, JsonSerializerOptions)' 
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples: - **I'd kindly ask an active contributor of this project to do this.**
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 

  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
    - @mandrean, @shibayan, @Blackclaws, @lucamazzanti, @iBicha - sorry if I should not have pinged all of you