### PR TITLE
[go] Correctly set default array value on query parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.languages;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Iterables;
 import com.samskivert.mustache.Mustache;
 import io.swagger.v3.oas.models.media.Schema;
@@ -438,6 +439,17 @@ public class GoClientCodegen extends AbstractGoCodegen {
                 return "\"" + escapeText(String.valueOf(defaultObj)) + "\"";
             }
             return null;
+        }
+
+        if (ModelUtils.isArraySchema(p)) {
+            StringJoiner joinedDefaultValues = new StringJoiner(", ");
+            Object defaultValues = p.getDefault();
+            if (defaultValues instanceof ArrayNode) {
+                for (var value : (ArrayNode) defaultValues) {
+                    joinedDefaultValues.add(value.toString());
+                }
+                return "{" + joinedDefaultValues + "}";
+            }
         }
 
         return super.toDefaultValue(p);

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -217,8 +217,16 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		parameterAddToHeaderOrQuery(localVarQueryParams, "{{{baseName}}}", r.{{paramName}}, "{{style}}", "{{collectionFormat}}")
 	{{/isCollectionFormatMulti}}
 	{{#defaultValue}}} else {
-		var defaultValue {{{dataType}}} = {{{.}}}
-		r.{{paramName}} = &defaultValue
+    {{#isArray}}
+        var defaultValue {{{dataType}}} = {{{dataType}}}{{{.}}}
+        parameterAddToHeaderOrQuery(localVarQueryParams, "{{{baseName}}}", defaultValue, "{{style}}", "{{collectionFormat}}")
+        r.{{paramName}} = &defaultValue
+    {{/isArray}}
+    {{^isArray}}
+        var defaultValue {{{dataType}}} = {{{.}}}
+        parameterAddToHeaderOrQuery(localVarQueryParams, "{{{baseName}}}", defaultValue, "{{style}}", "{{collectionFormat}}")
+        r.{{paramName}} = &defaultValue
+    {{/isArray}}
 	{{/defaultValue}}}
 	{{/required}}
 	{{/queryParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -418,4 +418,24 @@ public class GoClientCodegenTest {
 
         TestUtils.assertFileContains(Paths.get(output + "/model_pet.go"), "tags>tag");
     }
+
+    @Test
+    public void testArrayDefaultValue() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_1/issue_21077.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+        Path apiPath = Paths.get(output + "/api_default.go");
+        String defaultArrayString = "var defaultValue []interface{} = []interface{}{\"test1\", \"test2\", 1}";
+        String defaultValueString = "var defaultValue string = \"test3\"";
+        TestUtils.assertFileContains(apiPath, defaultArrayString);
+        TestUtils.assertFileContains(apiPath, defaultValueString);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/issue_21077.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_21077.yaml
@@ -1,0 +1,29 @@
+openapi: 3.1.0
+
+info:
+  title: Test
+  version: "1.0"
+
+paths:
+  /a:
+    post:
+      summary: Test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      parameters:
+        - name: "arrayparam"
+          in: query
+          schema:
+            type: array
+            default: ["test1", "test2", 1]
+        - name: "stringparam"
+          in: query
+          schema:
+            type: string
+            default: "test3"
+      responses:
+        200:
+          description: Ok

--- a/samples/client/echo_api/go-external-refs/docs/DefaultValue.md
+++ b/samples/client/echo_api/go-external-refs/docs/DefaultValue.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayStringEnumRefDefault** | Pointer to [**[]StringEnumRef**](StringEnumRef.md) |  | [optional] [default to ["success","failure"]]
-**ArrayStringEnumDefault** | Pointer to **[]string** |  | [optional] [default to ["success","failure"]]
-**ArrayStringDefault** | Pointer to **[]string** |  | [optional] [default to ["failure","skipped"]]
-**ArrayIntegerDefault** | Pointer to **[]int32** |  | [optional] [default to [1,3]]
+**ArrayStringEnumRefDefault** | Pointer to [**[]StringEnumRef**](StringEnumRef.md) |  | [optional] [default to {"success", "failure"}]
+**ArrayStringEnumDefault** | Pointer to **[]string** |  | [optional] [default to {"success", "failure"}]
+**ArrayStringDefault** | Pointer to **[]string** |  | [optional] [default to {"failure", "skipped"}]
+**ArrayIntegerDefault** | Pointer to **[]int32** |  | [optional] [default to {1, 3}]
 **ArrayString** | Pointer to **[]string** |  | [optional] 
 **ArrayStringNullable** | Pointer to **[]string** |  | [optional] 
 **ArrayStringExtensionNullable** | Pointer to **[]string** |  | [optional] 

--- a/samples/client/echo_api/go-external-refs/docs/Query.md
+++ b/samples/client/echo_api/go-external-refs/docs/Query.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | Pointer to **int64** | Query | [optional] 
-**Outcomes** | Pointer to **[]string** |  | [optional] [default to ["SUCCESS","FAILURE"]]
+**Outcomes** | Pointer to **[]string** |  | [optional] [default to {"SUCCESS", "FAILURE"}]
 
 ## Methods
 

--- a/samples/client/echo_api/go/docs/DefaultValue.md
+++ b/samples/client/echo_api/go/docs/DefaultValue.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayStringEnumRefDefault** | Pointer to [**[]StringEnumRef**](StringEnumRef.md) |  | [optional] [default to ["success","failure"]]
-**ArrayStringEnumDefault** | Pointer to **[]string** |  | [optional] [default to ["success","failure"]]
-**ArrayStringDefault** | Pointer to **[]string** |  | [optional] [default to ["failure","skipped"]]
-**ArrayIntegerDefault** | Pointer to **[]int32** |  | [optional] [default to [1,3]]
+**ArrayStringEnumRefDefault** | Pointer to [**[]StringEnumRef**](StringEnumRef.md) |  | [optional] [default to {"success", "failure"}]
+**ArrayStringEnumDefault** | Pointer to **[]string** |  | [optional] [default to {"success", "failure"}]
+**ArrayStringDefault** | Pointer to **[]string** |  | [optional] [default to {"failure", "skipped"}]
+**ArrayIntegerDefault** | Pointer to **[]int32** |  | [optional] [default to {1, 3}]
 **ArrayString** | Pointer to **[]string** |  | [optional] 
 **ArrayStringNullable** | Pointer to **[]string** |  | [optional] 
 **ArrayStringExtensionNullable** | Pointer to **[]string** |  | [optional] 

--- a/samples/client/echo_api/go/docs/Query.md
+++ b/samples/client/echo_api/go/docs/Query.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Id** | Pointer to **int64** | Query | [optional] 
-**Outcomes** | Pointer to **[]string** |  | [optional] [default to ["SUCCESS","FAILURE"]]
+**Outcomes** | Pointer to **[]string** |  | [optional] [default to {"SUCCESS", "FAILURE"}]
 
 ## Methods
 

--- a/samples/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/client/petstore/go/go-petstore/api_fake.go
@@ -1425,8 +1425,9 @@ func (a *FakeAPIService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	if r.enumQueryString != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string", r.enumQueryString, "", "")
 	} else {
-		var defaultValue string = "-efg"
-		r.enumQueryString = &defaultValue
+        var defaultValue string = "-efg"
+        parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string", defaultValue, "", "")
+        r.enumQueryString = &defaultValue
 	}
 	if r.enumQueryInteger != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_integer", r.enumQueryInteger, "", "")

--- a/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/api_fake.go
@@ -1751,8 +1751,9 @@ func (a *FakeAPIService) TestEnumParametersExecute(r ApiTestEnumParametersReques
 	if r.enumQueryString != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string", r.enumQueryString, "form", "")
 	} else {
-		var defaultValue string = "-efg"
-		r.enumQueryString = &defaultValue
+        var defaultValue string = "-efg"
+        parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_string", defaultValue, "form", "")
+        r.enumQueryString = &defaultValue
 	}
 	if r.enumQueryInteger != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "enum_query_integer", r.enumQueryInteger, "form", "")


### PR DESCRIPTION
When an array is specified as the default value for a query parameter, the value is incorrectly output as a serialized Java array, which leads to invalid Go client code. This adds an extra check to output default array values in the expected syntax and adds the value to the query parameters. 

The existing `r.{{paramName}} = &defaultValue` line in the template was preserved as an existing behavior, though I'm not entirely sure what it does in this context.

Fixes #21077 

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
