### PR TITLE
[cpp-rest] Fixing Incorrect Header Name Used

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/api-source.mustache
@@ -239,7 +239,7 @@ pplx::task<{{{returnType}}}{{^returnType}}void{{/returnType}}> {{classname}}::{{
     {{#isApiKey}}
     {{#isKeyInHeader}}
     {
-        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
+        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("{{name}}"));
         if ( localVarApiKey.size() > 0 )
         {
             localVarHeaderParams[utility::conversions::to_string_t("{{keyParamName}}")] = localVarApiKey;
@@ -248,7 +248,7 @@ pplx::task<{{{returnType}}}{{^returnType}}void{{/returnType}}> {{classname}}::{{
     {{/isKeyInHeader}}
     {{#isKeyInQuery}}
     {
-        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("{{keyParamName}}"));
+        utility::string_t localVarApiKey = localVarApiConfiguration->getApiKey(utility::conversions::to_string_t("{{name}}"));
         if ( localVarApiKey.size() > 0 )
         {
             localVarQueryParams[utility::conversions::to_string_t("{{keyParamName}}")] = localVarApiKey;


### PR DESCRIPTION
Fixes #22297

@aminya

If I have a security scheme defined as `api_key` which uses the header name `x-api-key`, suddenly neither work with the cpp-restsdk generator. It works with other generators - they fetch the correct header name from the security scheme name.

**I ran the generation of the test snapshot but there are no changes since in the test the security scheme and key name are the same.**

If desired I can add a test for this specific scenario. I verified it by using the built generator on our SDK.