### PR TITLE
fix: missing imports for array of files and date-time parameters

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -547,13 +547,15 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             }
             for (CodegenParameter param : operation.allParams) {
                 // import "os" if the operation uses files
-                if (!addedOSImport && "*os.File".equals(param.dataType)) {
+                if (!addedOSImport && ("*os.File".equals(param.dataType) ||
+                        (param.items != null && "*os.File".equals(param.items.dataType)))) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }
 
                 // import "time" if the operation has a time parameter.
-                if (!addedTimeImport && "time.Time".equals(param.dataType)) {
+                if (!addedTimeImport && ("time.Time".equals(param.dataType) ||
+                        (param.items != null && "time.Time".equals(param.items.dataType)))) {
                     imports.add(createMapping("import", "time"));
                     addedTimeImport = true;
                 }
@@ -648,13 +650,15 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             }
             for (CodegenParameter param : operation.allParams) {
                 // import "os" if the operation uses files
-                if (!addedOSImport && "*os.File".equals(param.dataType)) {
+                if (!addedOSImport && ("*os.File".equals(param.dataType) ||
+                        (param.items != null && "*os.File".equals(param.items.dataType)))) {
                     imports.add(createMapping("import", "os"));
                     addedOSImport = true;
                 }
 
                 // import "time" if the operation has a time parameter.
-                if (!addedTimeImport && "time.Time".equals(param.dataType)) {
+                if (!addedTimeImport && ("time.Time".equals(param.dataType) ||
+                        (param.items != null && "time.Time".equals(param.items.dataType)))) {
                     imports.add(createMapping("import", "time"));
                     addedTimeImport = true;
                 }


### PR DESCRIPTION
This pull request improves the Go code generator to correctly add necessary imports when operations or webhooks use array parameters of binary files or date-time types. It also adds new tests to verify this behavior. The main changes are in the logic for determining imports and in the test coverage. Fixes #22389

### Import logic improvements

* Updated `AbstractGoCodegen.java` to add the `"os"` import if any parameter is an array of binary files (`*os.File`), and the `"time"` import if any parameter is an array of date-time values (`time.Time`) in both `postProcessOperationsWithModels` and `postProcessWebhooksWithModels` methods. [[1]](diffhunk://#diff-a5fc9752c935154ba9de07c3a6cfae9e6a6fac95418980719164ea4026de7b69L550-R558) [[2]](diffhunk://#diff-a5fc9752c935154ba9de07c3a6cfae9e6a6fac95418980719164ea4026de7b69L651-R661)

### Test coverage

* Added new tests in `AbstractGoCodegenTest.java` to verify that the `"os"` import is added for array of binary file parameters and the `"time"` import is added for array of date-time parameters in operations.
* Included additional imports in the test file to support new test cases.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)
