### PR TITLE
Use description from child schema for ComposedSchema

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2820,6 +2820,9 @@ public class DefaultCodegen implements CodegenConfig {
 
                     // includes child's properties (all, required) in allProperties, allRequired
                     addProperties(allProperties, allRequired, component, new HashSet<>());
+
+                    // use description from child schema
+                    m.description = escapeText(component.getDescription());
                 }
                 // in 7.0.0 release, we comment out below to allow more than 1 child schemas in allOf
                 //break; // at most one child only

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinClientCodegenModelTest.java
@@ -675,6 +675,36 @@ public class KotlinClientCodegenModelTest {
         TestUtils.assertFileNotContains(modelKt, "data class EmptyModel");
     }
 
+    @Test(description = "provide description in kdoc of polymorphic type")
+    public void testDescriptionOnPolymorphicType() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("kotlin")
+                .setLibrary("jvm-okhttp4")
+                .setAdditionalProperties(new HashMap<>() {{
+                    put(CodegenConstants.SERIALIZATION_LIBRARY, "jackson");
+                    put(CodegenConstants.MODEL_PACKAGE, "xyz.abcdef.model");
+                }})
+                .setInputSpec("src/test/resources/3_0/kotlin/polymorphism-description.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        Assert.assertEquals(files.size(), 28);
+
+        final Path animalKt = Paths.get(output + "/src/main/kotlin/xyz/abcdef/model/Animal.kt");
+        // base has description
+        TestUtils.assertFileContains(animalKt, "Description on supertype");
+
+        final Path birdKt = Paths.get(output + "/src/main/kotlin/xyz/abcdef/model/Bird.kt");
+        // derived has description
+        TestUtils.assertFileContains(birdKt, "Description on subtype");
+    }
+
     private static class ModelNameTest {
         private final String expectedName;
         private final String expectedClassName;

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/polymorphism-description.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/polymorphism-description.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.1
+info:
+  title: Example
+  version: '0.1'
+servers:
+  - url: http://example.org
+paths:
+  '/v1/bird':
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bird'
+      operationId: get-bird
+components:
+  schemas:
+    animal:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id
+      discriminator:
+        propertyName: discriminator
+      description: 'Description on supertype'
+    bird:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/animal'
+        - properties:
+            featherType:
+              type: string
+          required:
+            - featherType
+          description: 'Description on subtype'


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
When generating models from allOf schemas, where one type is the parent and another is the child, the description from the child should be used.
The test was written for the kotlin generator, because that's what I'm using, but the fix applies generally.

I'm trying to be forward by providing a fix directly, but if this is not the correct solution, I can create an issue instead.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
