### PR TITLE
[fix] [html] oneOf schema display in HTML2 generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/StaticHtml2Generator.java
@@ -39,7 +39,7 @@ import java.util.*;
 
 import static org.openapitools.codegen.utils.StringUtils.*;
 
-public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfig {
+public class StaticHtml2Generator extends DefaultCodegen {
     private final Logger LOGGER = LoggerFactory.getLogger(StaticHtml2Generator.class);
 
     protected String invokerPackage = "org.openapitools.client"; // default for Java and Android
@@ -140,6 +140,8 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
         }
         return super.getTypeDeclaration(p);
     }
+
+
 
     @Override
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
@@ -286,6 +288,44 @@ public class StaticHtml2Generator extends DefaultCodegen implements CodegenConfi
     public String escapeUnsafeCharacters(String input) {
         // just return the original string
         return input;
+    }
+
+    @Override
+    public String getSchemaType(Schema p) {
+        String schemaType = super.getSchemaType(p);
+        
+        // For oneOf schemas, provide a more human-readable format for HTML display
+        if (schemaType != null && schemaType.startsWith("oneOf<") && schemaType.endsWith(">")) {
+            // Extract the types inside oneOf<...> and format them as "Type1 or Type2"
+            String innerTypes = schemaType.substring(6, schemaType.length() - 1);
+            String[] types = innerTypes.split(",");
+            List<String> formattedTypes = new ArrayList<>();
+            
+            for (String type : types) {
+                String trimmedType = type.trim();
+                // Convert technical names to more readable ones
+                if ("object".equals(trimmedType)) {
+                    formattedTypes.add("Object");
+                } else if ("string".equals(trimmedType)) {
+                    formattedTypes.add("String");
+                } else if ("integer".equals(trimmedType)) {
+                    formattedTypes.add("Integer");
+                } else if ("number".equals(trimmedType)) {
+                    formattedTypes.add("Number");
+                } else if ("boolean".equals(trimmedType)) {
+                    formattedTypes.add("Boolean");
+                } else if ("array".equals(trimmedType)) {
+                    formattedTypes.add("Array");
+                } else {
+                    // Capitalize first letter for other types
+                    formattedTypes.add(trimmedType.substring(0, 1).toUpperCase() + trimmedType.substring(1));
+                }
+            }
+            
+            return String.join(" or ", formattedTypes);
+        }
+        
+        return schemaType;
     }
 
     @Override


### PR DESCRIPTION
## Description
OpenAPI 3.0 specs with oneOf constructs containing mixed types (string + object) were producing unreadable output in HTML2 documentation
The issue was that technical strings like "oneOf<string,object>" were appearing in the generated HTML instead of human-readable text

Resolves: #4431 

## Root Cause Analysis
The issue was in the [StaticHtml2Generator](vscode-file://vscode-app/private/var/folders/2d/njyp3x797xvf2rfn03z99dqw0000gn/T/AppTranslocation/E6E4984D-6E7E-4991-899F-1020C2CF0F4F/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) class which inherits from DefaultCodegen
The parent class's [getSchemaType](vscode-file://vscode-app/private/var/folders/2d/njyp3x797xvf2rfn03z99dqw0000gn/T/AppTranslocation/E6E4984D-6E7E-4991-899F-1020C2CF0F4F/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method calls toOneOfName() which returns technical format "oneOf<Type1,Type2>"
This technical format is not suitable for HTML documentation display


## Solution Implemented
Added a custom override of the [getSchemaType](vscode-file://vscode-app/private/var/folders/2d/njyp3x797xvf2rfn03z99dqw0000gn/T/AppTranslocation/E6E4984D-6E7E-4991-899F-1020C2CF0F4F/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method in [StaticHtml2Generator.java](vscode-file://vscode-app/private/var/folders/2d/njyp3x797xvf2rfn03z99dqw0000gn/T/AppTranslocation/E6E4984D-6E7E-4991-899F-1020C2CF0F4F/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
The new method detects oneOf technical formats and converts them to human-readable text
Example transformation: "oneOf<string,object>" → "String or Object"

## Key Implementation Details
Detection: Identifies strings starting with "oneOf<" and ending with ">"
Parsing: Extracts individual types from within the brackets
Formatting: Converts technical type names (string → String, object → Object, etc.)
Output: Joins types with " or " for clear, readable documentation

## The HTML2 generator will now produce:
Before: oneOf<string,object> (technical, unreadable)
After: String or Object (human-readable, clear)

## Mentions
@simllll

## PR checklist
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).

- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.

- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
./mvnw clean package || exit
./bin/generate-samples.sh ./bin/configs/.yaml || exit
./bin/utils/export_docs_generators.sh || exit
(For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
Commit all changed files.
This is important, as CI jobs will verify all generator outputs of your HEAD commit as it would merge with master.
These must match the expectations made by your contribution.
You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example ./bin/generate-samples.sh bin/configs/java.
IMPORTANT: Do NOT purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.

- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): master (upcoming 7.x.0 minor release - breaking changes with fallbacks), 8.0.x (breaking changes without fallbacks)

- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having "fixes https://github.com/OpenAPITools/openapi-generator/pull/123" present in the PR description)

- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.