### PR TITLE
[Typescript-fetch] Add isBoolean blocks to modelOneOf.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -89,6 +89,13 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         }
     }
     {{/isNumeric}}
+    {{#isBoolean}}
+    if (Array.isArray(json)) {
+        if (json.every(item => typeof item === 'boolean'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
+            return json;
+        }
+    }
+    {{/isBoolean}}
     {{#isString}}
     if (Array.isArray(json)) {
         if (json.every(item => typeof item === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
@@ -116,6 +123,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         return json;
     }
     {{/isNumeric}}
+    {{#isBoolean}}
+    if (typeof json === 'boolean'{{#isEnum}} && ({{#allowableValues}}{{#values}}json === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+        return json;
+    }
+    {{/isBoolean}}
     {{#isString}}
     if (typeof json === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}json === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
         return json;
@@ -194,6 +206,13 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
         }
     }
     {{/isNumeric}}
+    {{#isBoolean}}
+    if (Array.isArray(value)) {
+        if (value.every(item => typeof item === 'boolean'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
+            return value;
+        }
+    }
+    {{/isBoolean}}
     {{#isString}}
     if (Array.isArray(value)) {
         if (value.every(item => typeof item === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}item === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}})) {
@@ -219,6 +238,11 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
         return value;
     }
     {{/isNumeric}}
+    {{#isBoolean}}
+    if (typeof value === 'boolean'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === {{.}}{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
+        return value;
+    }
+    {{/isBoolean}}
     {{#isString}}
     if (typeof value === 'string'{{#isEnum}} && ({{#allowableValues}}{{#values}}value === '{{.}}'{{^-last}} || {{/-last}}{{/values}}{{/allowableValues}}){{/isEnum}}) {
         return value;


### PR DESCRIPTION
Adds booleans to modelOneOf

We have a union type that unions with `boolean`:

```tsx
export type AdminSettingsModelValue = boolean | number | object | string;
```

This is being compiled without the `boolean` typeof check:

```tsx
export function AdminSettingsModelValueFromJSONTyped(
  json: any,
  ignoreDiscriminator: boolean
): AdminSettingsModelValue {
  if (json == null) {
    return json;
  }
  if (typeof json === 'number') {
    return json;
  }
  if (typeof json === 'string') {
    return json;
  }
  return {} as any;
}
```

This PR adds the boolean sections to the template. This compiles correctly for us, and adds the boolean type to the exported union.

Any suggestions are very welcome!

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
