### PR TITLE
Support deprecated API endpoints in reqwest-based Rust clients

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -99,6 +99,9 @@ pub enum {{{operationIdCamelCase}}}Error {
 {{#notes}}
 /// {{{.}}}
 {{/notes}}
+{{#isDeprecated}}
+#[deprecated]
+{{/isDeprecated}}
 {{#vendorExtensions.x-group-parameters}}
 pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: &configuration::Configuration{{#allParams}}{{#-first}}, {{!
 ### Params

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/pet_api.rs
@@ -359,6 +359,7 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub async fn find_pets_by_tags(configuration: &configuration::Configuration, params: FindPetsByTagsParams) -> Result<ResponseContent<FindPetsByTagsSuccess>, Error<FindPetsByTagsError>> {
 
     let uri_str = format!("{}/pet/findByTags", configuration.base_path);

--- a/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-tokensource/src/apis/pet_api.rs
@@ -365,6 +365,7 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub async fn find_pets_by_tags(configuration: &configuration::Configuration, params: FindPetsByTagsParams) -> Result<ResponseContent<FindPetsByTagsSuccess>, Error<FindPetsByTagsError>> {
 
     let uri_str = format!("{}/pet/findByTags", configuration.base_path);

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/pet_api.rs
@@ -359,6 +359,7 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub async fn find_pets_by_tags(configuration: &configuration::Configuration, params: FindPetsByTagsParams) -> Result<ResponseContent<FindPetsByTagsSuccess>, Error<FindPetsByTagsError>> {
 
     let uri_str = format!("{}/pet/findByTags", configuration.base_path);

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/pet_api.rs
@@ -359,6 +359,7 @@ pub async fn find_pets_by_status(configuration: &configuration::Configuration, p
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub async fn find_pets_by_tags(configuration: &configuration::Configuration, params: FindPetsByTagsParams) -> Result<ResponseContent<FindPetsByTagsSuccess>, Error<FindPetsByTagsError>> {
 
     let uri_str = format!("{}/pet/findByTags", configuration.base_path);

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
@@ -263,6 +263,7 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec<String>) -> Result<Vec<models::Pet>, Error<FindPetsByTagsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_query_tags = tags;

--- a/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-model-name-prefix/src/apis/pet_api.rs
@@ -224,6 +224,7 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec<String>) -> Result<Vec<models::FooPet>, Error<FindPetsByTagsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_query_tags = tags;

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -224,6 +224,7 @@ pub fn find_pets_by_status(configuration: &configuration::Configuration, status:
 }
 
 /// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+#[deprecated]
 pub fn find_pets_by_tags(configuration: &configuration::Configuration, tags: Vec<String>) -> Result<Vec<models::Pet>, Error<FindPetsByTagsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_query_tags = tags;


### PR DESCRIPTION
Previously, if an API endpoint was marked deprecated, this fact was not reflected in the generated Rust clients using the reqwest library. We want to know exactly when our client code is using a deprecated endpoint, so marking the corresponding functions with the `#[deprecatd]` attribute would be very helpful. Uses of the endpoint would then be picked up by linters so that we can react.

This adds a line to the template which marks functions generated from deprecated endpoints with the `#[deprecated]` attribute.

This does not touch any of the other client generators for Rust or any other language, since they are out of scope for our needs.

Unfortunately, even after about a dozen attempts, I was unable to coax Mustache into not introducing an extra vertical whitespace when the `#[deprecated]` attribute is absent. This has no effect on functionality of the generated code, but is visually unappealing.

@frol @farcaller @richardwhiuk @paladinzh @jacob-pro @dsteeley

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
