### PR TITLE
Add UUID examples and documentation

### DIFF
--- a/docs/generators/python-aiohttp.md
+++ b/docs/generators/python-aiohttp.md
@@ -55,6 +55,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Dict</li>
 <li>List</li>
+<li>UUID</li>
 <li>bool</li>
 <li>bytes</li>
 <li>date</li>

--- a/docs/generators/python-blueplanet.md
+++ b/docs/generators/python-blueplanet.md
@@ -55,6 +55,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Dict</li>
 <li>List</li>
+<li>UUID</li>
 <li>bool</li>
 <li>bytes</li>
 <li>date</li>

--- a/docs/generators/python-fastapi.md
+++ b/docs/generators/python-fastapi.md
@@ -50,6 +50,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Dict</li>
 <li>List</li>
+<li>UUID</li>
 <li>bool</li>
 <li>bytes</li>
 <li>date</li>

--- a/docs/generators/python-flask.md
+++ b/docs/generators/python-flask.md
@@ -55,6 +55,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Dict</li>
 <li>List</li>
+<li>UUID</li>
 <li>bool</li>
 <li>bytes</li>
 <li>date</li>

--- a/docs/generators/python.md
+++ b/docs/generators/python.md
@@ -53,6 +53,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Dict</li>
 <li>List</li>
+<li>UUID</li>
 <li>bool</li>
 <li>bytearray</li>
 <li>bytes</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -108,6 +108,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         // TODO file and binary is mapped as `file`
         languageSpecificPrimitives.add("file");
         languageSpecificPrimitives.add("bytes");
+        languageSpecificPrimitives.add("UUID");
 
         typeMapping.clear();
         typeMapping.put("integer", "int");
@@ -129,8 +130,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         // mapped to String as a workaround
         typeMapping.put("binary", "str");
         typeMapping.put("ByteArray", "str");
-        // map uuid to string for the time being
-        typeMapping.put("UUID", "str");
+        typeMapping.put("UUID", "UUID");
         typeMapping.put("URI", "str");
         typeMapping.put("null", "none_type");
 
@@ -571,7 +571,12 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             type = p.dataType;
         }
 
-        if ("String".equalsIgnoreCase(type) || "str".equalsIgnoreCase(type)) {
+        if (Boolean.TRUE.equals(p.isUuid)) {
+            if (example == null) {
+                example = "38400000-8cf0-11bd-b23e-10b96e4ef00d";
+            }
+            example = "UUID('" + escapeTextInSingleQuotes(example) + "')";
+        } else if ("String".equalsIgnoreCase(type) || "str".equalsIgnoreCase(type)) {
             if (example == null) {
                 example = p.paramName + "_example";
             }

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/FakeApi.md
@@ -1328,7 +1328,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    uuid_example = '84529ad2-2265-4e15-b76b-c17025d848f6' # str | uuid example
+    uuid_example = UUID('84529ad2-2265-4e15-b76b-c17025d848f6') # UUID | uuid example
 
     try:
         # test uuid example
@@ -1344,7 +1344,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **uuid_example** | **str**| uuid example | 
+ **uuid_example** | **UUID**| uuid example | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **binary** | **bytearray** |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **password** | **str** |  | 
 **pattern_with_digits** | **str** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **pattern_with_digits_and_delimiter** | **str** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **date_time** | **datetime** |  | [optional] 
 **map** | [**Dict[str, Animal]**](Animal.md) |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/Task.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/Task.md
@@ -6,7 +6,7 @@ Used to test oneOf enums with only one string value.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** |  | 
+**id** | **UUID** |  | 
 **activity** | [**TaskActivity**](TaskActivity.md) |  | 
 
 ## Example

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -4932,7 +4932,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -4998,7 +4998,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -5064,7 +5064,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of

--- a/samples/openapi3/client/petstore/python-httpx/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/FakeApi.md
@@ -1328,7 +1328,7 @@ configuration = petstore_api.Configuration(
 async with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    uuid_example = '84529ad2-2265-4e15-b76b-c17025d848f6' # str | uuid example
+    uuid_example = UUID('84529ad2-2265-4e15-b76b-c17025d848f6') # UUID | uuid example
 
     try:
         # test uuid example
@@ -1344,7 +1344,7 @@ async with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **uuid_example** | **str**| uuid example | 
+ **uuid_example** | **UUID**| uuid example | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-httpx/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **binary** | **bytearray** |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **password** | **str** |  | 
 **pattern_with_digits** | **str** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **pattern_with_digits_and_delimiter** | **str** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/openapi3/client/petstore/python-httpx/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **date_time** | **datetime** |  | [optional] 
 **map** | [**Dict[str, Animal]**](Animal.md) |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-httpx/docs/Task.md
+++ b/samples/openapi3/client/petstore/python-httpx/docs/Task.md
@@ -6,7 +6,7 @@ Used to test oneOf enums with only one string value.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** |  | 
+**id** | **UUID** |  | 
 **activity** | [**TaskActivity**](TaskActivity.md) |  | 
 
 ## Example

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api/fake_api.py
@@ -4932,7 +4932,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -4998,7 +4998,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -5064,7 +5064,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/FakeApi.md
@@ -1328,7 +1328,7 @@ configuration = petstore_api.Configuration(
 with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    uuid_example = '84529ad2-2265-4e15-b76b-c17025d848f6' # str | uuid example
+    uuid_example = UUID('84529ad2-2265-4e15-b76b-c17025d848f6') # UUID | uuid example
 
     try:
         # test uuid example
@@ -1344,7 +1344,7 @@ with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **uuid_example** | **str**| uuid example | 
+ **uuid_example** | **UUID**| uuid example | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **binary** | **bytearray** |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **password** | **str** |  | 
 **pattern_with_digits** | **str** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **pattern_with_digits_and_delimiter** | **str** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **date_time** | **datetime** |  | [optional] 
 **map** | [**Dict[str, Animal]**](Animal.md) |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-lazyImports/docs/Task.md
+++ b/samples/openapi3/client/petstore/python-lazyImports/docs/Task.md
@@ -6,7 +6,7 @@ Used to test oneOf enums with only one string value.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** |  | 
+**id** | **UUID** |  | 
 **activity** | [**TaskActivity**](TaskActivity.md) |  | 
 
 ## Example

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api/fake_api.py
@@ -4932,7 +4932,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -4998,7 +4998,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -5064,7 +5064,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of

--- a/samples/openapi3/client/petstore/python/docs/FakeApi.md
+++ b/samples/openapi3/client/petstore/python/docs/FakeApi.md
@@ -1328,7 +1328,7 @@ configuration = petstore_api.Configuration(
 with petstore_api.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = petstore_api.FakeApi(api_client)
-    uuid_example = '84529ad2-2265-4e15-b76b-c17025d848f6' # str | uuid example
+    uuid_example = UUID('84529ad2-2265-4e15-b76b-c17025d848f6') # UUID | uuid example
 
     try:
         # test uuid example
@@ -1344,7 +1344,7 @@ with petstore_api.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **uuid_example** | **str**| uuid example | 
+ **uuid_example** | **UUID**| uuid example | 
 
 ### Return type
 

--- a/samples/openapi3/client/petstore/python/docs/FormatTest.md
+++ b/samples/openapi3/client/petstore/python/docs/FormatTest.md
@@ -18,7 +18,7 @@ Name | Type | Description | Notes
 **binary** | **bytearray** |  | [optional] 
 **var_date** | **date** |  | 
 **date_time** | **datetime** |  | [optional] 
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **password** | **str** |  | 
 **pattern_with_digits** | **str** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **pattern_with_digits_and_delimiter** | **str** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/openapi3/client/petstore/python/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/openapi3/client/petstore/python/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**uuid** | **str** |  | [optional] 
+**uuid** | **UUID** |  | [optional] 
 **date_time** | **datetime** |  | [optional] 
 **map** | [**Dict[str, Animal]**](Animal.md) |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python/docs/Task.md
+++ b/samples/openapi3/client/petstore/python/docs/Task.md
@@ -6,7 +6,7 @@ Used to test oneOf enums with only one string value.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** |  | 
+**id** | **UUID** |  | 
 **activity** | [**TaskActivity**](TaskActivity.md) |  | 
 
 ## Example

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -4932,7 +4932,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -4998,7 +4998,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -5064,7 +5064,7 @@ class FakeApi:
 
 
         :param uuid_example: uuid example (required)
-        :type uuid_example: str
+        :type uuid_example: UUID
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR updates the examples and documentation to use UUID fields of type `UUID` instead of `str`.

While `str` works for `UUID` fields (since Pydantic automatically casts strings to `UUID` objects), using the actual UUID type provides better clarity and type consistency in the generated models and examples.
Notes:
- This change introduces `UUID` to `languageSpecificPrimitives`, similar to how `datetime` is handled.
- The `uuid` package is part of Python’s standard library, so this doesn’t add any external dependencies.
- Although using `str` isn’t technically incorrect, adopting `UUID` makes the documentation more explicit and aligned with real-world usage.

Relates to PR https://github.com/OpenAPITools/openapi-generator/pull/21740


<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)