### PR TITLE
[php-nextgen] Cast $weight to int in HeaderSelector::getNextWeight()

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/HeaderSelector.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/HeaderSelector.mustache
@@ -186,12 +186,12 @@ class HeaderSelector
 
     /**
      * @param string $header
-     * @param int    $weight
+     * @param float  $weight
      * @return string
      */
-    private function buildAcceptHeader(string $header, int $weight): string
+    private function buildAcceptHeader(string $header, float $weight): string
     {
-        if($weight === 1000) {
+        if ($weight === 1000.0) {
             return $header;
         }
 
@@ -216,11 +216,11 @@ class HeaderSelector
      * if there is a maximum of 28 "Accept" headers. If we have more than that (which is extremely unlikely), then we fall back to a 1-by-1
      * decrement rule, which will result in quality codes like "q=0.999", "q=0.998" etc.
      *
-     * @param int  $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
-     * @param bool $hasMoreThan28Headers
-     * @return int
+     * @param float $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
+     * @param bool  $hasMoreThan28Headers
+     * @return float
      */
-    public function getNextWeight(int $currentWeight, bool $hasMoreThan28Headers): int
+    public function getNextWeight(float $currentWeight, bool $hasMoreThan28Headers): float
     {
         if ($currentWeight <= 1) {
             return 1;

--- a/samples/client/echo_api/php-nextgen-streaming/src/HeaderSelector.php
+++ b/samples/client/echo_api/php-nextgen-streaming/src/HeaderSelector.php
@@ -195,12 +195,12 @@ class HeaderSelector
 
     /**
      * @param string $header
-     * @param int    $weight
+     * @param float  $weight
      * @return string
      */
-    private function buildAcceptHeader(string $header, int $weight): string
+    private function buildAcceptHeader(string $header, float $weight): string
     {
-        if($weight === 1000) {
+        if ($weight === 1000.0) {
             return $header;
         }
 
@@ -225,11 +225,11 @@ class HeaderSelector
      * if there is a maximum of 28 "Accept" headers. If we have more than that (which is extremely unlikely), then we fall back to a 1-by-1
      * decrement rule, which will result in quality codes like "q=0.999", "q=0.998" etc.
      *
-     * @param int  $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
-     * @param bool $hasMoreThan28Headers
-     * @return int
+     * @param float $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
+     * @param bool  $hasMoreThan28Headers
+     * @return float
      */
-    public function getNextWeight(int $currentWeight, bool $hasMoreThan28Headers): int
+    public function getNextWeight(float $currentWeight, bool $hasMoreThan28Headers): float
     {
         if ($currentWeight <= 1) {
             return 1;

--- a/samples/client/echo_api/php-nextgen/src/HeaderSelector.php
+++ b/samples/client/echo_api/php-nextgen/src/HeaderSelector.php
@@ -195,12 +195,12 @@ class HeaderSelector
 
     /**
      * @param string $header
-     * @param int    $weight
+     * @param float  $weight
      * @return string
      */
-    private function buildAcceptHeader(string $header, int $weight): string
+    private function buildAcceptHeader(string $header, float $weight): string
     {
-        if($weight === 1000) {
+        if ($weight === 1000.0) {
             return $header;
         }
 
@@ -225,11 +225,11 @@ class HeaderSelector
      * if there is a maximum of 28 "Accept" headers. If we have more than that (which is extremely unlikely), then we fall back to a 1-by-1
      * decrement rule, which will result in quality codes like "q=0.999", "q=0.998" etc.
      *
-     * @param int  $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
-     * @param bool $hasMoreThan28Headers
-     * @return int
+     * @param float $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
+     * @param bool  $hasMoreThan28Headers
+     * @return float
      */
-    public function getNextWeight(int $currentWeight, bool $hasMoreThan28Headers): int
+    public function getNextWeight(float $currentWeight, bool $hasMoreThan28Headers): float
     {
         if ($currentWeight <= 1) {
             return 1;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/HeaderSelector.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/HeaderSelector.php
@@ -194,12 +194,12 @@ class HeaderSelector
 
     /**
      * @param string $header
-     * @param int    $weight
+     * @param float  $weight
      * @return string
      */
-    private function buildAcceptHeader(string $header, int $weight): string
+    private function buildAcceptHeader(string $header, float $weight): string
     {
-        if($weight === 1000) {
+        if ($weight === 1000.0) {
             return $header;
         }
 
@@ -224,11 +224,11 @@ class HeaderSelector
      * if there is a maximum of 28 "Accept" headers. If we have more than that (which is extremely unlikely), then we fall back to a 1-by-1
      * decrement rule, which will result in quality codes like "q=0.999", "q=0.998" etc.
      *
-     * @param int  $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
-     * @param bool $hasMoreThan28Headers
-     * @return int
+     * @param float $currentWeight varying from 1 to 1000 (will be divided by 1000 to build the quality value)
+     * @param bool  $hasMoreThan28Headers
+     * @return float
      */
-    public function getNextWeight(int $currentWeight, bool $hasMoreThan28Headers): int
+    public function getNextWeight(float $currentWeight, bool $hasMoreThan28Headers): float
     {
         if ($currentWeight <= 1) {
             return 1;


### PR DESCRIPTION
This change prevents type casting issues between float and int when multiple `json` accept headers can be used:
`Argument #2 ($weight) must be of type int, float given`.

cc @jebentier @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
