### PR TITLE
Add support for trait mocking in rust-server generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -870,6 +870,16 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             op.vendorExtensions.put("x-has-request-body", true);
         }
 
+        if (op.allParams.stream()
+            .anyMatch(p -> p.isArray && !p.isPrimitiveType)) {
+            op.vendorExtensions.put("x-has-borrowed-params", Boolean.TRUE);
+            for (CodegenParameter param : op.allParams) {
+                if (param.isArray) {
+                    param.vendorExtensions.put("x-param-needs-lifetime", Boolean.TRUE);
+                }
+            }
+        }
+
         // The CLI generates a structopt structure for each operation. This can only have a single
         // use of a short option, which comes from the parameter name, so we need to police
         // against duplicates

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -70,6 +70,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -87,6 +89,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
@@ -1,5 +1,5 @@
     #[allow(clippy::vec_init_then_push)]
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#exts}}
   {{#x-callback-params}}
@@ -7,7 +7,7 @@
   {{/x-callback-params}}
 {{/exts}}
 {{#allParams}}
-        param_{{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        param_{{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         context: &C) -> Result<{{{operationId}}}Response, ApiError>
     {

--- a/modules/openapi-generator/src/main/resources/rust-server/example-server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-server-operation.mustache
@@ -1,7 +1,7 @@
 {{#summary}}
     /// {{{.}}}
 {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#exts}}
   {{#x-callback-params}}
@@ -9,7 +9,7 @@
   {{/x-callback-params}}
 {{/exts}}
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         context: &C) -> Result<{{{operationId}}}Response, ApiError>
     {

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+#[cfg(feature = "mock")]
+use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
@@ -33,6 +35,7 @@ pub use auth::{AuthenticationApi, Claims};
   {{/apis}}
 {{/apiInfo}}
 /// API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait Api<C: Send + Sync> {
@@ -43,10 +46,10 @@ pub trait Api<C: Send + Sync> {
 {{#summary}}
     /// {{{.}}}
 {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         context: &C) -> Result<{{{operationId}}}Response, ApiError>;
 
@@ -57,9 +60,14 @@ pub trait Api<C: Send + Sync> {
 }
 
 /// API where `Context` isn't passed on every API call
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait ApiNoContext<C: Send + Sync> {
+    // The std::task::Context struct houses a reference to std::task::Waker with the lifetime <'a>.
+    // Adding an anonymous lifetime `'a` to allow mockall to create a mock object with the right lifetimes.
+    // This is needed because the compiler is unable to determine the lifetimes on F's trait bound
+    // where F is the closure created by mockall. We use higher-rank trait bounds here to get around this.
 
     fn context(&self) -> &C;
 
@@ -70,10 +78,10 @@ pub trait ApiNoContext<C: Send + Sync> {
 {{#summary}}
     /// {{{.}}}
 {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         ) -> Result<{{{operationId}}}Response, ApiError>;
 
@@ -109,10 +117,10 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
 {{#summary}}
     /// {{{.}}}
 {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         ) -> Result<{{{operationId}}}Response, ApiError>
     {
@@ -146,6 +154,7 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
 {{/apiInfo}}
 
 /// Callback API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 pub trait CallbackApi<C: Send + Sync> {
 
@@ -159,7 +168,7 @@ pub trait CallbackApi<C: Send + Sync> {
 {{#summary}}
     /// {{{.}}}
 {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#exts}}
   {{#x-callback-params}}
@@ -167,7 +176,7 @@ pub trait CallbackApi<C: Send + Sync> {
   {{/x-callback-params}}
 {{/exts}}
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         context: &C) -> Result<{{{operationId}}}Response, ApiError>;
 
@@ -181,6 +190,7 @@ pub trait CallbackApi<C: Send + Sync> {
 }
 
 /// Callback API without a `Context`
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 pub trait CallbackApiNoContext<C: Send + Sync> {
 
@@ -196,7 +206,7 @@ pub trait CallbackApiNoContext<C: Send + Sync> {
 {{#summary}}
     /// {{{.}}}
 {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#exts}}
   {{#x-callback-params}}
@@ -204,7 +214,7 @@ pub trait CallbackApiNoContext<C: Send + Sync> {
   {{/x-callback-params}}
 {{/exts}}
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         ) -> Result<{{{operationId}}}Response, ApiError>;
 
@@ -246,7 +256,7 @@ impl<T: CallbackApi<C> + Send + Sync, C: Clone + Send + Sync> CallbackApiNoConte
               {{#summary}}
     /// {{{.}}}
               {{/summary}}
-    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}(
+    async fn {{#exts}}{{{x-operation-id}}}{{/exts}}{{#exts.x-has-borrowed-params}}<'a>{{/exts.x-has-borrowed-params}}(
         &self,
 {{#exts}}
   {{#x-callback-params}}
@@ -254,7 +264,7 @@ impl<T: CallbackApi<C> + Send + Sync, C: Clone + Send + Sync> CallbackApiNoConte
   {{/x-callback-params}}
 {{/exts}}
 {{#allParams}}
-        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{{dataType}}}{{^required}}>{{/required}},
+        {{{paramName}}}: {{^required}}Option<{{/required}}{{#isArray}}&{{/isArray}}{{#exts.x-param-needs-lifetime}}'a {{/exts.x-param-needs-lifetime}}{{{dataType}}}{{^required}}>{{/required}},
 {{/allParams}}
         ) -> Result<{{{operationId}}}Response, ApiError>
     {

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -24,6 +24,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -41,6 +43,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+#[cfg(feature = "mock")]
+use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
@@ -39,6 +41,7 @@ pub enum MultipleIdenticalMimeTypesPostResponse {
 }
 
 /// API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait Api<C: Send + Sync> {
@@ -66,9 +69,14 @@ pub trait Api<C: Send + Sync> {
 }
 
 /// API where `Context` isn't passed on every API call
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait ApiNoContext<C: Send + Sync> {
+    // The std::task::Context struct houses a reference to std::task::Waker with the lifetime <'a>.
+    // Adding an anonymous lifetime `'a` to allow mockall to create a mock object with the right lifetimes.
+    // This is needed because the compiler is unable to determine the lifetimes on F's trait bound
+    // where F is the closure created by mockall. We use higher-rank trait bounds here to get around this.
 
     fn context(&self) -> &C;
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -20,6 +20,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -37,6 +39,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+#[cfg(feature = "mock")]
+use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
@@ -27,6 +29,7 @@ pub enum OpGetResponse {
 }
 
 /// API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait Api<C: Send + Sync> {
@@ -38,9 +41,14 @@ pub trait Api<C: Send + Sync> {
 }
 
 /// API where `Context` isn't passed on every API call
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait ApiNoContext<C: Send + Sync> {
+    // The std::task::Context struct houses a reference to std::task::Waker with the lifetime <'a>.
+    // Adding an anonymous lifetime `'a` to allow mockall to create a mock object with the right lifetimes.
+    // This is needed because the compiler is unable to determine the lifetimes on F's trait bound
+    // where F is the closure created by mockall. We use higher-rank trait bounds here to get around this.
 
     fn context(&self) -> &C;
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -23,6 +23,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -40,6 +42,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -176,9 +176,9 @@ use swagger::ApiError;
 #[async_trait]
 impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
 {
-    async fn any_of_get(
+    async fn any_of_get<'a>(
         &self,
-        any_of: Option<&Vec<models::AnyOfObject>>,
+        any_of: Option<&'a Vec<models::AnyOfObject>>,
         context: &C) -> Result<AnyOfGetResponse, ApiError>
     {
         info!("any_of_get({:?}) - X-Span-ID: {:?}", any_of, context.get().0.clone());
@@ -194,9 +194,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
-    async fn complex_query_param_get(
+    async fn complex_query_param_get<'a>(
         &self,
-        list_of_strings: Option<&Vec<models::StringObject>>,
+        list_of_strings: Option<&'a Vec<models::StringObject>>,
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>
     {
         info!("complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
@@ -204,9 +204,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// Test examples
-    async fn examples_test(
+    async fn examples_test<'a>(
         &self,
-        ids: Option<&Vec<String>>,
+        ids: Option<&'a Vec<String>>,
         context: &C) -> Result<ExamplesTestResponse, ApiError>
     {
         info!("examples_test({:?}) - X-Span-ID: {:?}", ids, context.get().0.clone());
@@ -214,9 +214,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// Test a Form Post
-    async fn form_test(
+    async fn form_test<'a>(
         &self,
-        required_array: &Vec<String>,
+        required_array: &'a Vec<String>,
         enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>
     {
@@ -233,9 +233,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 
-    async fn json_complex_query_param_get(
+    async fn json_complex_query_param_get<'a>(
         &self,
-        list_of_strings: Option<&Vec<models::StringObject>>,
+        list_of_strings: Option<&'a Vec<models::StringObject>>,
         context: &C) -> Result<JsonComplexQueryParamGetResponse, ApiError>
     {
         info!("json_complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -439,9 +439,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
 {
 
     #[allow(clippy::vec_init_then_push)]
-    async fn any_of_get(
+    async fn any_of_get<'a>(
         &self,
-        param_any_of: Option<&Vec<models::AnyOfObject>>,
+        param_any_of: Option<&'a Vec<models::AnyOfObject>>,
         context: &C) -> Result<AnyOfGetResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -629,9 +629,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn complex_query_param_get(
+    async fn complex_query_param_get<'a>(
         &self,
-        param_list_of_strings: Option<&Vec<models::StringObject>>,
+        param_list_of_strings: Option<&'a Vec<models::StringObject>>,
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -702,9 +702,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn examples_test(
+    async fn examples_test<'a>(
         &self,
-        param_ids: Option<&Vec<String>>,
+        param_ids: Option<&'a Vec<String>>,
         context: &C) -> Result<ExamplesTestResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -787,9 +787,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn form_test(
+    async fn form_test<'a>(
         &self,
-        param_required_array: &Vec<String>,
+        param_required_array: &'a Vec<String>,
         param_enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>
     {
@@ -949,9 +949,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn json_complex_query_param_get(
+    async fn json_complex_query_param_get<'a>(
         &self,
-        param_list_of_strings: Option<&Vec<models::StringObject>>,
+        param_list_of_strings: Option<&'a Vec<models::StringObject>>,
         context: &C) -> Result<JsonComplexQueryParamGetResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -20,6 +20,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -37,6 +39,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -24,6 +24,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -41,6 +43,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
@@ -286,11 +286,11 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// To test enum parameters
-    async fn test_enum_parameters(
+    async fn test_enum_parameters<'a>(
         &self,
-        enum_header_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_header_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_header_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
-        enum_query_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_query_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_query_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
         enum_query_integer: Option<models::TestEnumParametersEnumQueryIntegerParameter>,
         enum_query_double: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
@@ -352,9 +352,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// Finds Pets by status
-    async fn find_pets_by_status(
+    async fn find_pets_by_status<'a>(
         &self,
-        status: &Vec<models::FindPetsByStatusStatusParameterInner>,
+        status: &'a Vec<models::FindPetsByStatusStatusParameterInner>,
         context: &C) -> Result<FindPetsByStatusResponse, ApiError>
     {
         info!("find_pets_by_status({:?}) - X-Span-ID: {:?}", status, context.get().0.clone());
@@ -362,9 +362,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// Finds Pets by tags
-    async fn find_pets_by_tags(
+    async fn find_pets_by_tags<'a>(
         &self,
-        tags: &Vec<String>,
+        tags: &'a Vec<String>,
         context: &C) -> Result<FindPetsByTagsResponse, ApiError>
     {
         info!("find_pets_by_tags({:?}) - X-Span-ID: {:?}", tags, context.get().0.clone());
@@ -476,9 +476,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// Creates list of users with given input array
-    async fn create_users_with_array_input(
+    async fn create_users_with_array_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         context: &C) -> Result<CreateUsersWithArrayInputResponse, ApiError>
     {
         info!("create_users_with_array_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
@@ -486,9 +486,9 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     }
 
     /// Creates list of users with given input array
-    async fn create_users_with_list_input(
+    async fn create_users_with_list_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         context: &C) -> Result<CreateUsersWithListInputResponse, ApiError>
     {
         info!("create_users_with_list_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -1390,11 +1390,11 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn test_enum_parameters(
+    async fn test_enum_parameters<'a>(
         &self,
-        param_enum_header_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        param_enum_header_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         param_enum_header_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
-        param_enum_query_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        param_enum_query_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         param_enum_query_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
         param_enum_query_integer: Option<models::TestEnumParametersEnumQueryIntegerParameter>,
         param_enum_query_double: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
@@ -1968,9 +1968,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn find_pets_by_status(
+    async fn find_pets_by_status<'a>(
         &self,
-        param_status: &Vec<models::FindPetsByStatusStatusParameterInner>,
+        param_status: &'a Vec<models::FindPetsByStatusStatusParameterInner>,
         context: &C) -> Result<FindPetsByStatusResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -2076,9 +2076,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn find_pets_by_tags(
+    async fn find_pets_by_tags<'a>(
         &self,
-        param_tags: &Vec<String>,
+        param_tags: &'a Vec<String>,
         context: &C) -> Result<FindPetsByTagsResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -3201,9 +3201,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn create_users_with_array_input(
+    async fn create_users_with_array_input<'a>(
         &self,
-        param_body: &Vec<models::User>,
+        param_body: &'a Vec<models::User>,
         context: &C) -> Result<CreateUsersWithArrayInputResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -3278,9 +3278,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
     }
 
     #[allow(clippy::vec_init_then_push)]
-    async fn create_users_with_list_input(
+    async fn create_users_with_list_input<'a>(
         &self,
-        param_body: &Vec<models::User>,
+        param_body: &'a Vec<models::User>,
         context: &C) -> Result<CreateUsersWithListInputResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+#[cfg(feature = "mock")]
+use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
@@ -322,6 +324,7 @@ pub enum UpdateUserResponse {
 }
 
 /// API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait Api<C: Send + Sync> {
@@ -391,11 +394,11 @@ pub trait Api<C: Send + Sync> {
         context: &C) -> Result<TestEndpointParametersResponse, ApiError>;
 
     /// To test enum parameters
-    async fn test_enum_parameters(
+    async fn test_enum_parameters<'a>(
         &self,
-        enum_header_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_header_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_header_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
-        enum_query_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_query_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_query_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
         enum_query_integer: Option<models::TestEnumParametersEnumQueryIntegerParameter>,
         enum_query_double: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
@@ -433,15 +436,15 @@ pub trait Api<C: Send + Sync> {
         context: &C) -> Result<AddPetResponse, ApiError>;
 
     /// Finds Pets by status
-    async fn find_pets_by_status(
+    async fn find_pets_by_status<'a>(
         &self,
-        status: &Vec<models::FindPetsByStatusStatusParameterInner>,
+        status: &'a Vec<models::FindPetsByStatusStatusParameterInner>,
         context: &C) -> Result<FindPetsByStatusResponse, ApiError>;
 
     /// Finds Pets by tags
-    async fn find_pets_by_tags(
+    async fn find_pets_by_tags<'a>(
         &self,
-        tags: &Vec<String>,
+        tags: &'a Vec<String>,
         context: &C) -> Result<FindPetsByTagsResponse, ApiError>;
 
     /// Update an existing pet
@@ -509,15 +512,15 @@ pub trait Api<C: Send + Sync> {
         context: &C) -> Result<CreateUserResponse, ApiError>;
 
     /// Creates list of users with given input array
-    async fn create_users_with_array_input(
+    async fn create_users_with_array_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         context: &C) -> Result<CreateUsersWithArrayInputResponse, ApiError>;
 
     /// Creates list of users with given input array
-    async fn create_users_with_list_input(
+    async fn create_users_with_list_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         context: &C) -> Result<CreateUsersWithListInputResponse, ApiError>;
 
     /// Logs user into the system
@@ -554,9 +557,14 @@ pub trait Api<C: Send + Sync> {
 }
 
 /// API where `Context` isn't passed on every API call
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait ApiNoContext<C: Send + Sync> {
+    // The std::task::Context struct houses a reference to std::task::Waker with the lifetime <'a>.
+    // Adding an anonymous lifetime `'a` to allow mockall to create a mock object with the right lifetimes.
+    // This is needed because the compiler is unable to determine the lifetimes on F's trait bound
+    // where F is the closure created by mockall. We use higher-rank trait bounds here to get around this.
 
     fn context(&self) -> &C;
 
@@ -626,11 +634,11 @@ pub trait ApiNoContext<C: Send + Sync> {
         ) -> Result<TestEndpointParametersResponse, ApiError>;
 
     /// To test enum parameters
-    async fn test_enum_parameters(
+    async fn test_enum_parameters<'a>(
         &self,
-        enum_header_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_header_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_header_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
-        enum_query_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_query_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_query_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
         enum_query_integer: Option<models::TestEnumParametersEnumQueryIntegerParameter>,
         enum_query_double: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
@@ -668,15 +676,15 @@ pub trait ApiNoContext<C: Send + Sync> {
         ) -> Result<AddPetResponse, ApiError>;
 
     /// Finds Pets by status
-    async fn find_pets_by_status(
+    async fn find_pets_by_status<'a>(
         &self,
-        status: &Vec<models::FindPetsByStatusStatusParameterInner>,
+        status: &'a Vec<models::FindPetsByStatusStatusParameterInner>,
         ) -> Result<FindPetsByStatusResponse, ApiError>;
 
     /// Finds Pets by tags
-    async fn find_pets_by_tags(
+    async fn find_pets_by_tags<'a>(
         &self,
-        tags: &Vec<String>,
+        tags: &'a Vec<String>,
         ) -> Result<FindPetsByTagsResponse, ApiError>;
 
     /// Update an existing pet
@@ -744,15 +752,15 @@ pub trait ApiNoContext<C: Send + Sync> {
         ) -> Result<CreateUserResponse, ApiError>;
 
     /// Creates list of users with given input array
-    async fn create_users_with_array_input(
+    async fn create_users_with_array_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         ) -> Result<CreateUsersWithArrayInputResponse, ApiError>;
 
     /// Creates list of users with given input array
-    async fn create_users_with_list_input(
+    async fn create_users_with_list_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         ) -> Result<CreateUsersWithListInputResponse, ApiError>;
 
     /// Logs user into the system
@@ -913,11 +921,11 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// To test enum parameters
-    async fn test_enum_parameters(
+    async fn test_enum_parameters<'a>(
         &self,
-        enum_header_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_header_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_header_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
-        enum_query_string_array: Option<&Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
+        enum_query_string_array: Option<&'a Vec<models::TestEnumParametersEnumHeaderStringArrayParameterInner>>,
         enum_query_string: Option<models::TestEnumParametersEnumHeaderStringParameter>,
         enum_query_integer: Option<models::TestEnumParametersEnumQueryIntegerParameter>,
         enum_query_double: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
@@ -979,9 +987,9 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// Finds Pets by status
-    async fn find_pets_by_status(
+    async fn find_pets_by_status<'a>(
         &self,
-        status: &Vec<models::FindPetsByStatusStatusParameterInner>,
+        status: &'a Vec<models::FindPetsByStatusStatusParameterInner>,
         ) -> Result<FindPetsByStatusResponse, ApiError>
     {
         let context = self.context().clone();
@@ -989,9 +997,9 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// Finds Pets by tags
-    async fn find_pets_by_tags(
+    async fn find_pets_by_tags<'a>(
         &self,
-        tags: &Vec<String>,
+        tags: &'a Vec<String>,
         ) -> Result<FindPetsByTagsResponse, ApiError>
     {
         let context = self.context().clone();
@@ -1103,9 +1111,9 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// Creates list of users with given input array
-    async fn create_users_with_array_input(
+    async fn create_users_with_array_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         ) -> Result<CreateUsersWithArrayInputResponse, ApiError>
     {
         let context = self.context().clone();
@@ -1113,9 +1121,9 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// Creates list of users with given input array
-    async fn create_users_with_list_input(
+    async fn create_users_with_list_input<'a>(
         &self,
-        body: &Vec<models::User>,
+        body: &'a Vec<models::User>,
         ) -> Result<CreateUsersWithListInputResponse, ApiError>
     {
         let context = self.context().clone();

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -20,6 +20,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -37,6 +39,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/lib.rs
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+#[cfg(feature = "mock")]
+use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
@@ -27,6 +29,7 @@ pub enum PingGetResponse {
 }
 
 /// API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait Api<C: Send + Sync> {
@@ -37,9 +40,14 @@ pub trait Api<C: Send + Sync> {
 }
 
 /// API where `Context` isn't passed on every API call
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait ApiNoContext<C: Send + Sync> {
+    // The std::task::Context struct houses a reference to std::task::Waker with the lifetime <'a>.
+    // Adding an anonymous lifetime `'a` to allow mockall to create a mock object with the right lifetimes.
+    // This is needed because the compiler is unable to determine the lifetimes on F's trait bound
+    // where F is the closure created by mockall. We use higher-rank trait bounds here to get around this.
 
     fn context(&self) -> &C;
 

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -20,6 +20,8 @@ cli = [
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
+mock = ["mockall"]
+
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
 hyper-tls = { version = "0.6", optional = true }
@@ -37,6 +39,7 @@ swagger = { version = "7.0.0-rc2", features = ["serdejson", "server", "client", 
 headers = "0.4.0"
 log = "0.4.27"
 mime = "0.3"
+mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -3,6 +3,8 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+#[cfg(feature = "mock")]
+use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
@@ -80,6 +82,7 @@ pub enum SoloObjectPostResponse {
 }
 
 /// API
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait Api<C: Send + Sync> {
@@ -131,9 +134,14 @@ pub trait Api<C: Send + Sync> {
 }
 
 /// API where `Context` isn't passed on every API call
+#[cfg_attr(feature = "mock", automock)]
 #[async_trait]
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 pub trait ApiNoContext<C: Send + Sync> {
+    // The std::task::Context struct houses a reference to std::task::Waker with the lifetime <'a>.
+    // Adding an anonymous lifetime `'a` to allow mockall to create a mock object with the right lifetimes.
+    // This is needed because the compiler is unable to determine the lifetimes on F's trait bound
+    // where F is the closure created by mockall. We use higher-rank trait bounds here to get around this.
 
     fn context(&self) -> &C;
 


### PR DESCRIPTION
Enhancement to the rust-server generator to enable trait mocking using the mockall library. This enables consumers of an autogenerated server crate to mock the API for their tests. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10) @dsteeley (2025/07)