### PR TITLE
[JAVA](native-client) Add support for UnaryInterceptors

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/ApiClient.mustache
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 {{#useUnaryInterceptor}}
 import java.util.function.UnaryOperator;
 {{/useUnaryInterceptor}}
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -74,7 +75,6 @@ public class ApiClient {
   protected Consumer<HttpResponse<InputStream>> responseInterceptor;
   protected Consumer<HttpResponse<InputStream>> asyncResponseInterceptor;
 {{/useUnaryInterceptor}}
-
   protected Duration readTimeout;
   protected Duration connectTimeout;
 
@@ -345,7 +345,8 @@ public class ApiClient {
    * request builder is passed into this function for further modification,
    * after which it is sent out.</p>
    *
-   *<p>This is useful for altering the requests in a custom manner, such as adding headers. It could also be used for logging and monitoring.</p>
+   * <p>This is useful for altering the requests in a custom manner, such as
+   * adding headers. It could also be used for logging and monitoring.</p>
    *
    * @param interceptor A function invoked before creating each request. A value
    *                    of null resets the interceptor to a no-op.

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.stream.Collectors;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -65,7 +66,6 @@ public class ApiClient {
   protected Consumer<HttpRequest.Builder> interceptor;
   protected Consumer<HttpResponse<InputStream>> responseInterceptor;
   protected Consumer<HttpResponse<InputStream>> asyncResponseInterceptor;
-
   protected Duration readTimeout;
   protected Duration connectTimeout;
 
@@ -334,7 +334,8 @@ public class ApiClient {
    * request builder is passed into this function for further modification,
    * after which it is sent out.</p>
    *
-   *<p>This is useful for altering the requests in a custom manner, such as adding headers. It could also be used for logging and monitoring.</p>
+   * <p>This is useful for altering the requests in a custom manner, such as
+   * adding headers. It could also be used for logging and monitoring.</p>
    *
    * @param interceptor A function invoked before creating each request. A value
    *                    of null resets the interceptor to a no-op.

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiClient.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.stream.Collectors;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -65,7 +66,6 @@ public class ApiClient {
   protected Consumer<HttpRequest.Builder> interceptor;
   protected Consumer<HttpResponse<InputStream>> responseInterceptor;
   protected Consumer<HttpResponse<InputStream>> asyncResponseInterceptor;
-
   protected Duration readTimeout;
   protected Duration connectTimeout;
 
@@ -334,7 +334,8 @@ public class ApiClient {
    * request builder is passed into this function for further modification,
    * after which it is sent out.</p>
    *
-   *<p>This is useful for altering the requests in a custom manner, such as adding headers. It could also be used for logging and monitoring.</p>
+   * <p>This is useful for altering the requests in a custom manner, such as
+   * adding headers. It could also be used for logging and monitoring.</p>
    *
    * @param interceptor A function invoked before creating each request. A value
    *                    of null resets the interceptor to a no-op.

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.stream.Collectors;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -65,7 +66,6 @@ public class ApiClient {
   protected Consumer<HttpRequest.Builder> interceptor;
   protected Consumer<HttpResponse<InputStream>> responseInterceptor;
   protected Consumer<HttpResponse<InputStream>> asyncResponseInterceptor;
-
   protected Duration readTimeout;
   protected Duration connectTimeout;
 
@@ -334,7 +334,8 @@ public class ApiClient {
    * request builder is passed into this function for further modification,
    * after which it is sent out.</p>
    *
-   *<p>This is useful for altering the requests in a custom manner, such as adding headers. It could also be used for logging and monitoring.</p>
+   * <p>This is useful for altering the requests in a custom manner, such as
+   * adding headers. It could also be used for logging and monitoring.</p>
    *
    * @param interceptor A function invoked before creating each request. A value
    *                    of null resets the interceptor to a no-op.

--- a/samples/client/petstore/java/native-useGzipFeature/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native-useGzipFeature/src/main/java/org/openapitools/client/ApiClient.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.stream.Collectors;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -65,7 +66,6 @@ public class ApiClient {
   protected Consumer<HttpRequest.Builder> interceptor;
   protected Consumer<HttpResponse<InputStream>> responseInterceptor;
   protected Consumer<HttpResponse<InputStream>> asyncResponseInterceptor;
-
   protected Duration readTimeout;
   protected Duration connectTimeout;
 
@@ -334,7 +334,8 @@ public class ApiClient {
    * request builder is passed into this function for further modification,
    * after which it is sent out.</p>
    *
-   *<p>This is useful for altering the requests in a custom manner, such as adding headers. It could also be used for logging and monitoring.</p>
+   * <p>This is useful for altering the requests in a custom manner, such as
+   * adding headers. It could also be used for logging and monitoring.</p>
    *
    * @param interceptor A function invoked before creating each request. A value
    *                    of null resets the interceptor to a no-op.

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiClient.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.stream.Collectors;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -65,7 +66,6 @@ public class ApiClient {
   protected Consumer<HttpRequest.Builder> interceptor;
   protected Consumer<HttpResponse<InputStream>> responseInterceptor;
   protected Consumer<HttpResponse<InputStream>> asyncResponseInterceptor;
-
   protected Duration readTimeout;
   protected Duration connectTimeout;
 
@@ -334,7 +334,8 @@ public class ApiClient {
    * request builder is passed into this function for further modification,
    * after which it is sent out.</p>
    *
-   *<p>This is useful for altering the requests in a custom manner, such as adding headers. It could also be used for logging and monitoring.</p>
+   * <p>This is useful for altering the requests in a custom manner, such as
+   * adding headers. It could also be used for logging and monitoring.</p>
    *
    * @param interceptor A function invoked before creating each request. A value
    *                    of null resets the interceptor to a no-op.


### PR DESCRIPTION
This Pr solves Issue: #22333  by adding Support for UnaryInterceptors in the Java-Native-Client

This is done by adding a new config option called "useUnaryInterceptor" which changes the Datatype of the ResponseInterceptor from a Consumer to a UnaryInterceptor. With a variable reassignment this allows for changing an incomming response before it gets passed.

This change doesn't break any existing Systems due to the default value of false for the "useUnaryInterceptor".
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)