### PR TITLE
[java] fix: five nondeterministic tests

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -6,6 +6,9 @@ import org.testng.annotations.Test;
 
 import java.util.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNull;
 
@@ -40,7 +43,7 @@ public class ExampleGeneratorTest {
     }
 
     @Test
-    public void generateFromResponseSchemaWithDateFormat() {
+    public void generateFromResponseSchemaWithDateFormat() throws Exception {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
@@ -62,9 +65,11 @@ public class ExampleGeneratorTest {
                 mediaTypeKeys
         );
 
+        ObjectMapper mapper = new ObjectMapper();
+
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
-        assertEquals(String.format(Locale.ROOT, "{%n  \"date_with_example\" : \"2024-01-01\",%n  \"date_without_example\" : \"2000-01-23\"%n}"), examples.get(0).get("example"));
+        assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n  \"date_with_example\" : \"2024-01-01\",%n  \"date_without_example\" : \"2000-01-23\"%n}")), mapper.readTree(examples.get(0).get("example")));     
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 
@@ -211,7 +216,7 @@ public class ExampleGeneratorTest {
     }
 
     @Test
-    public void generateFromResponseSchemaWithAllOfComposedModel() {
+    public void generateFromResponseSchemaWithAllOfComposedModel() throws Exception{
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
@@ -233,14 +238,16 @@ public class ExampleGeneratorTest {
                 mediaTypeKeys
         );
 
+        ObjectMapper mapper = new ObjectMapper();
+
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
-        assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
+        assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property\" : \"example schema property value\"%n}")), mapper.readTree(examples.get(0).get("example")));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 
     @Test
-    public void generateFromResponseSchemaWithAllOfChildComposedModel() {
+    public void generateFromResponseSchemaWithAllOfChildComposedModel() throws Exception {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
         new InlineModelResolver().flatten(openAPI);
@@ -262,9 +269,11 @@ public class ExampleGeneratorTest {
                 mediaTypeKeys
         );
 
+        ObjectMapper mapper = new ObjectMapper();
+
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
-        assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property_composed_parent\" : \"example schema property value composed parent\",%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
+        assertEquals(mapper.readTree(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property_composed_parent\" : \"example schema property value composed parent\",%n  \"example_schema_property\" : \"example schema property value\"%n}")), mapper.readTree(examples.get(0).get("example")));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -1251,29 +1251,33 @@ public class JavaClientCodegenTest {
 
         final List<CodegenOperation> codegenOperations = paths.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
         final CodegenOperation getWithBasicAuthAndOauth = getByOperationId(codegenOperations, "getWithBasicAuthAndOauth");
-        assertEquals(getWithBasicAuthAndOauth.authMethods.size(), 3);
-        assertEquals(getWithBasicAuthAndOauth.authMethods.get(0).name, "basic_auth");
+        List<CodegenSecurity> sortedAuthMethods = new ArrayList<>(getWithBasicAuthAndOauth.authMethods);
+        sortedAuthMethods.sort(Comparator.comparing(am -> am.name));
+        assertEquals(sortedAuthMethods.size(), 3);
+        assertEquals(sortedAuthMethods.get(0).name, "basic_auth");
 
-        final Map<String, Object> passwordFlowScope = getWithBasicAuthAndOauth.authMethods.get(1).scopes.get(0);
+        final Map<String, Object> passwordFlowScope = sortedAuthMethods.get(1).scopes.get(0);
         assertEquals(passwordFlowScope.get("scope"), "something:create");
         assertEquals(passwordFlowScope.get("description"), "create from password flow");
 
-        final Map<String, Object> clientCredentialsFlow = getWithBasicAuthAndOauth.authMethods.get(2).scopes.get(0);
+        final Map<String, Object> clientCredentialsFlow = sortedAuthMethods.get(2).scopes.get(0);
         assertEquals(clientCredentialsFlow.get("scope"), "something:create");
         assertEquals(clientCredentialsFlow.get("description"), "create from client credentials flow");
 
         final CodegenOperation getWithOauthAuth = getByOperationId(codegenOperations, "getWithOauthAuth");
-        assertEquals(getWithOauthAuth.authMethods.size(), 2);
+        List<CodegenSecurity> sortedOauthAuthMethods = new ArrayList<>(getWithOauthAuth.authMethods);
+        sortedOauthAuthMethods.sort(Comparator.comparing(am -> am.name));
+        assertEquals(sortedOauthAuthMethods.size(), 2);
 
-        final Map<String, Object> passwordFlow = getWithOauthAuth.authMethods.get(0).scopes.get(0);
+        final Map<String, Object> passwordFlow = sortedOauthAuthMethods.get(0).scopes.get(0);
         assertEquals(passwordFlow.get("scope"), "something:create");
         assertEquals(passwordFlow.get("description"), "create from password flow");
 
-        final Map<String, Object> clientCredentialsCreateFlow = getWithOauthAuth.authMethods.get(1).scopes.get(0);
+        final Map<String, Object> clientCredentialsCreateFlow = sortedOauthAuthMethods.get(1).scopes.get(0);
         assertEquals(clientCredentialsCreateFlow.get("scope"), "something:create");
         assertEquals(clientCredentialsCreateFlow.get("description"), "create from client credentials flow");
 
-        final Map<String, Object> clientCredentialsProcessFlow = getWithOauthAuth.authMethods.get(1).scopes.get(1);
+        final Map<String, Object> clientCredentialsProcessFlow = sortedOauthAuthMethods.get(1).scopes.get(1);
         assertEquals(clientCredentialsProcessFlow.get("scope"), "something:process");
         assertEquals(clientCredentialsProcessFlow.get("description"), "process from client credentials flow");
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/jetbrains/http/client/JetbrainsHttpClientClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/jetbrains/http/client/JetbrainsHttpClientClientCodegenTest.java
@@ -387,19 +387,19 @@ public class JetbrainsHttpClientClientCodegenTest {
                 "Accept: application/json\n" +
                 "Authorization: Bearer {{bearerToken}}");
 
-        TestUtils.assertFileContains(path, "### Get payment methods\n" +
-                "## Get payment methods\n" +
-                "GET https://checkout-test.adyen.com/v71/paymentMethods\n" +
-                "Accept: application/json\n" +
-                "Authorization: Basic: {{username-password}}\n" +
+        TestUtils.assertFileContains(path, "### Get payment methods",
+                "## Get payment methods",
+                "GET https://checkout-test.adyen.com/v71/paymentMethods",
+                "Accept: application/json",
+                "Authorization: Basic: {{username-password}}",
                 "Authorization: Bearer {{bearerToken}}");
 
-        TestUtils.assertFileContains(path, "### Make a payment\n" +
-                "## Example with a merchant account that doesn&#39;t exist\n" +
-                "POST https://checkout-test.adyen.com/v71/payments\n" +
-                "Content-Type: application/json\n" +
-                "Accept: application/json\n" +
-                "Cookie: X-API-Key={{cookieKey}}\n" +
+        TestUtils.assertFileContains(path, "### Make a payment",
+                "## Example with a merchant account that doesn&#39;t exist",
+                "POST https://checkout-test.adyen.com/v71/payments",
+                "Content-Type: application/json",
+                "Accept: application/json",
+                "Cookie: X-API-Key={{cookieKey}}",
                 "Authorization: Bearer {{bearerToken}}");
     }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This pull request fix five non-deterministic tests that are detected by [NonDex](https://github.com/TestingResearchIllinois/NonDex), a tool for detecting wrong assumptions on under-determined Java APIs.

### Problem
- In ```ExampleGeneratorTest``` (```generateFromResponseSchemaWithAllOfChildComposedModel```, ```generateFromResponseSchemaWithAllOfComposedModel```, and  ```generateFromResponseSchemaWithDateFormat```): 
The test compared the generated example against a single hard-coded JSON string. When the underlying JSON object fields were emitted in a different order, the assertion failed even though the structure and values were correct.

- ```JavaClientCodegenTest.testNotDuplicateOauth2FlowsScopes```: 
This test assumed a fixed iteration order of ```getWithBasicAuthAndOauth.authMethods``` and ```getWithOauthAuth.authMethods```, i.e., that index ```0``` would always be ```basic_auth``` and subsequent entries would always correspond to specific OAuth2 flows. Under NonDex, the backing collection order can change, causing intermittent failures.

- ```JetbrainsHttpClientClientCodegenTest.testBasicGenerationManyAuths```: 
The test relied on a specific block layout in the generated ```.http``` file. NonDeterminism in generation (e.g., heading level changes or header ordering) caused the entire assertion to fail even when the essential content was still present.

To reproduce the failures, run NonDex on ```modules/openapi-generator``` using the following commands:
```
mvn -pl modules/openapi-generator edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=packageName.ClassName#methodName
```
Replace ```packageName.ClassName#methodName``` with one of:
```
org.openapitools.codegen.ExampleGeneratorTest#generateFromResponseSchemaWithAllOfChildComposedModel
```
```
org.openapitools.codegen.ExampleGeneratorTest#generateFromResponseSchemaWithAllOfComposedModel
```
```
org.openapitools.codegen.ExampleGeneratorTest#generateFromResponseSchemaWithDateFormat
```
```
org.openapitools.codegen.java.JavaClientCodegenTest#testNotDuplicateOauth2FlowsScopes
```
```
org.openapitools.codegen.jetbrains.http.client.JetbrainsHttpClientClientCodegenTest#testBasicGenerationManyAuths
```

### The Fix 
- In ```ExampleGeneratorTest``` (```generateFromResponseSchemaWithAllOfChildComposedModel```, ```generateFromResponseSchemaWithAllOfComposedModel```, and  ```generateFromResponseSchemaWithDateFormat```): 
Construct an ```ObjectMapper``` and compare ```JsonNode``` by ```mapper.readTree(...)``` for both the expected JSON and ```examples.get(0).get("example")```, so the assertion focuses on field values while ignoring non-deterministic JSON key ordering.
- ```JavaClientCodegenTest.testNotDuplicateOauth2FlowsScopes```: 
Copy ```authMethods``` into new lists and sort them by ```name``` before performing assertions. This keeps the intent  while avoiding reliance on the original collection iteration order.

- ```JetbrainsHttpClientClientCodegenTest.testBasicGenerationManyAuths```: 
Update the assertions to check that the generated .http file contains the expected sections, request lines, and headers regardless of their order or heading level, instead of depending on a single fixed layout.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
