### PR TITLE
fix: Rust-server bytes response fixed to not attempt string conversion

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -44,7 +44,7 @@ client = [
     "serde_urlencoded",
 {{/usesUrlEncodedForm}}
 {{#hasCallbacks}}
-    "serde_ignored", "percent-encoding", {{^apiUsesByteArray}}"lazy_static", "regex"{{/apiUsesByteArray}}
+    "serde_ignored", "percent-encoding", {{^apiUsesByteArray}}"lazy_static", "regex",{{/apiUsesByteArray}}
 {{/hasCallbacks}}
 {{! Anything added to the list below, should probably be added to the callbacks list below }}
     "hyper", "hyper-util/http1", "hyper-util/http2", "hyper-openssl", "hyper-tls", "native-tls", "openssl", "url"

--- a/modules/openapi-generator/src/main/resources/rust-server/client-request-body-multipart-form.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-request-body-multipart-form.mustache
@@ -1,4 +1,4 @@
-        let (body_string, multipart_header) = {
+        let (body_bytes, multipart_header) = {
             let mut multipart = Multipart::new();
 
     {{#exts}}
@@ -43,9 +43,9 @@
                 Err(err) => return Err(ApiError(format!("Unable to build request: {err}"))),
             };
 
-            let mut body_string = String::new();
+            let mut body_bytes = Vec::new();
 
-            match fields.read_to_string(&mut body_string) {
+            match fields.read_to_end(&mut body_bytes) {
                 Ok(_) => (),
                 Err(err) => return Err(ApiError(format!("Unable to build body: {err}"))),
             }
@@ -54,10 +54,10 @@
 
             let multipart_header = format!("multipart/form-data;boundary={boundary}");
 
-            (body_string, multipart_header)
-        };
+            (body_bytes, multipart_header)
+          };
 
-        *request.body_mut() = body_from_string(body_string);
+        *request.body_mut() = BoxBody::new(Full::new(Bytes::from(body_bytes)));
 
         request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(&multipart_header) {
             Ok(h) => h,

--- a/modules/openapi-generator/src/main/resources/rust-server/server-response-body-instance.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-response-body-instance.mustache
@@ -23,7 +23,7 @@
     {{/x-produces-json}}
     {{#x-produces-bytes}}
                                                     // Binary Body
-                                                    let body = String::from_utf8(body.0).expect("Error converting octet stream to string");
+                                                    *response.body_mut() = BoxBody::new(Full::new(Bytes::from(body.0)));
     {{/x-produces-bytes}}
     {{#x-produces-plain-text}}
                                                     // Plain text Body
@@ -42,7 +42,12 @@
                                                             &["multipart/related; boundary=".as_bytes(), &boundary].concat())
                                                         .expect("Unable to create Content-Type header for multipart/related"));
       {{/formParams}}
+                                                    *response.body_mut() = BoxBody::new(Full::new(Bytes::from(body.0)));
     {{/x-produces-multipart-related}}
-  {{/exts}}
+  {{^x-produces-bytes}}
+  {{^x-produces-multipart-related}}
                                                     *response.body_mut() = body_from_string(body);
+  {{/x-produces-multipart-related}}
+  {{/x-produces-bytes}}
+  {{/exts}}
 {{/dataType}}

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -795,8 +795,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
                                                         CONTENT_TYPE,
                                                         HeaderValue::from_static("application/octet-stream"));
                                                     // Binary Body
-                                                    let body = String::from_utf8(body.0).expect("Error converting octet stream to string");
-                                                    *response.body_mut() = body_from_string(body);
+                                                    *response.body_mut() = BoxBody::new(Full::new(Bytes::from(body.0)));
 
                                                 },
                                                 MultigetGetResponse::StringRsp

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -2650,7 +2650,7 @@ impl<S, C, B> Api<C> for Client<S, C> where
         };
 
         // Consumes multipart/form body
-        let (body_string, multipart_header) = {
+        let (body_bytes, multipart_header) = {
             let mut multipart = Multipart::new();
 
             // For each parameter, encode as appropriate and add to the multipart body as a stream.
@@ -2684,9 +2684,9 @@ impl<S, C, B> Api<C> for Client<S, C> where
                 Err(err) => return Err(ApiError(format!("Unable to build request: {err}"))),
             };
 
-            let mut body_string = String::new();
+            let mut body_bytes = Vec::new();
 
-            match fields.read_to_string(&mut body_string) {
+            match fields.read_to_end(&mut body_bytes) {
                 Ok(_) => (),
                 Err(err) => return Err(ApiError(format!("Unable to build body: {err}"))),
             }
@@ -2695,10 +2695,10 @@ impl<S, C, B> Api<C> for Client<S, C> where
 
             let multipart_header = format!("multipart/form-data;boundary={boundary}");
 
-            (body_string, multipart_header)
-        };
+            (body_bytes, multipart_header)
+          };
 
-        *request.body_mut() = body_from_string(body_string);
+        *request.body_mut() = BoxBody::new(Full::new(Bytes::from(body_bytes)));
 
         request.headers_mut().insert(CONTENT_TYPE, match HeaderValue::from_str(&multipart_header) {
             Ok(h) => h,


### PR DESCRIPTION
Fix bug in rust-server where it was attempting to convert bytes to string and failing on invalid UTF-8 format. Fixed this up in multiple locations and the multipart support. 

Error hit - `Error converting octet stream to string: FromUtf8Error { bytes: [...], error: Utf8Error { valid_up_to: 1, error_len: Some(1) }`
Endpoint this was hit on 
```
     content:
        application/gzip:
          schema:
            type: string
            format: binary
```

Resolve by directly returning the bytes rather than attempting string conversion. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
