### PR TITLE
fix: Format Date/DateTime Query Parameters in exploded, non-container Parameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -140,21 +140,11 @@ export class {{classname}} extends runtime.BaseAPI {
             }
             {{/isContainer}}
             {{^isContainer}}
-            queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];
+{{>apisAssignQueryParam}}
             {{/isContainer}}
             {{/isExplode}}
             {{^isExplode}}
-            {{#isDateTimeType}}
-            queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString();
-            {{/isDateTimeType}}
-            {{^isDateTimeType}}
-            {{#isDateType}}
-            queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString().substring(0,10);
-            {{/isDateType}}
-            {{^isDateType}}
-            queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];
-            {{/isDateType}}
-            {{/isDateTimeType}}
+{{>apisAssignQueryParam}}
             {{/isExplode}}
         }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apisAssignQueryParam.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apisAssignQueryParam.mustache
@@ -1,0 +1,12 @@
+{{! Assign query parameters based on their type }}
+{{#isDateTimeType}}
+            queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString();
+{{/isDateTimeType}}
+{{^isDateTimeType}}
+{{#isDateType}}
+            queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString().substring(0,10);
+{{/isDateType}}
+{{^isDateType}}
+            queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];
+{{/isDateType}}
+{{/isDateTimeType}}


### PR DESCRIPTION
Fixes #22267

Tagging the committee as stated in the checklist: @TiFu @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha

### Change Description

Externalise the query parameter assignment into a separate mustache script and call it in the original place as well as while setting a `exploded: true`, non-container param.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
