### PR TITLE
[csharp] Extend HostConfiguration with additional AddApiHttpClients signatures

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HostConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/HostConfiguration.mustache
@@ -86,15 +86,42 @@ namespace {{packageName}}.{{clientPackage}}
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration Add{{apiName}}HttpClients(Action<IHttpClientBuilder>{{nrt?}} builder = null)
+        {
+            return Add{{apiName}}HttpClients((Action<IServiceProvider, HttpClient>{{nrt?}})null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration Add{{apiName}}HttpClients
-        (
-            Action<HttpClient>{{nrt?}} client = null, Action<IHttpClientBuilder>{{nrt?}} builder = null)
+        public HostConfiguration Add{{apiName}}HttpClients(
+            Action<HttpClient>{{nrt?}} client,
+            Action<IHttpClientBuilder>{{nrt?}} builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return Add{{apiName}}HttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration Add{{apiName}}HttpClients(
+            Action<IServiceProvider, HttpClient>{{nrt?}} client,
+            Action<IHttpClientBuilder>{{nrt?}} builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -57,15 +57,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -52,15 +52,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -57,15 +57,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -54,15 +54,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -54,15 +54,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -215,15 +215,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -52,15 +52,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -165,15 +165,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -49,15 +49,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -215,15 +215,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -52,15 +52,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -165,15 +165,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -49,15 +49,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -55,15 +55,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -55,15 +55,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -55,15 +55,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -217,15 +217,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -169,15 +169,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -56,15 +56,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -167,15 +167,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -277,15 +277,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -55,15 +55,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -55,15 +55,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -55,15 +55,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -217,15 +217,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -169,15 +169,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -56,15 +56,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -167,15 +167,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -277,15 +277,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -51,15 +51,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder>? builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>?)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient>? client = null, Action<IHttpClientBuilder>? builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient>? client,
+            Action<IHttpClientBuilder>? builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/HostConfiguration.cs
@@ -165,15 +165,42 @@ namespace Org.OpenAPITools.Client
         /// <summary>
         /// Configures the HttpClients.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(Action<IHttpClientBuilder> builder = null)
+        {
+            return AddApiHttpClients((Action<IServiceProvider, HttpClient>)null, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
         /// <param name="client"></param>
         /// <param name="builder"></param>
         /// <returns></returns>
-        public HostConfiguration AddApiHttpClients
-        (
-            Action<HttpClient> client = null, Action<IHttpClientBuilder> builder = null)
+        public HostConfiguration AddApiHttpClients(
+            Action<HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
+        {
+            var wrapped = client != null ? new Action<IServiceProvider, HttpClient>((_, httpClient) =>
+            {
+                client(httpClient);
+            }) : null;
+            return AddApiHttpClients(wrapped, builder);
+        }
+
+        /// <summary>
+        /// Configures the HttpClients.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public HostConfiguration AddApiHttpClients(
+            Action<IServiceProvider, HttpClient> client,
+            Action<IHttpClientBuilder> builder = null)
         {
             if (client == null)
-                client = c => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
+                client = (_, c) => c.BaseAddress = new Uri(ClientUtils.BASE_ADDRESS);
 
             List<IHttpClientBuilder> builders = new List<IHttpClientBuilder>();
 


### PR DESCRIPTION
This change adds new Method signatures to the `HostConfiguration` in regards of `AddApiHttpClients` to support also the `AddHttpClient(Action<IServiceProvider, HttpClient> configureClient)` variant. This allows to access the `ServiceProvider` during configuration which can be very benefitial.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)