### PR TITLE
go: Fix missing imports for optional body params.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenOperation.java
@@ -116,6 +116,15 @@ public class CodegenOperation {
     }
 
     /**
+     * Check if there's at least one optional body parameter
+     *
+     * @return true if optional body parameter exists, false otherwise
+     */
+    public boolean getHasOptionalBodyParam() {
+        return nonEmpty(bodyParams) && nonEmpty(optionalParams) && bodyParams.stream().anyMatch(optionalParams::contains);
+    }
+
+    /**
      * Check if there's at least one query parameter
      *
      * @return true if query parameter exists, false otherwise

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoServerCodegen.java
@@ -410,6 +410,7 @@ public class GoServerCodegen extends AbstractGoCodegen {
     private void addConditionalImportInformation(OperationsMap operations) {
         boolean hasPathParams = false;
         boolean hasBodyParams = false;
+        boolean hasOptionalBodyParams = false;
 
         for (CodegenOperation op : operations.getOperations().getOperation()) {
             if (op.getHasPathParams()) {
@@ -418,10 +419,14 @@ public class GoServerCodegen extends AbstractGoCodegen {
             if (op.getHasBodyParam()) {
                 hasBodyParams = true;
             }
+            if (op.getHasOptionalBodyParam()) {
+                hasOptionalBodyParams = true;
+            }
         }
 
         additionalProperties.put("hasPathParams", hasPathParams);
         additionalProperties.put("hasBodyParams", hasBodyParams);
+        additionalProperties.put("hasOptionalBodyParams", hasOptionalBodyParams);
     }
 
 

--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -6,12 +6,10 @@ import (
 	{{#hasBodyParams}}
 	"encoding/json"
 	{{/hasBodyParams}}
-	{{#isBodyParam}}
-	    {{^required}}
+	{{#hasOptionalBodyParams}}
 	"errors"
 	"io"
-	    {{/required}}
-	{{/isBodyParam}}
+	{{/hasOptionalBodyParams}}
 	"net/http"
 	"strings"
 {{#imports}}	"{{import}}"


### PR DESCRIPTION
Previous mustache template was using #isBodyParam outside of #operation
context, so it was not effective.

Even if we'd add the proper context, we'd then risk generating duplicate
imports for multiple matching parameters.

For this reason, this patch implements detection of an optional body
parameter in code, making sure the corresponding import is added just
once.

Fixes #19237

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
