### PR TITLE
[typescript-fetch] Fix explode query parameters 

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -133,6 +133,17 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/isArray}}
         {{^isArray}}
         if (requestParameters['{{paramName}}'] != null) {
+            {{#isExplode}}
+            {{#isContainer}}
+            for (let key of Object.keys(requestParameters['{{paramName}}'])) {
+                queryParameters[key] = requestParameters['{{paramName}}'][key];
+            }
+            {{/isContainer}}
+            {{^isContainer}}
+            queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];
+            {{/isContainer}}
+            {{/isExplode}}
+            {{^isExplode}}
             {{#isDateTimeType}}
             queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString();
             {{/isDateTimeType}}
@@ -144,6 +155,7 @@ export class {{classname}} extends runtime.BaseAPI {
             queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];
             {{/isDateType}}
             {{/isDateTimeType}}
+            {{/isExplode}}
         }
 
         {{/isArray}}

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -1214,7 +1214,9 @@ export class FakeApi extends runtime.BaseAPI {
         }
 
         if (requestParameters['language'] != null) {
-            queryParameters['language'] = requestParameters['language'];
+            for (let key of Object.keys(requestParameters['language'])) {
+                queryParameters[key] = requestParameters['language'][key];
+            }
         }
 
         if (requestParameters['allowEmpty'] != null) {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -1072,7 +1072,9 @@ export class FakeApi extends runtime.BaseAPI {
         }
 
         if (requestParameters['language'] != null) {
-            queryParameters['language'] = requestParameters['language'];
+            for (let key of Object.keys(requestParameters['language'])) {
+                queryParameters[key] = requestParameters['language'][key];
+            }
         }
 
         if (requestParameters['allowEmpty'] != null) {


### PR DESCRIPTION
Fixes #10438

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR attempts to fix the current issue affecting the typescript-fetch generator that is currently unable to generate exploded query parameters.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

### Technical commitee

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10)
