### PR TITLE
 [Java] do not generate default constructor if lombok.RequiredArgsCon…

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pojo.mustache
@@ -84,6 +84,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
     {{#parent}}
     {{#parcelableModel}}
@@ -97,6 +98,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/discriminator}}
     {{/gson}}
   }
+  {{/lombok.RequiredArgsConstructor}}
   {{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/pojo.mustache
@@ -88,10 +88,11 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() { {{#parent}}{{#parcelableModel}}
     super();{{/parcelableModel}}{{/parent}}{{#gson}}{{#discriminator}}
     this.{{{discriminatorName}}} = this.getClass().getSimpleName();{{/discriminator}}{{/gson}}
-  }{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}{{#jackson}}
+  }{{/lombok.RequiredArgsConstructor}}{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}{{#jackson}}
 
   @JsonCreator
   public {{classname}}(

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/pojo.mustache
@@ -88,10 +88,11 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() { {{#parent}}{{#parcelableModel}}
     super();{{/parcelableModel}}{{/parent}}{{#gson}}{{#discriminator}}
     this.{{{discriminatorName}}} = this.getClass().getSimpleName();{{/discriminator}}{{/gson}}
-  }{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}{{#jackson}}
+  }{{/lombok.RequiredArgsConstructor}}{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}{{#jackson}}
 
   @JsonCreator
   public {{classname}}(

--- a/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/microprofile/pojo.mustache
@@ -61,8 +61,10 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
 {{>additional_properties}}
 
 {{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
   }
+  {{/lombok.RequiredArgsConstructor}}
 
  {{#jsonb}}@JsonbCreator{{/jsonb}}{{#jackson}}@JsonCreator{{/jackson}}
   public {{classname}}(

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/pojo.mustache
@@ -82,10 +82,11 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() { {{#parent}}{{#parcelableModel}}
     super();{{/parcelableModel}}{{/parent}}{{#gson}}{{#discriminator}}
     this.{{{discriminatorName}}} = this.getClass().getSimpleName();{{/discriminator}}{{/gson}}
-  }{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}
+  }{{/lombok.RequiredArgsConstructor}}{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}
 
   {{#jackson}}@JsonCreator{{/jackson}}
   public {{classname}}(

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/pojo.mustache
@@ -77,6 +77,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{#isDiscriminator}}protected{{/isDiscriminator}}{{^isDiscriminator}}private{{/isDiscriminator}} {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
     {{#parent}}
     {{#parcelableModel}}
@@ -94,6 +95,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/discriminator.isEnum}}
     {{/discriminator}}
   }
+  {{/lombok.RequiredArgsConstructor}}
   {{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/restclient/pojo.mustache
@@ -94,6 +94,7 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#v
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
     {{#parent}}
     {{#parcelableModel}}
@@ -107,6 +108,7 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#v
     {{/discriminator}}
     {{/gson}}
   }
+  {{/lombok.RequiredArgsConstructor}}
   {{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pojo.mustache
@@ -94,6 +94,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
     {{#parent}}
     {{#parcelableModel}}
@@ -107,6 +108,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/discriminator}}
     {{/gson}}
   }
+  {{/lombok.RequiredArgsConstructor}}
   {{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
   /**

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/pojo.mustache
@@ -94,6 +94,7 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#v
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
     {{#parent}}
     {{#parcelableModel}}
@@ -107,6 +108,7 @@ public {{>sealed}}class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#v
     {{/discriminator}}
     {{/gson}}
   }
+  {{/lombok.RequiredArgsConstructor}}
   {{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
   /**

--- a/modules/openapi-generator/src/main/resources/Java/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pojo.mustache
@@ -94,6 +94,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
   {{/vendorExtensions.x-is-jackson-optional-nullable}}
 
   {{/vars}}
+  {{^lombok.RequiredArgsConstructor}}
   public {{classname}}() {
     {{#parent}}
     {{#parcelableModel}}
@@ -107,6 +108,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     {{/discriminator}}
     {{/gson}}
   }
+  {{/lombok.RequiredArgsConstructor}}
   {{#vendorExtensions.x-has-readonly-properties}}
   {{^withXml}}
   /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -40,7 +40,6 @@ import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.java.assertions.JavaFileAssert;
 import org.openapitools.codegen.languages.AbstractJavaCodegen;
 import org.openapitools.codegen.languages.JavaClientCodegen;
-import org.openapitools.codegen.languages.RubyClientCodegen;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.CXFServerFeatures;
 import org.openapitools.codegen.meta.features.SecurityFeature;
@@ -49,7 +48,6 @@ import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.testutils.ConfigAssert;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -3589,6 +3587,23 @@ public class JavaClientCodegenTest {
                 .generate().stream().collect(Collectors.toMap(File::getName, Function.identity()));
 
         JavaFileAssert.assertThat(files.get("Type.java")).fileContains("Type implements java.io.Serializable {");
+    }
+
+    @Test(dataProvider = "supportedLibraries")
+    void testLombokRequiredArgsConstructor(Library library) {
+        final Path output = newTempFolder();
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName(JAVA_GENERATOR)
+                .setLibrary(library.getValue())
+                .setAdditionalProperties(Map.of(
+                        AbstractJavaCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS, "@lombok.RequiredArgsConstructor"
+                ))
+                .setInputSpec("src/test/resources/3_1/java/petstore.yaml")
+                .setOutputDir(output.toString().replace("\\", "/"));
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+
+        JavaFileAssert.assertThat(output.resolve("src/main/java/org/openapitools/client/model/Pet.java"))
+                .hasNoConstructor();
     }
 
     /**


### PR DESCRIPTION
This will make the code-generator for Java aware of lombok.RequiredArgsConstructor. This is a partial solution for #16880 . The Spring-Openapi Generator already generates pojos with RequiredArgs and also handles this lombok annotation in its templates.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
