### PR TITLE
[cpp-rest] Fixes segfault for nullable strings

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-header.mustache
@@ -16,6 +16,7 @@
 #include <variant>
 {{/-first}}
 {{/oneOf}}
+#include <boost/optional.hpp>
 {{^parent}}
 {{{defaultInclude}}}
 #include "{{packageName}}/ModelBase.h"
@@ -264,6 +265,15 @@ public:
 protected:
     {{#vars}}
     {{^isInherited}}
+    {{#isNullable}}
+    {{^isEnum}}
+    boost::optional<{{{dataType}}}> m_{{name}};
+    {{/isEnum}}
+    {{#isEnum}}
+    boost::optional<{{^isMap}}{{{datatypeWithEnum}}}{{/isMap}}{{#isMap}}{{{dataType}}}{{/isMap}}> m_{{name}};
+    {{/isEnum}}
+    {{/isNullable}}
+    {{^isNullable}}
     {{^isEnum}}
     {{{dataType}}} m_{{name}};
     {{/isEnum}}
@@ -271,6 +281,7 @@ protected:
     {{^isMap}}{{{datatypeWithEnum}}}{{/isMap}}{{#isMap}}{{{dataType}}}{{/isMap}} m_{{name}};
     {{/isEnum}}
     bool m_{{name}}IsSet;
+    {{/isNullable}}
     {{/isInherited}}
 
     {{/vars}}

--- a/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-rest-sdk-client/model-source.mustache
@@ -187,6 +187,7 @@ void {{classname}}::setValue({{classname}}::e{{classname}} const value)
 {
     {{#vars}}
     {{^isInherited}}
+    {{^isNullable}}
     {{^isContainer}}
     {{^isEnum}}
     {{#isPrimitiveType}}
@@ -203,6 +204,7 @@ void {{classname}}::setValue({{classname}}::e{{classname}} const value)
     {{/isEnum}}
     {{/isContainer}}
     m_{{name}}IsSet = false;
+    {{/isNullable}}
     {{/isInherited}}
     {{/vars}}
 }
@@ -226,8 +228,25 @@ web::json::value {{classname}}::toJson() const
     {{/parent}}
     {{#vars}}
     {{^isInherited}}
+    {{#isNullable}}
+    if(m_{{name}}.has_value())
+    {
+        {{#isEnum}}{{#isContainer}}{{#isArray}}
+        {{{dataType}}} refVal = from{{{enumName}}}(m_{{name}}.get());
+        {{/isArray}}{{#isMap}}
+        val[utility::conversions::to_string_t(_XPLATSTR("{{baseName}}"))] = ModelBase::toJson(m_{{name}}.get());
+        {{/isMap}}{{/isContainer}}{{^isContainer}}
+        utility::string_t refVal = from{{{datatypeWithEnum}}}(m_{{name}}.get());
+        {{/isContainer}}{{^isMap}}val[utility::conversions::to_string_t(_XPLATSTR("{{baseName}}"))] = ModelBase::toJson(refVal);
+        {{/isMap}}{{/isEnum}}
+        {{^isEnum}}
+        val[utility::conversions::to_string_t(_XPLATSTR("{{baseName}}"))] = ModelBase::toJson(m_{{name}}.get());
+        {{/isEnum}}
+    }
+    {{/isNullable}}
+    {{^isNullable}}
     if(m_{{name}}IsSet)
-    {   
+    {
         {{#isEnum}}{{#isContainer}}{{#isArray}}
         {{{dataType}}} refVal = from{{{enumName}}}(m_{{name}});
         {{/isArray}}{{#isMap}}
@@ -240,6 +259,7 @@ web::json::value {{classname}}::toJson() const
         val[utility::conversions::to_string_t(_XPLATSTR("{{baseName}}"))] = ModelBase::toJson(m_{{name}});
         {{/isEnum}}
     }
+    {{/isNullable}}
     {{/isInherited}}
     {{/vars}}
 
@@ -286,6 +306,27 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
         namePrefix += utility::conversions::to_string_t(_XPLATSTR("."));
     }
     {{#vars}}
+    {{#isNullable}}
+    if(m_{{name}}.has_value())
+    {
+        {{^isEnum}}
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("{{baseName}}")), m_{{name}}.get()));
+        {{/isEnum}}
+        {{#isEnum}}
+	{{#isContainer}}
+	{{#isArray}}
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("{{baseName}}")), from{{{enumName}}}(m_{{name}}.get())));
+        {{/isArray}}{{#isMap}}
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("{{baseName}}")), m_{{name}}.get()));
+        {{/isMap}}
+	{{/isContainer}}
+	{{^isContainer}}
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("{{baseName}}")), from{{{datatypeWithEnum}}}(m_{{name}}.get())));
+        {{/isContainer}}
+	{{/isEnum}}
+    }
+    {{/isNullable}}
+    {{^isNullable}}
     if(m_{{name}}IsSet)
     {
         {{^isEnum}}
@@ -304,6 +345,7 @@ void {{classname}}::toMultipart(std::shared_ptr<MultipartFormData> multipart, co
         {{/isContainer}}
 	{{/isEnum}}
     }
+    {{/isNullable}}
     {{/vars}}
 }
 
@@ -405,7 +447,12 @@ const {{dataType}} {{classname}}::from{{{datatypeWithEnum}}}(const {{{datatypeWi
 {{^isEnum}}
 {{{dataType}}} {{classname}}::{{getter}}() const
 {
+    {{#isNullable}}
+    return m_{{name}}.get();
+    {{/isNullable}}
+    {{^isNullable}}
     return m_{{name}};
+    {{/isNullable}}
 }
 {{/isEnum}}
 {{/isContainer}}
@@ -413,14 +460,24 @@ const {{dataType}} {{classname}}::from{{{datatypeWithEnum}}}(const {{{datatypeWi
 {{^isEnum}}
 {{{dataType}}} {{classname}}::{{getter}}() const
 {
+    {{#isNullable}}
+    return m_{{name}}.get();
+    {{/isNullable}}
+    {{^isNullable}}
     return m_{{name}};
+    {{/isNullable}}
 }
 {{/isEnum}}
 {{/isContainer}}
 {{#isEnum}}
 {{^isMap}}{{#isArray}}{{{baseType}}}<{{/isArray}}{{{classname}}}::{{{enumName}}}{{#isArray}}>{{/isArray}}{{/isMap}}{{#isMap}}{{{dataType}}}{{/isMap}} {{classname}}::{{getter}}() const
 {
+    {{#isNullable}}
+    return m_{{name}}.get();
+    {{/isNullable}}
+    {{^isNullable}}
     return m_{{name}};
+    {{/isNullable}}
 }
 {{/isEnum}}
 
@@ -433,17 +490,29 @@ void {{classname}}::{{setter}}(const {{^isMap}}{{{datatypeWithEnum}}}{{/isMap}}{
 {{/isEnum}}
 {
     m_{{name}} = value;
+    {{^isNullable}}
     m_{{name}}IsSet = true;
+    {{/isNullable}}
 }
 
 bool {{classname}}::{{nameInCamelCase}}IsSet() const
 {
+    {{#isNullable}}
+    return m_{{name}}.has_value();
+    {{/isNullable}}
+    {{^isNullable}}
     return m_{{name}}IsSet;
+    {{/isNullable}}
 }
 
 void {{classname}}::unset{{name}}()
 {
+    {{#isNullable}}
+    m_{{name}}.reset();
+    {{/isNullable}}
+    {{^isNullable}}
     m_{{name}}IsSet = false;
+    {{/isNullable}}
 }
 {{/isInherited}}{{/vars}}
 {{/isEnum}}

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/ApiResponse.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/ApiResponse.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_ApiResponse_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_ApiResponse_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Category.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Category.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_Category_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Category_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Color.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Color.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_Color_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Color_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/CreateUserOrPet_request.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/CreateUserOrPet_request.h
@@ -20,6 +20,7 @@
 
 #include <stdexcept>
 #include <variant>
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Order.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Order.h
@@ -19,6 +19,7 @@
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Order_H_
 
 #include <stdexcept>
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Page.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Page.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_Page_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Page_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Pet.h
@@ -19,6 +19,7 @@
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Pet_H_
 
 #include <stdexcept>
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/SchemaWithSet.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/SchemaWithSet.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_SchemaWithSet_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_SchemaWithSet_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/SchemaWithSet_vaccinationBook.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/SchemaWithSet_vaccinationBook.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_SchemaWithSet_vaccinationBook_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_SchemaWithSet_vaccinationBook_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Tag.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Tag.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_Tag_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Tag_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/User.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/User.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_User_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_User_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 

--- a/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Vaccine.h
+++ b/samples/client/petstore/cpp-restsdk/client/include/CppRestPetstoreClient/model/Vaccine.h
@@ -18,6 +18,7 @@
 #ifndef ORG_OPENAPITOOLS_CLIENT_MODEL_Vaccine_H_
 #define ORG_OPENAPITOOLS_CLIENT_MODEL_Vaccine_H_
 
+#include <boost/optional.hpp>
 
 #include "CppRestPetstoreClient/ModelBase.h"
 
@@ -71,8 +72,7 @@ public:
 
 
 protected:
-    std::shared_ptr<AnyType> m_date;
-    bool m_dateIsSet;
+    boost::optional<std::shared_ptr<AnyType>> m_date;
 
     bool m_BoosterRequired;
     bool m_BoosterRequiredIsSet;

--- a/samples/client/petstore/cpp-restsdk/client/src/model/ApiResponse.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/ApiResponse.cpp
@@ -41,17 +41,17 @@ web::json::value ApiResponse::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_CodeIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("code"))] = ModelBase::toJson(m_Code);
     }
     if(m_TypeIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("type"))] = ModelBase::toJson(m_Type);
     }
     if(m_MessageIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("message"))] = ModelBase::toJson(m_Message);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Category.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Category.cpp
@@ -39,12 +39,12 @@ web::json::value Category::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_IdIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("id"))] = ModelBase::toJson(m_Id);
     }
     if(m_NameIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("name"))] = ModelBase::toJson(m_Name);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Order.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Order.cpp
@@ -46,34 +46,34 @@ web::json::value Order::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_IdIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("id"))] = ModelBase::toJson(m_Id);
     }
     if(m_PetIdIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("petId"))] = ModelBase::toJson(m_PetId);
     }
     if(m_QuantityIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("quantity"))] = ModelBase::toJson(m_Quantity);
     }
     if(m_ShipDateIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("shipDate"))] = ModelBase::toJson(m_ShipDate);
     }
     if(m_StatusIsSet)
-    {   
+    {
         
         utility::string_t refVal = fromStatusEnum(m_Status);
         val[utility::conversions::to_string_t(_XPLATSTR("status"))] = ModelBase::toJson(refVal);
         
     }
     if(m_CompleteIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("complete"))] = ModelBase::toJson(m_Complete);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Page.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Page.cpp
@@ -40,17 +40,17 @@ web::json::value Page::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_PageIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("page"))] = ModelBase::toJson(m_Page);
     }
     if(m_PerPageIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("perPage"))] = ModelBase::toJson(m_PerPage);
     }
     if(m_Reference_testIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("reference_test"))] = ModelBase::toJson(m_Reference_test);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Pet.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Pet.cpp
@@ -44,39 +44,39 @@ web::json::value Pet::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_IdIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("id"))] = ModelBase::toJson(m_Id);
     }
     if(m_CategoryIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("category"))] = ModelBase::toJson(m_Category);
     }
     if(m_NameIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("name"))] = ModelBase::toJson(m_Name);
     }
     if(m_PhotoUrlsIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("photoUrls"))] = ModelBase::toJson(m_PhotoUrls);
     }
     if(m_TagsIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("tags"))] = ModelBase::toJson(m_Tags);
     }
     if(m_StatusIsSet)
-    {   
+    {
         
         utility::string_t refVal = fromStatusEnum(m_Status);
         val[utility::conversions::to_string_t(_XPLATSTR("status"))] = ModelBase::toJson(refVal);
         
     }
     if(m_MetadataIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("metadata"))] = ModelBase::toJson(m_Metadata);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/SchemaWithSet.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/SchemaWithSet.cpp
@@ -37,12 +37,12 @@ web::json::value SchemaWithSet::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_CertificatesIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("certificates"))] = ModelBase::toJson(m_Certificates);
     }
     if(m_VaccinationBookIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("vaccinationBook"))] = ModelBase::toJson(m_VaccinationBook);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/SchemaWithSet_vaccinationBook.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/SchemaWithSet_vaccinationBook.cpp
@@ -36,7 +36,7 @@ web::json::value SchemaWithSet_vaccinationBook::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_VaccinesIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("vaccines"))] = ModelBase::toJson(m_Vaccines);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Tag.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Tag.cpp
@@ -39,12 +39,12 @@ web::json::value Tag::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_IdIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("id"))] = ModelBase::toJson(m_Id);
     }
     if(m_NameIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("name"))] = ModelBase::toJson(m_Name);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/User.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/User.cpp
@@ -51,42 +51,42 @@ web::json::value User::toJson() const
 {
     web::json::value val = web::json::value::object();
     if(m_IdIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("id"))] = ModelBase::toJson(m_Id);
     }
     if(m_UsernameIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("username"))] = ModelBase::toJson(m_Username);
     }
     if(m_FirstNameIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("firstName"))] = ModelBase::toJson(m_FirstName);
     }
     if(m_LastNameIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("lastName"))] = ModelBase::toJson(m_LastName);
     }
     if(m_EmailIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("email"))] = ModelBase::toJson(m_Email);
     }
     if(m_PasswordIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("password"))] = ModelBase::toJson(m_Password);
     }
     if(m_PhoneIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("phone"))] = ModelBase::toJson(m_Phone);
     }
     if(m_UserStatusIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("userStatus"))] = ModelBase::toJson(m_UserStatus);
     }

--- a/samples/client/petstore/cpp-restsdk/client/src/model/Vaccine.cpp
+++ b/samples/client/petstore/cpp-restsdk/client/src/model/Vaccine.cpp
@@ -20,7 +20,6 @@ namespace model {
 
 Vaccine::Vaccine()
 {
-    m_dateIsSet = false;
     m_BoosterRequired = false;
     m_BoosterRequiredIsSet = false;
 }
@@ -37,13 +36,13 @@ void Vaccine::validate()
 web::json::value Vaccine::toJson() const
 {
     web::json::value val = web::json::value::object();
-    if(m_dateIsSet)
-    {   
+    if(m_date.has_value())
+    {
         
-        val[utility::conversions::to_string_t(_XPLATSTR("date"))] = ModelBase::toJson(m_date);
+        val[utility::conversions::to_string_t(_XPLATSTR("date"))] = ModelBase::toJson(m_date.get());
     }
     if(m_BoosterRequiredIsSet)
-    {   
+    {
         
         val[utility::conversions::to_string_t(_XPLATSTR("boosterRequired"))] = ModelBase::toJson(m_BoosterRequired);
     }
@@ -86,9 +85,9 @@ void Vaccine::toMultipart(std::shared_ptr<MultipartFormData> multipart, const ut
     {
         namePrefix += utility::conversions::to_string_t(_XPLATSTR("."));
     }
-    if(m_dateIsSet)
+    if(m_date.has_value())
     {
-        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("date")), m_date));
+        multipart->add(ModelBase::toHttpContent(namePrefix + utility::conversions::to_string_t(_XPLATSTR("date")), m_date.get()));
     }
     if(m_BoosterRequiredIsSet)
     {
@@ -123,24 +122,23 @@ bool Vaccine::fromMultiPart(std::shared_ptr<MultipartFormData> multipart, const 
 
 std::shared_ptr<AnyType> Vaccine::getDate() const
 {
-    return m_date;
+    return m_date.get();
 }
 
 
 void Vaccine::setDate(const std::shared_ptr<AnyType>& value)
 {
     m_date = value;
-    m_dateIsSet = true;
 }
 
 bool Vaccine::dateIsSet() const
 {
-    return m_dateIsSet;
+    return m_date.has_value();
 }
 
 void Vaccine::unsetdate()
 {
-    m_dateIsSet = false;
+    m_date.reset();
 }
 bool Vaccine::isBoosterRequired() const
 {


### PR DESCRIPTION
Fixes #22404

Was seeing segfaults on nullable fields that were actually set to null at runtime.
Switches to boost optional, which seems to be the best way to go, or I can add guards instead of we prefer that.

@ravinikam @stkrwork @etherealjoy @martindelille @muttleyxd @aminya