### PR TITLE
[typescript-angular] Add includeEndpointUrl option to include endpoint

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptAngularClientCodegen.java
@@ -83,6 +83,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
     public static final String RXJS_VERSION = "rxjsVersion";
     public static final String NGPACKAGR_VERSION = "ngPackagrVersion";
     public static final String ZONEJS_VERSION = "zonejsVersion";
+    public static final String INCLUDE_ENDPOINT_URL = "includeEndpointUrl";
 
     protected String ngVersion = "20.0.0";
     @Getter @Setter
@@ -155,6 +156,7 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         this.cliOptions.add(new CliOption(RXJS_VERSION, "The version of RxJS compatible with Angular (see ngVersion option)."));
         this.cliOptions.add(new CliOption(NGPACKAGR_VERSION, "The version of ng-packagr compatible with Angular (see ngVersion option)."));
         this.cliOptions.add(new CliOption(ZONEJS_VERSION, "The version of zone.js compatible with Angular (see ngVersion option)."));
+        this.cliOptions.add(CliOption.newBoolean(INCLUDE_ENDPOINT_URL, "Include endpoint URL as comment in generated service methods.", false));
     }
 
     @Override
@@ -308,6 +310,11 @@ public class TypeScriptAngularClientCodegen extends AbstractTypeScriptClientCode
         additionalProperties.put("isQueryParamObjectFormatDot", getQueryParamObjectFormatDot());
         additionalProperties.put("isQueryParamObjectFormatJson", getQueryParamObjectFormatJson());
         additionalProperties.put("isQueryParamObjectFormatKey", getQueryParamObjectFormatKey());
+
+        if (additionalProperties.containsKey(INCLUDE_ENDPOINT_URL)) {
+            boolean includeEndpointUrl = Boolean.parseBoolean(additionalProperties.get(INCLUDE_ENDPOINT_URL).toString());
+            additionalProperties.put(INCLUDE_ENDPOINT_URL, includeEndpointUrl);
+        }
 
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/api.service.mustache
@@ -74,6 +74,9 @@ export class {{classname}} extends BaseService {
 {{#notes}}
      * {{.}}
 {{/notes}}
+{{#includeEndpointUrl}}
+     * @endpoint {{httpMethod}} {{{path}}}
+{{/includeEndpointUrl}}
      {{^useSingleRequestParameter}}
      {{#allParams}}
      * @param {{paramName}} {{description}}

--- a/modules/openapi-generator/src/main/resources/typescript-angular/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-angular/apiInterface.mustache
@@ -38,6 +38,9 @@ export interface {{classname}}Interface {
     /**
      * {{summary}}
      * {{notes}}
+{{#includeEndpointUrl}}
+     * @endpoint {{httpMethod}} {{{path}}}
+{{/includeEndpointUrl}}
      {{^useSingleRequestParameter}}
      {{#allParams}}* @param {{paramName}} {{description}}
      {{/allParams}}{{/useSingleRequestParameter}}{{#useSingleRequestParameter}}{{#allParams.0}}* @param requestParameters


### PR DESCRIPTION
# Add includeEndpointUrl option to include endpoint URLs in generated service comments

Adds a new boolean option 'includeEndpointUrl' that, when enabled, includes endpoint URL information as JSDoc comments in generated service methods and interfaces. This helps developers quickly identify the HTTP method and path for each API operation.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@joscha
