### PR TITLE
Fix Kotlin codegen for enum with int items (issue #15204)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -145,7 +145,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
     {{#multiplatform}}
     @Serializable
     {{/multiplatform}}
-    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{{nameInPascalCase}}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}) {
+    {{#nonPublicApi}}internal {{/nonPublicApi}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}enum class {{{nameInPascalCase}}}({{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}val value: {{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}{{#mostInnerItems}}{{dataType}}{{/mostInnerItems}}{{/isContainer}}) {
     {{#allowableValues}}
     {{#enumVars}}
         {{^multiplatform}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.openapitools.codegen.CodegenConstants.*;
+import static org.openapitools.codegen.TestUtils.assertFileContains;
 
 @SuppressWarnings("static-method")
 public class KotlinClientCodegenModelTest {
@@ -616,6 +617,32 @@ public class KotlinClientCodegenModelTest {
         // derived doesn't contain disciminator
         TestUtils.assertFileNotContains(birdKt, "val discriminator");
     }
+
+  @Test
+  public void testIntArrayToEnum() throws IOException {
+      File output = Files.createTempDirectory("test").toFile();
+      output.deleteOnExit();
+
+      final CodegenConfigurator configurator = new CodegenConfigurator()
+              .setGeneratorName("kotlin")
+              .setLibrary("jvm-ktor")
+              .setAdditionalProperties(new HashMap<>() {{
+                put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                put(CodegenConstants.MODEL_PACKAGE, "model");
+                put(ENUM_PROPERTY_NAMING, "UPPERCASE");
+              }})
+              .setInputSpec("src/test/resources/3_0/kotlin/issue15204-int-array-enum.yaml")
+              .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+      final ClientOptInput clientOptInput = configurator.toClientOptInput();
+      DefaultGenerator generator = new DefaultGenerator();
+
+      generator.opts(clientOptInput).generate();
+
+      final Path modelKt = Paths.get(output + "/src/main/kotlin/model/ModelWithIntArrayEnum.kt");
+
+      TestUtils.assertFileContains(modelKt, "enum class DaysOfWeek(val value: kotlin.Int)");
+  }
 
     private static class ModelNameTest {
         private final String expectedName;

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue15204-int-array-enum.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue15204-int-array-enum.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 15204 Int Array Enum'
+  version: latest
+paths:
+  '/':
+    get:
+      operationId: operation
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelWithIntArrayEnum'
+components:
+  schemas:
+    ModelWithIntArrayEnum:
+      required:
+        - daysOfWeek
+      properties:
+        daysOfWeek:
+          type: array
+          items:
+            type: integer
+            enum: [0, 1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

When an array property has enum integer items, the kotlin codegen would generate invalid code, e.g.:

```kotlin
    /**
     * 
     *
     * Values: _0,_1,_2,_3,_4,_5,_6
     */
    enum class DaysOfWeek(val value: kotlin.String) { // <---- value is of type String
        @JsonProperty(value = "0") _0(0), // <---- but Ints are being passed to constructor
        @JsonProperty(value = "1") _1(1),
        @JsonProperty(value = "2") _2(2),
        @JsonProperty(value = "3") _3(3),
        @JsonProperty(value = "4") _4(4),
        @JsonProperty(value = "5") _5(5),
        @JsonProperty(value = "6") _6(6);
    }
```

With the fix, the code is generated correctly:

```kotlin
    /**
     *
     *
     * Values: _0,_1,_2,_3,_4,_5,_6
     */
    enum class DaysOfWeek(val value: kotlin.Int) {
        @JsonProperty(value = "0") _0(0),
        @JsonProperty(value = "1") _1(1),
        @JsonProperty(value = "2") _2(2),
        @JsonProperty(value = "3") _3(3),
        @JsonProperty(value = "4") _4(4),
        @JsonProperty(value = "5") _5(5),
        @JsonProperty(value = "6") _6(6);
    }
```

I was following the [Java codegen](https://github.com/OpenAPITools/openapi-generator/blob/d318752478b620b3b697b973f86a1a90dbc1acb1/modules/openapi-generator/src/main/resources/Java/pojo.mustache#L43-L49).

Fixes #15204.

@karismann @Zomzog @andrewemery @4brunu @stefankoppier @e5l

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
