### PR TITLE
[JAVA] Add vendorExtensions.x-class-extra-annotation to oneOf interfaces

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/oneof_interface.mustache
@@ -1,4 +1,7 @@
 {{>additionalOneOfTypeAnnotations}}{{>generatedAnnotation}}{{>typeInfoAnnotation}}{{>xmlAnnotation}}
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{vendorExtensions.x-class-extra-annotation}}}
+{{/vendorExtensions.x-class-extra-annotation}}
 public {{>sealed}}interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}}{{>permits}}{
     {{#discriminator}}
     public {{propertyType}} {{propertyGetter}}();

--- a/modules/openapi-generator/src/main/resources/JavaSpring/oneof_interface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/oneof_interface.mustache
@@ -13,7 +13,8 @@
     @JsonSubTypes.Type(value = {{classname}}.class){{^-last}}, {{/-last}}
     {{/interfaceModels}}
 })
-{{/useDeductionForOneOfInterfaces}}
+{{/useDeductionForOneOfInterfaces}}{{#vendorExtensions.x-class-extra-annotation}}{{{vendorExtensions.x-class-extra-annotation}}}
+{{/vendorExtensions.x-class-extra-annotation}}
 {{/discriminator}}
 {{>generatedAnnotation}}
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -3982,4 +3982,21 @@ public class JavaClientCodegenTest {
         }
         assertTrue(speciesSeen);
     }
+
+    @Test
+    public void testOneOfClassWithAnnotation() throws IOException {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/oneOf-with-annotations.yaml", RESTCLIENT);
+        JavaFileAssert.assertThat(files.get("Fruit.java"))
+                .isNormalClass()
+                .assertTypeAnnotations().containsWithName("SuppressWarnings");
+    }
+
+    @Test
+    public void testOneOfInterfaceWithAnnotation() throws IOException {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/oneOf-with-annotations.yaml", RESTCLIENT,
+                Map.of(USE_ONE_OF_INTERFACES, "true"));
+        JavaFileAssert.assertThat(files.get("Fruit.java"))
+                .isInterface()
+                .assertTypeAnnotations().containsWithName("SuppressWarnings");
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -5730,4 +5730,12 @@ public class SpringCodegenTest {
         javaFileAssert
                 .hasImports("java.util.concurrent.atomic.AtomicInteger");
     }
+
+    @Test
+    public void testOneOfInterfaceWithAnnotation() throws IOException {
+        final Map<String, File> files = generateFromContract("src/test/resources/3_0/java/oneOf-with-annotations.yaml", SPRING_BOOT);
+        JavaFileAssert.assertThat(files.get("Fruit.java"))
+                .isInterface()
+                .assertTypeAnnotations().containsWithName("SuppressWarnings");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/java/oneOf-with-annotations.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/java/oneOf-with-annotations.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.1
+info:
+   title: fruity
+   version: 0.0.1
+paths:
+   /:
+      get:
+         responses:
+            '200':
+               description: desc
+               content:
+                  application/json:
+                     schema:
+                        $ref: '#/components/schemas/fruit'
+components:
+   schemas:
+      fruit:
+         title: fruit
+         x-class-extra-annotation: '@SuppressWarnings("unchecked")'
+         properties:
+            color:
+               type: string
+         oneOf:
+            - $ref: '#/components/schemas/apple'
+            - $ref: '#/components/schemas/banana'
+            - $ref: '#/components/schemas/orange'
+      apple:
+         title: apple
+         type: object
+         properties:
+            kind:
+               type: string
+      banana:
+         title: banana
+         type: object
+         properties:
+            count:
+               type: number
+      orange:
+         title: orange
+         type: object
+         properties:
+            sweet:
+               type: boolean


### PR DESCRIPTION
Fix #20110

Allow annotations on interfaces generated for oneOfs

Main goal is to customize the serialization/deserialization.
For example with jackson:
```
@com.fasterxml.jackson.databind.annotation.JsonDeserialize(...)
interface Animal {
}
```
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

It works for Java generator supporting oneOfInterface
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg
and for Java Spring	
@cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente

