### PR TITLE
[php][php-nextgen] fix return type if empty and non-empty responses are mixed

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -188,6 +188,7 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
         for (CodegenOperation operation : operations.getOperation()) {
             Set<String> phpReturnTypeOptions = new LinkedHashSet<>();
             Set<String> docReturnTypeOptions = new LinkedHashSet<>();
+            boolean hasEmptyResponse = false;
 
             for (CodegenResponse response : operation.responses) {
                 if (response.dataType != null) {
@@ -200,6 +201,8 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
 
                     phpReturnTypeOptions.add(returnType);
                     docReturnTypeOptions.add(response.dataType);
+                } else {
+                    hasEmptyResponse = true;
                 }
             }
 
@@ -208,9 +211,16 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
                 operation.vendorExtensions.putIfAbsent("x-php-return-type", "void");
                 operation.vendorExtensions.putIfAbsent("x-php-doc-return-type", "void");
             } else {
+                String phpReturnType = String.join("|", phpReturnTypeOptions);
+                String docReturnType = String.join("|", docReturnTypeOptions);
+                if (hasEmptyResponse) {
+                    phpReturnType = "?" + phpReturnType;
+                    docReturnType = docReturnType + "|null";
+                }
+
                 operation.vendorExtensions.putIfAbsent("x-php-return-type-is-void", false);
-                operation.vendorExtensions.putIfAbsent("x-php-return-type", String.join("|", phpReturnTypeOptions));
-                operation.vendorExtensions.putIfAbsent("x-php-doc-return-type", String.join("|", docReturnTypeOptions));
+                operation.vendorExtensions.putIfAbsent("x-php-return-type", phpReturnType);
+                operation.vendorExtensions.putIfAbsent("x-php-doc-return-type", docReturnType);
             }
 
             for (CodegenParameter param : operation.allParams) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -470,12 +470,12 @@ class FakeApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Error
+     * @return \OpenAPI\Client\Model\Error|null
      */
     public function fakeDeletePet(
         string $pet_id,
         string $contentType = self::contentTypes['fakeDeletePet'][0]
-    ): \OpenAPI\Client\Model\Error
+    ): ?\OpenAPI\Client\Model\Error
     {
         list($response) = $this->fakeDeletePetWithHttpInfo($pet_id, $contentType);
         return $response;
@@ -3225,12 +3225,12 @@ class FakeApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Pet
+     * @return \OpenAPI\Client\Model\Pet|null
      */
     public function fakeWith400And4xxRangeResponseNo4xxDatatypeEndpoint(
         \OpenAPI\Client\Model\Pet $pet,
         string $contentType = self::contentTypes['fakeWith400And4xxRangeResponseNo4xxDatatypeEndpoint'][0]
-    ): \OpenAPI\Client\Model\Pet
+    ): ?\OpenAPI\Client\Model\Pet
     {
         list($response) = $this->fakeWith400And4xxRangeResponseNo4xxDatatypeEndpointWithHttpInfo($pet, $contentType);
         return $response;
@@ -4094,12 +4094,12 @@ class FakeApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Pet
+     * @return \OpenAPI\Client\Model\Pet|null
      */
     public function fakeWith4xxRangeResponseNo4xxDatatypeEndpoint(
         \OpenAPI\Client\Model\Pet $pet,
         string $contentType = self::contentTypes['fakeWith4xxRangeResponseNo4xxDatatypeEndpoint'][0]
-    ): \OpenAPI\Client\Model\Pet
+    ): ?\OpenAPI\Client\Model\Pet
     {
         list($response) = $this->fakeWith4xxRangeResponseNo4xxDatatypeEndpointWithHttpInfo($pet, $contentType);
         return $response;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -808,12 +808,12 @@ class PetApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Pet[]
+     * @return \OpenAPI\Client\Model\Pet[]|null
      */
     public function findPetsByStatus(
         array $status,
         string $contentType = self::contentTypes['findPetsByStatus'][0]
-    ): array
+    ): ?array
     {
         list($response) = $this->findPetsByStatusWithHttpInfo($status, $contentType);
         return $response;
@@ -1093,13 +1093,13 @@ class PetApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Pet[]
+     * @return \OpenAPI\Client\Model\Pet[]|null
      * @deprecated
      */
     public function findPetsByTags(
         array $tags,
         string $contentType = self::contentTypes['findPetsByTags'][0]
-    ): array
+    ): ?array
     {
         list($response) = $this->findPetsByTagsWithHttpInfo($tags, $contentType);
         return $response;
@@ -1383,12 +1383,12 @@ class PetApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Pet
+     * @return \OpenAPI\Client\Model\Pet|null
      */
     public function getPetById(
         int $pet_id,
         string $contentType = self::contentTypes['getPetById'][0]
-    ): \OpenAPI\Client\Model\Pet
+    ): ?\OpenAPI\Client\Model\Pet
     {
         list($response) = $this->getPetByIdWithHttpInfo($pet_id, $contentType);
         return $response;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -636,12 +636,12 @@ class StoreApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Order
+     * @return \OpenAPI\Client\Model\Order|null
      */
     public function getOrderById(
         int $order_id,
         string $contentType = self::contentTypes['getOrderById'][0]
-    ): \OpenAPI\Client\Model\Order
+    ): ?\OpenAPI\Client\Model\Order
     {
         list($response) = $this->getOrderByIdWithHttpInfo($order_id, $contentType);
         return $response;
@@ -922,12 +922,12 @@ class StoreApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\Order
+     * @return \OpenAPI\Client\Model\Order|null
      */
     public function placeOrder(
         \OpenAPI\Client\Model\Order $order,
         string $contentType = self::contentTypes['placeOrder'][0]
-    ): \OpenAPI\Client\Model\Order
+    ): ?\OpenAPI\Client\Model\Order
     {
         list($response) = $this->placeOrderWithHttpInfo($order, $contentType);
         return $response;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -1081,12 +1081,12 @@ class UserApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return \OpenAPI\Client\Model\User
+     * @return \OpenAPI\Client\Model\User|null
      */
     public function getUserByName(
         string $username,
         string $contentType = self::contentTypes['getUserByName'][0]
-    ): \OpenAPI\Client\Model\User
+    ): ?\OpenAPI\Client\Model\User
     {
         list($response) = $this->getUserByNameWithHttpInfo($username, $contentType);
         return $response;
@@ -1362,13 +1362,13 @@ class UserApi
      *
      * @throws ApiException on non-2xx response or if the response body is not in the expected format
      * @throws InvalidArgumentException
-     * @return string
+     * @return string|null
      */
     public function loginUser(
         string $username,
         string $password,
         string $contentType = self::contentTypes['loginUser'][0]
-    ): string
+    ): ?string
     {
         list($response) = $this->loginUserWithHttpInfo($username, $password, $contentType);
         return $response;


### PR DESCRIPTION
This PR fixes an issue when you have an endpoint that either returns a response with data or an empty response (e.g., empty response on success but an error message on error, or the other way around). The return type would be annotated with the non-empty response types. If an empty response was encountered, null would be returned which throws an error because that's not a valid return type.

I added null to the possible return types if any of the responses have no schema. 

Fixes #21359.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon