### PR TITLE
Update kotlin-spring projects to use JDK 11

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradleKts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/buildGradleKts.mustache
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 {{#interfaceOnly}}

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/pom.mustache
@@ -59,7 +59,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-cloud/pom.mustache
@@ -69,7 +69,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-spring-cloud/pom.xml
+++ b/samples/server/petstore/kotlin-spring-cloud/pom.xml
@@ -52,7 +52,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-spring-default/build.gradle.kts
+++ b/samples/server/petstore/kotlin-spring-default/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-spring-default/pom.xml
+++ b/samples/server/petstore/kotlin-spring-default/pom.xml
@@ -43,7 +43,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/pom.xml
@@ -43,7 +43,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-delegate/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-delegate/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-delegate/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-delegate/pom.xml
@@ -43,7 +43,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-modelMutable/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/pom.xml
@@ -43,7 +43,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/pom.xml
@@ -43,7 +43,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/pom.xml
@@ -44,7 +44,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-reactive/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-reactive/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-reactive/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-reactive/pom.xml
@@ -44,7 +44,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/pom.xml
@@ -44,7 +44,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/pom.xml
@@ -44,7 +44,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-springfox/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-springfox/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot-springfox/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-springfox/pom.xml
@@ -44,7 +44,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 tasks.bootJar {

--- a/samples/server/petstore/kotlin-springboot-x-kotlin-implements/pom.xml
+++ b/samples/server/petstore/kotlin-springboot-x-kotlin-implements/pom.xml
@@ -42,7 +42,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>

--- a/samples/server/petstore/kotlin-springboot/build.gradle.kts
+++ b/samples/server/petstore/kotlin-springboot/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 plugins {

--- a/samples/server/petstore/kotlin-springboot/pom.xml
+++ b/samples/server/petstore/kotlin-springboot/pom.xml
@@ -42,7 +42,7 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Update kotlin-spring projects to use JDK 11 instead of JDK 8 which has reached EOL

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)
