### PR TITLE
Fix Gradle properties mistakenly being marked as nullable

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/extensions/OpenApiGeneratorGenerateExtension.kt
@@ -81,12 +81,12 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * The template directory holding a custom template.
      */
-    val templateDir = project.objects.property<String?>()
+    val templateDir = project.objects.property<String>()
 
     /**
      * The template location (which may be a directory or a classpath location) holding custom templates.
      */
-    val templateResourcePath = project.objects.property<String?>()
+    val templateResourcePath = project.objects.property<String>()
 
     /**
      * Adds authorization headers when fetching the OpenAPI definitions remotely.
@@ -109,7 +109,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Specifies if the existing files should be overwritten during the generation.
      */
-    val skipOverwrite = project.objects.property<Boolean?>()
+    val skipOverwrite = project.objects.property<Boolean>()
 
     /**
      * Package for generated classes (where supported)
@@ -244,32 +244,32 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Reference the library template (sub-template) of a generator.
      */
-    val library = project.objects.property<String?>()
+    val library = project.objects.property<String>()
 
     /**
      * Git host, e.g. gitlab.com.
      */
-    val gitHost = project.objects.property<String?>()
+    val gitHost = project.objects.property<String>()
 
     /**
      * Git user ID, e.g. openapitools.
      */
-    val gitUserId = project.objects.property<String?>()
+    val gitUserId = project.objects.property<String>()
 
     /**
      * Git repo ID, e.g. openapi-generator.
      */
-    val gitRepoId = project.objects.property<String?>()
+    val gitRepoId = project.objects.property<String>()
 
     /**
      * Release note, default to 'Minor update'.
      */
-    val releaseNote = project.objects.property<String?>()
+    val releaseNote = project.objects.property<String>()
 
     /**
      * HTTP user agent, e.g. codegen_csharp_api_client, default to 'OpenAPI-Generator/{packageVersion}/{language}'
      */
-    val httpUserAgent = project.objects.property<String?>()
+    val httpUserAgent = project.objects.property<String>()
 
     /**
      * Specifies how a reserved name should be escaped to. Otherwise, the default _<name> is used.
@@ -279,17 +279,17 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Specifies an override location for the .openapi-generator-ignore file. Most useful on initial generation.
      */
-    val ignoreFileOverride = project.objects.property<String?>()
+    val ignoreFileOverride = project.objects.property<String>()
 
     /**
      * Remove prefix of operationId, e.g. config_getId => getId
      */
-    val removeOperationIdPrefix = project.objects.property<Boolean?>()
+    val removeOperationIdPrefix = project.objects.property<Boolean>()
 
     /**
      * Skip examples defined in the operation
      */
-    val skipOperationExample = project.objects.property<Boolean?>()
+    val skipOperationExample = project.objects.property<Boolean>()
 
     /**
      * Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all).
@@ -394,7 +394,7 @@ open class OpenApiGeneratorGenerateExtension(project: Project) {
     /**
      * Templating engine: "mustache" (default) or "handlebars" (beta)
      */
-    val engine = project.objects.property<String?>()
+    val engine = project.objects.property<String>()
 
     /**
      * Defines whether the output dir should be cleaned up before generating the output.

--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -55,7 +55,6 @@ import org.openapitools.codegen.config.MergedSpecBuilder
  *
  * @author Jim Schubert
  */
-@Suppress("UnstableApiUsage")
 @CacheableTask
 open class GenerateTask @Inject constructor(private val objectFactory: ObjectFactory) : DefaultTask() {
 
@@ -154,14 +153,14 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
     @get:Optional
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val templateDir = project.objects.property<String?>()
+    val templateDir = project.objects.property<String>()
 
     /**
      * Resource path containing template files.
      */
     @get:Optional
     @get:Input
-    val templateResourcePath = project.objects.property<String?>()
+    val templateResourcePath = project.objects.property<String>()
 
     /**
      * Adds authorization headers when fetching the OpenAPI definitions remotely.
@@ -193,7 +192,7 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
      */
     @get:Optional
     @get:Input
-    val skipOverwrite = project.objects.property<Boolean?>()
+    val skipOverwrite = project.objects.property<Boolean>()
 
     /**
      * Package for generated classes (where supported)
@@ -384,42 +383,42 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
      */
     @get:Optional
     @get:Input
-    val library = project.objects.property<String?>()
+    val library = project.objects.property<String>()
 
     /**
      * Git host, e.g. gitlab.com.
      */
     @get:Optional
     @get:Input
-    val gitHost = project.objects.property<String?>()
+    val gitHost = project.objects.property<String>()
 
     /**
      * Git user ID, e.g. openapitools.
      */
     @get:Optional
     @get:Input
-    val gitUserId = project.objects.property<String?>()
+    val gitUserId = project.objects.property<String>()
 
     /**
      * Git repo ID, e.g. openapi-generator.
      */
     @get:Optional
     @get:Input
-    val gitRepoId = project.objects.property<String?>()
+    val gitRepoId = project.objects.property<String>()
 
     /**
      * Release note, default to 'Minor update'.
      */
     @get:Optional
     @get:Input
-    val releaseNote = project.objects.property<String?>()
+    val releaseNote = project.objects.property<String>()
 
     /**
      * HTTP user agent, e.g. codegen_csharp_api_client, default to 'OpenAPI-Generator/{packageVersion}/{language}'
      */
     @get:Optional
     @get:Input
-    val httpUserAgent = project.objects.property<String?>()
+    val httpUserAgent = project.objects.property<String>()
 
     /**
      * Specifies how a reserved name should be escaped to.
@@ -434,21 +433,21 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
     @get:Optional
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    val ignoreFileOverride = project.objects.property<String?>()
+    val ignoreFileOverride = project.objects.property<String>()
 
     /**
      * Remove prefix of operationId, e.g. config_getId => getId
      */
     @get:Optional
     @get:Input
-    val removeOperationIdPrefix = project.objects.property<Boolean?>()
+    val removeOperationIdPrefix = project.objects.property<Boolean>()
 
     /**
      * Remove examples defined in the operation
      */
     @get:Optional
     @get:Input
-    val skipOperationExample = project.objects.property<Boolean?>()
+    val skipOperationExample = project.objects.property<Boolean>()
 
     /**
      * Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all).
@@ -581,7 +580,7 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
      */
     @get:Optional
     @get:Input
-    val engine = project.objects.property<String?>()
+    val engine = project.objects.property<String>()
 
     /**
      * Defines whether the output dir should be cleaned up before generating the output.
@@ -598,19 +597,11 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
     @get:Input
     val dryRun = project.objects.property<Boolean>()
 
-    private fun <T : Any?> Property<T>.ifNotEmpty(block: Property<T>.(T) -> Unit) {
+    private fun <T> Property<T>.ifNotEmpty(block: Property<T>.(T) -> Unit) {
         if (isPresent) {
-            val item: T? = get()
-            if (item != null) {
-                when (get()) {
-                    is String -> if ((get() as String).isNotEmpty()) {
-                        block(get())
-                    }
-                    is String? -> if (true == (get() as String?)?.isNotEmpty()) {
-                        block(get())
-                    }
-                    else -> block(get())
-                }
+            when (val value = get()) {
+                is String -> if (value.isNotEmpty()) block(value)
+                else -> block(value)
             }
         }
     }
@@ -725,7 +716,7 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
             }
 
             skipOverwrite.ifNotEmpty { value ->
-                configurator.setSkipOverwrite(value ?: false)
+                configurator.setSkipOverwrite(value)
             }
 
             generatorName.ifNotEmpty { value ->
@@ -820,11 +811,11 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
             }
 
             removeOperationIdPrefix.ifNotEmpty { value ->
-                configurator.setRemoveOperationIdPrefix(value!!)
+                configurator.setRemoveOperationIdPrefix(value)
             }
 
             skipOperationExample.ifNotEmpty { value ->
-                configurator.setSkipOperationExample(value!!)
+                configurator.setSkipOperationExample(value)
             }
 
             logToStderr.ifNotEmpty { value ->


### PR DESCRIPTION
Gradle's `Property` was never really intended to support null values, so this is kind of a bug. In Gradle 9, this becomes an error. This prevents users from using the plugin with Gradle 9 in cases where the affected configuration is used.

[Property#set](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html#set(T)) discards the set value when it receives `null`. However, this might be technically breaking in some edge cases. I can't think of a good example, but I also can't rule it out. Yet, this is a fix that justifies potential minor breakage.

This was originally pointed out by @NielsDoucet in https://github.com/OpenAPITools/openapi-generator/pull/21957#issuecomment-3350637241 (where a bit more context can be found).

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
