### PR TITLE
[kotlin] Add AnyOf/oneOf to multiplatform

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/anyof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/anyof_class.mustache
@@ -1,0 +1,79 @@
+{{#multiplatform}}
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+
+/**
+ * {{{description}}}
+ *
+ */
+{{#isDeprecated}}
+@Deprecated(message = "This schema is deprecated.")
+{{/isDeprecated}}
+@Serializable(with = {{classname}}.{{classname}}Serializer::class)
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}data class {{classname}}(var actualInstance: Any? = null) {
+
+    object {{classname}}Serializer : KSerializer<{{classname}}> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("{{classname}}") {
+            element("type", JsonPrimitive.serializer().descriptor)
+            element("actualInstance", JsonElement.serializer().descriptor)
+        }
+
+        override fun serialize(encoder: Encoder, value: {{classname}}) {
+            val jsonEncoder = encoder as? JsonEncoder ?: throw SerializationException("{{classname}} can only be serialized with Json")
+
+            when (val instance = value.actualInstance) {
+                {{#composedSchemas}}
+                {{#anyOf}}
+                {{#isPrimitiveType}}
+                {{#isString}}
+                is kotlin.String -> jsonEncoder.encodeString(instance)
+                {{/isString}}
+                {{#isBoolean}}
+                is kotlin.Boolean -> jsonEncoder.encodeBoolean(instance)
+                {{/isBoolean}}
+                {{#isInteger}}
+                is kotlin.Int -> jsonEncoder.encodeInt(instance)
+                {{/isInteger}}
+                {{#isNumber}}
+                {{#isDouble}}
+                is kotlin.Double -> jsonEncoder.encodeDouble(instance)
+                {{/isDouble}}
+                {{#isFloat}}
+                is kotlin.Float -> jsonEncoder.encodeFloat(instance)
+                {{/isFloat}}
+                {{/isNumber}}
+                {{/isPrimitiveType}}
+                {{^isPrimitiveType}}
+                is {{{dataType}}} -> jsonEncoder.encodeSerializableValue({{{dataType}}}.serializer(), instance)
+                {{/isPrimitiveType}}
+                {{/anyOf}}
+                {{/composedSchemas}}
+                null -> jsonEncoder.encodeJsonElement(JsonNull)
+                else -> throw SerializationException("Unknown type in actualInstance: ${instance::class}")
+            }
+        }
+
+        override fun deserialize(decoder: Decoder): {{classname}} {
+            val jsonDecoder = decoder as? JsonDecoder ?: throw SerializationException("{{classname}} can only be deserialized with Json")
+            val jsonElement = jsonDecoder.decodeJsonElement()
+
+            val errorMessages = mutableListOf<String>()
+
+            {{#composedSchemas}}
+            {{#anyOf}}
+            try {
+                val instance = jsonDecoder.json.decodeFromJsonElement<{{{dataType}}}>(jsonElement)
+                return {{classname}}(actualInstance = instance)
+            } catch (e: Exception) {
+                errorMessages.add("Failed to deserialize as {{{dataType}}}: ${e.message}")
+            }
+            {{/anyOf}}
+            {{/composedSchemas}}
+
+            throw SerializationException("Cannot deserialize {{classname}}. Tried: ${errorMessages.joinToString(", ")}")
+        }
+    }
+}
+{{/multiplatform}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/oneof_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/oneof_class.mustache
@@ -1,0 +1,79 @@
+{{#multiplatform}}
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
+import kotlinx.serialization.json.*
+
+/**
+ * {{{description}}}
+ *
+ */
+{{#isDeprecated}}
+@Deprecated(message = "This schema is deprecated.")
+{{/isDeprecated}}
+@Serializable(with = {{classname}}.{{classname}}Serializer::class)
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}data class {{classname}}(var actualInstance: Any? = null) {
+
+    object {{classname}}Serializer : KSerializer<{{classname}}> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("{{classname}}") {
+            element("type", JsonPrimitive.serializer().descriptor)
+            element("actualInstance", JsonElement.serializer().descriptor)
+        }
+
+        override fun serialize(encoder: Encoder, value: {{classname}}) {
+            val jsonEncoder = encoder as? JsonEncoder ?: throw SerializationException("{{classname}} can only be serialized with Json")
+
+            when (val instance = value.actualInstance) {
+                {{#composedSchemas}}
+                {{#oneOf}}
+                {{#isPrimitiveType}}
+                {{#isString}}
+                is kotlin.String -> jsonEncoder.encodeString(instance)
+                {{/isString}}
+                {{#isBoolean}}
+                is kotlin.Boolean -> jsonEncoder.encodeBoolean(instance)
+                {{/isBoolean}}
+                {{#isInteger}}
+                is kotlin.Int -> jsonEncoder.encodeInt(instance)
+                {{/isInteger}}
+                {{#isNumber}}
+                {{#isDouble}}
+                is kotlin.Double -> jsonEncoder.encodeDouble(instance)
+                {{/isDouble}}
+                {{#isFloat}}
+                is kotlin.Float -> jsonEncoder.encodeFloat(instance)
+                {{/isFloat}}
+                {{/isNumber}}
+                {{/isPrimitiveType}}
+                {{^isPrimitiveType}}
+                is {{{dataType}}} -> jsonEncoder.encodeSerializableValue({{{dataType}}}.serializer(), instance)
+                {{/isPrimitiveType}}
+                {{/oneOf}}
+                {{/composedSchemas}}
+                null -> jsonEncoder.encodeJsonElement(JsonNull)
+                else -> throw SerializationException("Unknown type in actualInstance: ${instance::class}")
+            }
+        }
+
+        override fun deserialize(decoder: Decoder): {{classname}} {
+            val jsonDecoder = decoder as? JsonDecoder ?: throw SerializationException("{{classname}} can only be deserialized with Json")
+            val jsonElement = jsonDecoder.decodeJsonElement()
+
+            val errorMessages = mutableListOf<String>()
+
+            {{#composedSchemas}}
+            {{#oneOf}}
+            try {
+                val instance = jsonDecoder.json.decodeFromJsonElement<{{{dataType}}}>(jsonElement)
+                return {{classname}}(actualInstance = instance)
+            } catch (e: Exception) {
+                errorMessages.add("Failed to deserialize as {{{dataType}}}: ${e.message}")
+            }
+            {{/oneOf}}
+            {{/composedSchemas}}
+
+            throw SerializationException("Cannot deserialize {{classname}}. Tried: ${errorMessages.joinToString(", ")}")
+        }
+    }
+}
+{{/multiplatform}}


### PR DESCRIPTION
This PR adds support for AnyOf and OneOf with the `generateOneOfAnyOfWrappers` flag in Kotlin Multiplatform.

I removed some checks to compare with the original `anyof_class.mustache` and `oneof_class.mustache` because multiplutform is more limited(`kotlinx.serialization` only).

For testing, you can use the following code:
```
openapi: 3.0.0
info:
  version: 1.0.0
  title: pets

paths:
  /petsOneOf:
    patch:
      requestBody:
        content:
          application/json:
            schema:
              oneOf:
                - $ref: '#/components/schemas/PetByAge'
                - $ref: '#/components/schemas/PetByType'
      responses:
        '200':
          description: Updated

  /petsAnyOf:
    patch:
      requestBody:
        content:
          application/json:
            schema:
              oneOf:
                - $ref: '#/components/schemas/PetByAge'
                - $ref: '#/components/schemas/PetByType'
      responses:
        '200':
          description: Updated

components:
  schemas:
    PetByAge:
      type: object
      properties:
        age:
          type: integer
        nickname:
          type: string
      required:
        - age

    PetByType:
      type: object
      properties:
        pet_type:
          type: string
          enum: [Cat, Dog]
        hunts:
          type: boolean
      required:
        - pet_type
```

It would be great if someone added testing for these cases, but I can't do that because I don't understand how they are organized here.

@dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

@wing328 