### PR TITLE
C# GenericHost Support multi targetting

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/netcore_project.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/netcore_project.mustache
@@ -36,13 +36,74 @@
     <PackageReference Include="RestSharp" Version="112.0.0" />
     {{/useRestSharp}}
     {{#useGenericHost}}
-    <PackageReference Include="Microsoft.Extensions.Http" Version="{{#lambda.first}}{{#netStandard}}5.0.0  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.0  {{/net6.0}}{{#net7.0}}7.0.0  {{/net7.0}}{{#net8.0}}8.0.1  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="{{#lambda.first}}{{#netStandard}}5.0.0  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.1  {{/net6.0}}{{#net7.0}}7.0.1  {{/net7.0}}{{#net8.0}}8.0.1  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
+    {{#netStandard}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" Version="6.0.1" />
+    {{/netStandard}}
+    {{#net47}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    {{/net47}}
+    {{#net48}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    {{/net48}}
+    {{#net6.0}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net6.0'" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net6.0'" Version="6.0.1" />
+    {{/net6.0}}
+    {{#net7.0}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net7.0'" Version=7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net7.0'" Version="7.0.1" />
+    {{/net7.0}}
+    {{#net8.0}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    {{/net8.0}}
+    {{#net9.0}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    {{/net9.0}}
+    {{#net10.0}}
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    {{/net10.0}}
     {{#supportsRetry}}
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="{{#lambda.first}}{{#netStandard}}5.0.1  {{/netStandard}}{{#net47}}7.0.0  {{/net47}}{{#net48}}7.0.0  {{/net48}}{{#net6.0}}6.0.19  {{/net6.0}}{{#net7.0}}7.0.11  {{/net7.0}}{{#net8.0}}8.0.8  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
+    {{#netStandard}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" Version="5.0.1" />
+    {{/netStandard}}
+    {{#net47}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    {{/net47}}
+    {{#net48}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    {{/net48}}
+    {{#net6.0}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net6.0'" Version="6.0.36" />
+    {{/net6.0}}
+    {{#net7.0}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net7.0'" Version="7.0.20" />
+    {{/net7.0}}
+    {{#net8.0}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    {{/net8.0}}
+    {{#net9.0}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    {{/net9.0}}
+    {{#net10.0}}
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    {{/net10.0}}
     {{/supportsRetry}}
     {{#net80OrLater}}
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="{{#lambda.first}}{{#net8.0}}8.0.8  {{/net8.0}}{{#net9.0}}9.0.5  {{/net9.0}}{{#net10.0}}10.0.1 {{/net10.0}}{{/lambda.first}}" />
+    {{#net8.0}}
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
+    {{/net8.0}}
+    {{#net9.0}}
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    {{/net9.0}}
+    {{#net10.0}}
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    {{/net10.0}}
     {{/net80OrLater}}
     {{^net60OrLater}}
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.1 " />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="10.0.1 " />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net10.0'" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481'" Version="7.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <Reference Include="System.Web" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.20" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net8.0'" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,10 +23,10 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,10 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Condition="'$(TargetFramework)' == 'net9.0'" Version="9.0.6" />
   </ItemGroup>
 
 </Project>

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="CompareNETObjects" Version="4.84.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Condition="'$(TargetFramework)' == 'netstandard1.3' or '$(TargetFramework)' == 'netstandard1.4' or '$(TargetFramework)' == 'netstandard1.5' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'" Version="5.0.1" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Split 3 of #22062 

This makes it so that when you have both net8 and net9 (for example) the csproj includes both. This makes sure that consumers of your package will get to use the newest transitive dependencies.

This requires a bunch of `Condition` clauses.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

C# Technical Committee
@mandrean @shibayan @Blackclaws @lucamazzanti @iBicha

@devhl-labs