### PR TITLE
[typescript-nestjs-server] Fix #21842 by updating api.module.mustache

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs-server/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs-server/api.module.mustache
@@ -7,18 +7,30 @@ import { {{classname}}Controller } from './controllers';
 {{/apis}}
 {{/apiInfo}}
 
+export type ApiModuleConfiguration = {
+  /**
+  * your Api implementations
+  */
+  apiImplementations: ApiImplementations,
+  /**
+  * additional Providers that may be used by your implementations
+  */
+  providers?: Provider[],
+}
+
 @Module({})
 export class ApiModule {
-  static forRoot(apiImplementations: ApiImplementations): DynamicModule {
+  static forRoot(configuration: ApiModuleConfiguration): DynamicModule {
       const providers: Provider[] = [
 {{#apiInfo}}
 {{#apis}}
         {
           provide: {{classname}},
-          useClass: apiImplementations.{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}
+          useClass: configuration.apiImplementations.{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}
         },
 {{/apis}}
 {{/apiInfo}}
+        ...(configuration.providers || []),
       ];
 
       return {

--- a/samples/server/petstore/typescript-nestjs-server/builds/default/api.module.ts
+++ b/samples/server/petstore/typescript-nestjs-server/builds/default/api.module.ts
@@ -7,22 +7,34 @@ import { StoreApiController } from './controllers';
 import { UserApi } from './api';
 import { UserApiController } from './controllers';
 
+export type ApiModuleConfiguration = {
+  /**
+  * your Api implementations
+  */
+  apiImplementations: ApiImplementations,
+  /**
+  * additional Providers that may be used by your implementations
+  */
+  providers?: Provider[],
+}
+
 @Module({})
 export class ApiModule {
-  static forRoot(apiImplementations: ApiImplementations): DynamicModule {
+  static forRoot(configuration: ApiModuleConfiguration): DynamicModule {
       const providers: Provider[] = [
         {
           provide: PetApi,
-          useClass: apiImplementations.petApi
+          useClass: configuration.apiImplementations.petApi
         },
         {
           provide: StoreApi,
-          useClass: apiImplementations.storeApi
+          useClass: configuration.apiImplementations.storeApi
         },
         {
           provide: UserApi,
-          useClass: apiImplementations.userApi
+          useClass: configuration.apiImplementations.userApi
         },
+        ...(configuration.providers || []),
       ];
 
       return {

--- a/samples/server/petstore/typescript-nestjs-server/package-lock.json
+++ b/samples/server/petstore/typescript-nestjs-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nest-openapi-poc",
+  "name": "typescript-nestjs-server",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nest-openapi-poc",
+      "name": "typescript-nestjs-server",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {

--- a/samples/server/petstore/typescript-nestjs-server/src/TestService.ts
+++ b/samples/server/petstore/typescript-nestjs-server/src/TestService.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class TestService {
+  hello(): string {
+    return "Hello World";
+  }
+}

--- a/samples/server/petstore/typescript-nestjs-server/src/app.module.ts
+++ b/samples/server/petstore/typescript-nestjs-server/src/app.module.ts
@@ -3,14 +3,18 @@ import { PetService } from './handlers/PetService';
 import { UserService } from './handlers/UserService';
 import { StoreService } from './handlers/StoreService';
 import { ApiModule } from '../builds/default';
+import { TestService } from './TestService';
 
 @Module({
   imports: [
     ApiModule.forRoot({
-      petApi: PetService,
-      userApi: UserService,
-      storeApi: StoreService,
-    }),
+      apiImplementations: {
+        petApi: PetService,
+        userApi: UserService,
+        storeApi: StoreService,
+    },
+    providers: [TestService]
+}),
   ],
   controllers: [],
   providers: [],

--- a/samples/server/petstore/typescript-nestjs-server/src/handlers/PetService.ts
+++ b/samples/server/petstore/typescript-nestjs-server/src/handlers/PetService.ts
@@ -3,9 +3,13 @@ import { Observable } from 'rxjs';
 import { Injectable } from '@nestjs/common';
 import { PetApi } from '../../builds/default/api';
 import { ApiResponse, Pet } from '../../builds/default/models';
+import { TestService } from '../TestService'
 
 @Injectable()
 export class PetService implements PetApi {
+
+  constructor(private readonly testService: TestService) {}
+
   addPet(pet: Pet, request: Request): Pet | Promise<Pet> | Observable<Pet> {
     console.log(JSON.stringify(pet));
     return pet;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fixes #21842

NestJS cannot resolve dependencies not known to the generated module without workarounds. This PR introduces the ability to specify providers when initializing the `ApiModule`.

A service injected into an implementation can now be specified with the providers parameter.

```typescript
@Injectable()
export class TestService {
    hello(): string {
        return "Hello World";
    }
}

@Injectable()
export class PetService implements PetApi {
    constructor(private readonly testService: TestService) {}
}

@Module({
    imports: [
        ApiModule.forRoot({
            apiImplementations: {
                petApi: PetService,
            },
            providers: [
                TestService
            ]
        }),
    ],
    controllers: [],
    providers: [],
})
export class AppModule {}
```
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04) @joscha (2024/10) @wing328  