### PR TITLE
Ensure rust-server compiles with no-default-features

### DIFF
--- a/.github/workflows/samples-rust-server.yaml
+++ b/.github/workflows/samples-rust-server.yaml
@@ -39,7 +39,10 @@ jobs:
 
       - name: Build
         working-directory: ${{ matrix.sample }}
-        run: cargo build --all-targets --all-features
+        run: |
+          set -e
+          cargo build --all-targets --all-features
+          cargo build --all-targets --no-default-features
       - name: Tests
         working-directory: ${{ matrix.sample }}
         run: |

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -1233,6 +1233,10 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
                 additionalProperties.put("apiUsesUuid", true);
             }
 
+            if (prop.isByteArray) {
+                additionalProperties.put("apiUsesByteArray", true);
+            }
+
             String xmlName = modelXmlNames.get(prop.dataType);
             if (xmlName != null) {
                 prop.vendorExtensions.put("x-item-xml-name", xmlName);
@@ -1533,6 +1537,11 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
         // If a parameter uses UUIDs, we need to import the UUID package.
         if (uuidType.equals(param.dataType)) {
             additionalProperties.put("apiUsesUuid", true);
+        }
+
+        // If a parameter uses byte arrays, we need to set a flag.
+        if (param.isByteArray) {
+            additionalProperties.put("apiUsesByteArray", true);
         }
 
         if (Boolean.TRUE.equals(param.isFreeFormObject)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
@@ -1213,6 +1213,10 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
                 additionalProperties.put("apiUsesUuid", true);
             }
 
+            if (prop.isByteArray) {
+                additionalProperties.put("apiUsesByteArray", true);
+            }
+
             String xmlName = modelXmlNames.get(prop.dataType);
             if (xmlName != null) {
                 prop.vendorExtensions.put("x-item-xml-name", xmlName);
@@ -1513,6 +1517,11 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
         // If a parameter uses UUIDs, we need to import the UUID package.
         if (uuidType.equals(param.dataType)) {
             additionalProperties.put("apiUsesUuid", true);
+        }
+
+        // If a parameter uses byte arrays, we need to set a flag.
+        if (param.isByteArray) {
+            additionalProperties.put("apiUsesByteArray", true);
         }
 
         if (Boolean.TRUE.equals(param.isFreeFormObject)) {

--- a/modules/openapi-generator/src/main/resources/rust-server-deprecated/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server-deprecated/Cargo.mustache
@@ -47,7 +47,7 @@ client = [
     "serde_urlencoded",
 {{/usesUrlEncodedForm}}
 {{#hasCallbacks}}
-    "serde_ignored", "regex", "percent-encoding", "lazy_static",
+    "serde_ignored", "percent-encoding", {{^apiUsesByteArray}}"lazy_static", "regex",{{/apiUsesByteArray}}
 {{/hasCallbacks}}
 {{! Anything added to the list below, should probably be added to the callbacks list below }}
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
@@ -66,7 +66,7 @@ server = [
     "native-tls", "hyper-openssl", "hyper-tls", "openssl",
 {{/hasCallbacks}}
 {{! Anything added to the list below, should probably be added to the callbacks list above }}
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" {{^apiUsesByteArray}},"lazy_static", "regex"{{/apiUsesByteArray}}
 ]
 cli = [
 {{#apiHasDeleteMethods}}
@@ -96,6 +96,10 @@ mime = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 validator = { version = "0.16", features = ["derive"] }
+{{#apiUsesByteArray}}
+lazy_static = "1.5"
+regex = "1.12"
+{{/apiUsesByteArray}}
 
 # Crates included if required by the API definition
 {{#usesXml}}
@@ -126,9 +130,11 @@ serde_urlencoded = {version = "0.6.1", optional = true}
 {{/usesUrlEncodedForm}}
 
 # Server, and client callback-specific
+{{^apiUsesByteArray}}
 lazy_static = { version = "1.4", optional = true }
-percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
+{{/apiUsesByteArray}}
+percent-encoding = {version = "2.1.0", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/modules/openapi-generator/src/main/resources/rust-server-deprecated/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server-deprecated/auth.mustache
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/modules/openapi-generator/src/main/resources/rust-server-deprecated/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server-deprecated/lib.mustache
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -44,7 +44,7 @@ client = [
     "serde_urlencoded",
 {{/usesUrlEncodedForm}}
 {{#hasCallbacks}}
-    "serde_ignored", "regex", "percent-encoding", "lazy_static",
+    "serde_ignored", "percent-encoding", {{^apiUsesByteArray}}"lazy_static", "regex"{{/apiUsesByteArray}}
 {{/hasCallbacks}}
 {{! Anything added to the list below, should probably be added to the callbacks list below }}
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
@@ -60,7 +60,8 @@ server = [
     "native-tls", "hyper-openssl", "hyper-tls", "openssl",
 {{/hasCallbacks}}
 {{! Anything added to the list below, should probably be added to the callbacks list above }}
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   {{^apiUsesByteArray}}"lazy_static", "regex"{{/apiUsesByteArray}}
 ]
 cli = [
 {{#apiHasDeleteMethods}}
@@ -88,8 +89,14 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+{{#apiUsesByteArray}}
+lazy_static = "1.5"
+regex = "1.12"
+{{/apiUsesByteArray}}
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -124,9 +131,11 @@ serde_urlencoded = { version = "0.7.1", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
+{{^apiUsesByteArray}}
 lazy_static = { version = "1.5", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
 regex = { version = "1.12", optional = true }
+{{/apiUsesByteArray}}
+percent-encoding = { version = "2.3.1", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/modules/openapi-generator/src/main/resources/rust-server/auth.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/auth.mustache
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "{{{basePathWithoutHost}}}";

--- a/samples/server/petstore/rust-server-deprecated/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/multipart-v3/Cargo.toml
@@ -19,7 +19,7 @@ server = [
     "mime_0_2",
     "multipart", "multipart/server", "swagger/multipart_form",
     "hyper_0_10", "mime_multipart", "swagger/multipart_related",
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" 
 ]
 cli = [
   "anyhow", "clap-verbosity-flag", "simple_logger", "structopt", "tokio"
@@ -46,6 +46,8 @@ mime = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 validator = { version = "0.16", features = ["derive"] }
+lazy_static = "1.5"
+regex = "1.12"
 
 # Crates included if required by the API definition
 mime_0_2 = { package = "mime", version = "0.2.6", optional = true }
@@ -61,9 +63,7 @@ url = {version = "2.1", optional = true}
 # Client-specific
 
 # Server, and client callback-specific
-lazy_static = { version = "1.4", optional = true }
 percent-encoding = {version = "2.1.0", optional = true}
-regex = {version = "1.3", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/multipart-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/multipart-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/multipart-v3/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server-deprecated/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/no-example-v3/Cargo.toml
@@ -13,7 +13,7 @@ client = [
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" ,"lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap-verbosity-flag", "simple_logger", "structopt", "tokio"
@@ -52,8 +52,8 @@ url = {version = "2.1", optional = true}
 
 # Server, and client callback-specific
 lazy_static = { version = "1.4", optional = true }
-percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
+percent-encoding = {version = "2.1.0", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/no-example-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/no-example-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/no-example-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/no-example-v3/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/Cargo.toml
@@ -11,12 +11,12 @@ edition = "2018"
 default = ["client", "server"]
 client = [
     "serde_urlencoded",
-    "serde_ignored", "regex", "percent-encoding", "lazy_static",
+    "serde_ignored", "percent-encoding", 
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
     "native-tls", "hyper-openssl", "hyper-tls", "openssl",
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" 
 ]
 cli = [
   "anyhow", "clap-verbosity-flag", "simple_logger", "structopt", "tokio"
@@ -43,6 +43,8 @@ mime = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 validator = { version = "0.16", features = ["derive"] }
+lazy_static = "1.5"
+regex = "1.12"
 
 # Crates included if required by the API definition
 serde-xml-rs = "0.8"
@@ -57,9 +59,7 @@ url = {version = "2.1", optional = true}
 serde_urlencoded = {version = "0.6.1", optional = true}
 
 # Server, and client callback-specific
-lazy_static = { version = "1.4", optional = true }
 percent-encoding = {version = "2.1.0", optional = true}
-regex = {version = "1.3", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server-deprecated/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/ops-v3/Cargo.toml
@@ -13,7 +13,7 @@ client = [
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" ,"lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap-verbosity-flag", "simple_logger", "structopt", "tokio"
@@ -52,8 +52,8 @@ url = {version = "2.1", optional = true}
 
 # Server, and client callback-specific
 lazy_static = { version = "1.4", optional = true }
-percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
+percent-encoding = {version = "2.1.0", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/ops-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/ops-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/ops-v3/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -18,7 +18,7 @@ client = [
 server = [
     "mime_0_2",
     "multipart", "multipart/server", "swagger/multipart_form",
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" 
 ]
 cli = [
   "dialoguer",
@@ -46,6 +46,8 @@ mime = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 validator = { version = "0.16", features = ["derive"] }
+lazy_static = "1.5"
+regex = "1.12"
 
 # Crates included if required by the API definition
 serde-xml-rs = "0.8"
@@ -62,9 +64,7 @@ url = {version = "2.1", optional = true}
 serde_urlencoded = {version = "0.6.1", optional = true}
 
 # Server, and client callback-specific
-lazy_static = { version = "1.4", optional = true }
 percent-encoding = {version = "2.1.0", optional = true}
-regex = {version = "1.3", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/Cargo.toml
@@ -13,7 +13,7 @@ client = [
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" ,"lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap-verbosity-flag", "simple_logger", "structopt", "tokio"
@@ -52,8 +52,8 @@ url = {version = "2.1", optional = true}
 
 # Server, and client callback-specific
 lazy_static = { version = "1.4", optional = true }
-percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
+percent-encoding = {version = "2.1.0", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/ping-bearer-auth/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/Cargo.toml
@@ -13,7 +13,7 @@ client = [
     "hyper", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url" ,"lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap-verbosity-flag", "simple_logger", "structopt", "tokio"
@@ -52,8 +52,8 @@ url = {version = "2.1", optional = true}
 
 # Server, and client callback-specific
 lazy_static = { version = "1.4", optional = true }
-percent-encoding = {version = "2.1.0", optional = true}
 regex = {version = "1.3", optional = true}
+percent-encoding = {version = "2.1.0", optional = true}
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/src/auth.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::{ApiError, auth::{Basic, Bearer}};
+use swagger::{ApiError, auth::{Basic, Bearer, Authorization}};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -24,7 +23,7 @@ pub trait AuthenticationApi {
 
     /// Method should be implemented (see example-code) to map Basic (Username:password) to an Authorization
     fn basic_authorization(&self, basic: &Basic) -> Result<Authorization, ApiError>;
-} 
+}
 
 // Implement it for AllowAllAuthenticator (dummy is needed, but should not used as we have Bearer authorization)
 use swagger::auth::{AllowAllAuthenticator, RcBound, Scopes};

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/src/lib.rs
@@ -6,10 +6,8 @@ use futures::Stream;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
-
 
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -17,7 +17,8 @@ client = [
 server = [
     "multipart", "multipart/server", "swagger/multipart_form",
     "mime_multipart", "swagger/multipart_related",
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   
 ]
 cli = [
   "anyhow", "clap", "clap-verbosity-flag", "simple_logger", "tokio"
@@ -42,8 +43,12 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+lazy_static = "1.5"
+regex = "1.12"
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -65,9 +70,7 @@ url = { version = "2.5", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
-lazy_static = { version = "1.5", optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
-regex = { version = "1.12", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "";

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -13,7 +13,8 @@ client = [
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   "lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap", "clap-verbosity-flag", "simple_logger", "tokio"
@@ -38,8 +39,10 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -60,8 +63,8 @@ tower-service = "0.3.3"
 
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
 regex = { version = "1.12", optional = true }
+percent-encoding = { version = "2.3.1", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "";

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -11,12 +11,13 @@ edition = "2018"
 default = ["client", "server"]
 client = [
     "serde_urlencoded",
-    "serde_ignored", "regex", "percent-encoding", "lazy_static",
+    "serde_ignored", "percent-encoding", 
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
     "native-tls", "hyper-openssl", "hyper-tls", "openssl",
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   
 ]
 cli = [
   "anyhow", "clap", "clap-verbosity-flag", "simple_logger", "tokio"
@@ -41,8 +42,12 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+lazy_static = "1.5"
+regex = "1.12"
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -65,9 +70,7 @@ serde_urlencoded = { version = "0.7.1", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
-lazy_static = { version = "1.5", optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
-regex = { version = "1.12", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "";

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -13,7 +13,8 @@ client = [
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   "lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap", "clap-verbosity-flag", "simple_logger", "tokio"
@@ -38,8 +39,10 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -60,8 +63,8 @@ tower-service = "0.3.3"
 
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
 regex = { version = "1.12", optional = true }
+percent-encoding = { version = "2.3.1", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/ops-v3/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "";

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -16,7 +16,8 @@ client = [
 ]
 server = [
     "multipart", "multipart/server", "swagger/multipart_form",
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   
 ]
 cli = [
   "dialoguer",
@@ -42,8 +43,12 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+lazy_static = "1.5"
+regex = "1.12"
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -67,9 +72,7 @@ serde_urlencoded = { version = "0.7.1", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
-lazy_static = { version = "1.5", optional = true }
 percent-encoding = { version = "2.3.1", optional = true }
-regex = { version = "1.12", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/v2";

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -13,7 +13,8 @@ client = [
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   "lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap", "clap-verbosity-flag", "simple_logger", "tokio"
@@ -38,8 +39,10 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -60,8 +63,8 @@ tower-service = "0.3.3"
 
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
 regex = { version = "1.12", optional = true }
+percent-encoding = { version = "2.3.1", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "";

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -13,7 +13,8 @@ client = [
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"
 ]
 server = [
-   "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
+   "serde_ignored", "hyper", "percent-encoding", "url",
+   "lazy_static", "regex"
 ]
 cli = [
   "anyhow", "clap", "clap-verbosity-flag", "simple_logger", "tokio"
@@ -38,8 +39,10 @@ futures = "0.3"
 swagger = { version = "7.0.0", features = ["serdejson", "server", "client", "tls"] }
 headers = "0.4.0"
 log = "0.4.27"
+
 mime = "0.3"
 mockall = { version = "0.13.1", optional = true }
+
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -60,8 +63,8 @@ tower-service = "0.3.3"
 
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
 regex = { version = "1.12", optional = true }
+percent-encoding = { version = "2.3.1", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/auth.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/auth.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
-use crate::server::Authorization;
 use serde::{Deserialize, Serialize};
-use swagger::ApiError;
+use swagger::{ApiError, auth::Authorization};
 use headers::authorization::{Basic, Bearer};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -8,11 +8,10 @@ use mockall::automock;
 use std::error::Error;
 use std::collections::BTreeSet;
 use std::task::{Poll, Context};
-use swagger::{ApiError, ContextWrapper};
+use swagger::{ApiError, ContextWrapper, auth::Authorization};
 use serde::{Serialize, Deserialize};
-use crate::server::Authorization;
 
-
+#[cfg(any(feature = "client", feature = "server"))]
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "";


### PR DESCRIPTION
In the rust-server generator we used the re-export of `Authorization` from `src/server.rs` rather than directly using `swagger::auth::Authorization`. This caused compilation errors when compiling an autogenerated crate with `--no-default-features`. To resolve I've updated the references to `crate::server::Authorization` to `swagger::auth::Authorization`. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
