### PR TITLE
[Java] Header parameters (`in: header`) are accepted as method parameters in the generated `google-api-client` Java client but are never added to the HTTP request.

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/api.mustache
@@ -123,7 +123,13 @@ public class {{classname}} {
         GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = {{#isBodyAllowed}}{{#bodyParam}}apiClient.new JacksonJsonHttpContent({{paramName}}){{/bodyParam}}{{^bodyParam}}new EmptyContent(){{/bodyParam}}{{/isBodyAllowed}}{{^isBodyAllowed}}null{{/isBodyAllowed}};
-        return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content).execute();
+        com.google.api.client.http.HttpRequest httpRequest = apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content);
+        {{#headerParams}}
+        if ({{paramName}} != null) {
+            httpRequest.getHeaders().set("{{baseName}}", {{paramName}});
+        }
+        {{/headerParams}}
+        return httpRequest.execute();
     }{{#bodyParam}}
 
       {{#isDeprecated}}
@@ -159,7 +165,13 @@ public class {{classname}} {
               HttpContent content = {{#bodyParam}}{{paramName}} == null ?
                 apiClient.new JacksonJsonHttpContent(null) :
                 new InputStreamContent(mediaType == null ? Json.MEDIA_TYPE : mediaType, {{paramName}}){{/bodyParam}};
-              return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content).execute();
+              com.google.api.client.http.HttpRequest httpRequest = apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content);
+              {{#headerParams}}
+              if ({{paramName}} != null) {
+                  httpRequest.getHeaders().set("{{baseName}}", {{paramName}});
+              }
+              {{/headerParams}}
+              return httpRequest.execute();
       }{{/bodyParam}}
 
     {{#isDeprecated}}
@@ -201,7 +213,19 @@ public class {{classname}} {
         GenericUrl genericUrl = new GenericUrl(localVarUrl);
 
         HttpContent content = {{#isBodyAllowed}}{{#bodyParam}}apiClient.new JacksonJsonHttpContent({{paramName}}){{/bodyParam}}{{^bodyParam}}new EmptyContent(){{/bodyParam}}{{/isBodyAllowed}}{{^isBodyAllowed}}null{{/isBodyAllowed}};
-        return apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content).execute();
+        com.google.api.client.http.HttpRequest httpRequest = apiClient.getHttpRequestFactory().buildRequest(HttpMethods.{{httpMethod}}, genericUrl, content);
+        // Note: Header params passed via 'params' map are handled below
+        for (Map.Entry<String, Object> entry: params.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            // Check if this is a header parameter by name
+            {{#headerParams}}
+            if ("{{baseName}}".equals(key) && value != null) {
+                httpRequest.getHeaders().set(key, value);
+            }
+            {{/headerParams}}
+        }
+        return httpRequest.execute();
     }
 
 


### PR DESCRIPTION
  ## Summary

  Fixes #22457

  Header parameters (`in: header`) are accepted as method parameters in the generated
  `google-api-client` Java client but are never added to the HTTP request. This PR is targeting java so mentioning the Java committee here @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

  ## Changes

  Updated `api.mustache` to add header parameters to `HttpRequest` before calling `execute()`:

  - Main `ForHttpResponse` method
  - InputStream variant method
  - Params map variant method

  ## Testing

  Generated a client with header parameters and verified headers are now properly sent locally.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
