### PR TITLE
[swift6] Don't encode Data as base64 in multipart request

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/APIHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/APIHelper.mustache
@@ -52,6 +52,8 @@ import Vapor{{/useVapor}}
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Extensions.mustache
@@ -86,9 +86,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -85,9 +85,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -85,9 +85,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ internal struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/APIHelper.swift
@@ -51,6 +51,8 @@ public struct APIHelper {
         guard let value = value else { return nil }
         if let value = value as? any RawRepresentable {
             return "\(value.rawValue)"
+        } else if let data = value as? Data {
+            return data.base64EncodedString(options: Data.Base64EncodingOptions())
         } else {
             return "\(value)"
         }

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Extensions.swift
@@ -84,9 +84,7 @@ extension Dictionary where Key: Sendable, Value: Sendable {
 }
 
 extension Data: ParameterConvertible {
-    func asParameter(codableHelper: CodableHelper) -> any Sendable {
-        return self.base64EncodedString(options: Data.Base64EncodingOptions())
-    }
+    func asParameter(codableHelper: CodableHelper) -> any Sendable { self }
 }
 
 extension Date: ParameterConvertible {


### PR DESCRIPTION
This will make sure Data is not encoded as base64 unless it's necessary for the request, i.e. it's part of the querystring or headers. A FormData request should always preserve the data as-is, to keep the same functionality as passing in a URL.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @4brunu (2019/11) @dydus0x14 (2023/06)
