### PR TITLE
Make python code compatible with urllib3 v2.6.0+

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -321,7 +321,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -338,7 +338,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -719,7 +719,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -31,12 +31,17 @@ class RESTResponse(io.IOBase):
             self.data = await self.response.read()
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a CIMultiDictProxy of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a CIMultiDictProxy of the response headers."""
+        """Returns a CIMultiDictProxy of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/modules/openapi-generator/src/main/resources/python/exceptions.mustache
+++ b/modules/openapi-generator/src/main/resources/python/exceptions.mustache
@@ -119,7 +119,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/modules/openapi-generator/src/main/resources/python/httpx/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/httpx/rest.mustache
@@ -28,12 +28,17 @@ class RESTResponse(io.IOBase):
             self.data = await self.response.aread()
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a CIMultiDictProxy of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a CIMultiDictProxy of the response headers."""
+        """Returns a CIMultiDictProxy of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -39,12 +39,17 @@ class RESTResponse(io.IOBase):
             self.data = self.response.data
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a dictionary of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a dictionary of the response headers."""
+        """Returns a dictionary of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/modules/openapi-generator/src/main/resources/python/tornado/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/tornado/rest.mustache
@@ -30,12 +30,17 @@ class RESTResponse(io.IOBase):
             self.data = self.response.body
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a CIMultiDictProxy of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a CIMultiDictProxy of the response headers."""
+        """Returns a CIMultiDictProxy of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -313,7 +313,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -330,7 +330,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -702,7 +702,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/exceptions.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/exceptions.py
@@ -129,7 +129,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/rest.py
@@ -49,12 +49,17 @@ class RESTResponse(io.IOBase):
             self.data = self.response.data
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a dictionary of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a dictionary of the response headers."""
+        """Returns a dictionary of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -313,7 +313,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -330,7 +330,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -702,7 +702,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/samples/client/echo_api/python/openapi_client/exceptions.py
+++ b/samples/client/echo_api/python/openapi_client/exceptions.py
@@ -129,7 +129,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -49,12 +49,17 @@ class RESTResponse(io.IOBase):
             self.data = self.response.data
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a dictionary of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a dictionary of the response headers."""
+        """Returns a dictionary of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -315,7 +315,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -332,7 +332,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -711,7 +711,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/exceptions.py
@@ -128,7 +128,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -40,12 +40,17 @@ class RESTResponse(io.IOBase):
             self.data = await self.response.read()
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a CIMultiDictProxy of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a CIMultiDictProxy of the response headers."""
+        """Returns a CIMultiDictProxy of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/api_client.py
@@ -315,7 +315,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -332,7 +332,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -711,7 +711,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/exceptions.py
@@ -128,7 +128,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/samples/openapi3/client/petstore/python-httpx/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-httpx/petstore_api/rest.py
@@ -37,12 +37,17 @@ class RESTResponse(io.IOBase):
             self.data = await self.response.aread()
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a CIMultiDictProxy of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a CIMultiDictProxy of the response headers."""
+        """Returns a CIMultiDictProxy of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/api_client.py
@@ -312,7 +312,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -329,7 +329,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -708,7 +708,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/exceptions.py
@@ -128,7 +128,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/petstore_api/rest.py
@@ -48,12 +48,17 @@ class RESTResponse(io.IOBase):
             self.data = self.response.data
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a dictionary of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a dictionary of the response headers."""
+        """Returns a dictionary of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/openapi3/client/petstore/python-lazyImports/tests/test_api.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/tests/test_api.py
@@ -16,29 +16,22 @@ class TestMultipleResponseTypes(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 204
         mock_resp.data = b""
-        mock_resp.getheaders.return_value = {}
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.test_empty_and_non_empty_responses()
-
         assert returned is None
 
     def test_206(self):
         mock_resp = Mock()
         mock_resp.status = 206
         mock_resp.data = b"some text"
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.test_empty_and_non_empty_responses()
-
         assert returned == "some text"
 
 
@@ -51,18 +44,12 @@ class TestErrorResponsesWithModels(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 400
         mock_resp.data = json.dumps({"reason400": "400 reason"}).encode("utf-8")
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader.return_value = ""
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             with pytest.raises(petstore_api.exceptions.BadRequestException) as exc_info:
                 self.fake_api.test_error_responses_with_model()
-
         expected_resp = petstore_api.TestErrorResponsesWithModel400Response(
             reason400="400 reason"
         )
@@ -72,18 +59,12 @@ class TestErrorResponsesWithModels(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 404
         mock_resp.data = json.dumps({"reason404": "404 reason"}).encode("utf-8")
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader.return_value = ""
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             with pytest.raises(petstore_api.exceptions.NotFoundException) as exc_info:
                 self.fake_api.test_error_responses_with_model()
-
         expected_resp = petstore_api.TestErrorResponsesWithModel404Response(
             reason404="404 reason"
         )

--- a/samples/openapi3/client/petstore/python-lazyImports/tests/test_fake_api.py
+++ b/samples/openapi3/client/petstore/python-lazyImports/tests/test_fake_api.py
@@ -30,70 +30,55 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'string'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_string()
             self.assertEqual("string", returned)
-    
+
     def testReturnInt(self):
         """Test ReturnInt"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'1'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_int()
             self.assertEqual(1, returned)
-    
+
     def testReturnFloat(self):
         """Test ReturnFloat"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'3.4'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_float()
             self.assertEqual(3.4, returned)
-    
+
     def testReturnBoolean(self):
         """Test ReturnBool"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'true'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_boolean()
             self.assertEqual(True, returned)
-    
+
     def testReturnEnum(self):
         """Test ReturnEnum"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'a'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
@@ -105,40 +90,31 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"a": "a"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {"content-type": "text/plain"}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_str_like_json()
             self.assertEqual('{"a": "a"}', returned)
-        
+
     def testEnumLikeJson(self):
         """Test EnumLikeJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"a": "a"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {"content-type": "text/plain"}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_enum_like_json()
             self.assertEqual('{"a": "a"}', returned)
-    
+
     def testByteLikeJson(self):
         """Test ByteLikeJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"a": "a"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
@@ -153,10 +129,7 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"value": "0"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
                 "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ) as call_api_mock:
@@ -171,70 +144,55 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'"a"'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_string()
             self.assertEqual('a', returned)
-    
+
     def testTopLevelIntJson(self):
         """Test TopLevelIntJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'1'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_int()
             self.assertEqual(1, returned)
-    
+
     def testTopLevelFloatJson(self):
         """Test TopLevelFloatJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'3.4'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_float()
             self.assertEqual(3.4, returned)
-    
+
     def testTopLevelBoolJson(self):
         """Test TopLevelBoolJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'true'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_boolean()
             self.assertEqual(True, returned)
-    
+
     def testTopLevelEnumJson(self):
         """Test TopLevelEnumJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'"a"'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -312,7 +312,7 @@ class ApiClient:
                 return_data = self.__deserialize_file(response_data)
             elif response_type is not None:
                 match = None
-                content_type = response_data.getheader('content-type')
+                content_type = response_data.headers.get('content-type')
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
@@ -329,7 +329,7 @@ class ApiClient:
         return ApiResponse(
             status_code = response_data.status,
             data = return_data,
-            headers = response_data.getheaders(),
+            headers = response_data.headers,
             raw_data = response_data.data
         )
 
@@ -708,7 +708,7 @@ class ApiClient:
         os.close(fd)
         os.remove(path)
 
-        content_disposition = response.getheader("Content-Disposition")
+        content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
             m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',

--- a/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/exceptions.py
@@ -128,7 +128,7 @@ class ApiException(OpenApiException):
                     self.body = http_resp.data.decode('utf-8')
                 except Exception:
                     pass
-            self.headers = http_resp.getheaders()
+            self.headers = http_resp.headers
 
     @classmethod
     def from_response(

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -48,12 +48,17 @@ class RESTResponse(io.IOBase):
             self.data = self.response.data
         return self.data
 
+    @property
+    def headers(self):
+        """Returns a dictionary of response headers."""
+        return self.response.headers
+
     def getheaders(self):
-        """Returns a dictionary of the response headers."""
+        """Returns a dictionary of the response headers; use ``headers`` instead."""
         return self.response.headers
 
     def getheader(self, name, default=None):
-        """Returns a given response header."""
+        """Returns a given response header; use ``headers.get()`` instead."""
         return self.response.headers.get(name, default)
 
 

--- a/samples/openapi3/client/petstore/python/tests/test_api.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api.py
@@ -16,29 +16,22 @@ class TestMultipleResponseTypes(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 204
         mock_resp.data = b""
-        mock_resp.getheaders.return_value = {}
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.test_empty_and_non_empty_responses()
-
         assert returned is None
 
     def test_206(self):
         mock_resp = Mock()
         mock_resp.status = 206
         mock_resp.data = b"some text"
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.test_empty_and_non_empty_responses()
-
         assert returned == "some text"
 
 
@@ -51,18 +44,12 @@ class TestErrorResponsesWithModels(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 400
         mock_resp.data = json.dumps({"reason400": "400 reason"}).encode("utf-8")
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader.return_value = ""
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             with pytest.raises(petstore_api.exceptions.BadRequestException) as exc_info:
                 self.fake_api.test_error_responses_with_model()
-
         expected_resp = petstore_api.TestErrorResponsesWithModel400Response(
             reason400="400 reason"
         )
@@ -72,18 +59,12 @@ class TestErrorResponsesWithModels(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 404
         mock_resp.data = json.dumps({"reason404": "404 reason"}).encode("utf-8")
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader.return_value = ""
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
-
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             with pytest.raises(petstore_api.exceptions.NotFoundException) as exc_info:
                 self.fake_api.test_error_responses_with_model()
-
         expected_resp = petstore_api.TestErrorResponsesWithModel404Response(
             reason404="404 reason"
         )

--- a/samples/openapi3/client/petstore/python/tests/test_fake_api.py
+++ b/samples/openapi3/client/petstore/python/tests/test_fake_api.py
@@ -30,70 +30,55 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'string'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_string()
             self.assertEqual("string", returned)
-    
+
     def testReturnInt(self):
         """Test ReturnInt"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'1'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_int()
             self.assertEqual(1, returned)
-    
+
     def testReturnFloat(self):
         """Test ReturnFloat"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'3.4'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_float()
             self.assertEqual(3.4, returned)
-    
+
     def testReturnBoolean(self):
         """Test ReturnBool"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'true'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_boolean()
             self.assertEqual(True, returned)
-    
+
     def testReturnEnum(self):
         """Test ReturnEnum"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'a'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
@@ -105,40 +90,31 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"a": "a"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {"content-type": "text/plain"}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_str_like_json()
             self.assertEqual('{"a": "a"}', returned)
-        
+
     def testEnumLikeJson(self):
         """Test EnumLikeJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"a": "a"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {"content-type": "text/plain"}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_enum_like_json()
             self.assertEqual('{"a": "a"}', returned)
-    
+
     def testByteLikeJson(self):
         """Test ByteLikeJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"a": "a"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "text/plain" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
@@ -153,10 +129,7 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'{"value": "0"}'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
                 "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ) as call_api_mock:
@@ -171,70 +144,55 @@ class TestFakeApi(unittest.TestCase):
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'"a"'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_string()
             self.assertEqual('a', returned)
-    
+
     def testTopLevelIntJson(self):
         """Test TopLevelIntJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'1'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_int()
             self.assertEqual(1, returned)
-    
+
     def testTopLevelFloatJson(self):
         """Test TopLevelFloatJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'3.4'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_float()
             self.assertEqual(3.4, returned)
-    
+
     def testTopLevelBoolJson(self):
         """Test TopLevelBoolJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'true'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):
             returned = self.fake_api.fake_return_boolean()
             self.assertEqual(True, returned)
-    
+
     def testTopLevelEnumJson(self):
         """Test TopLevelEnumJson"""
         mock_resp = Mock()
         mock_resp.status = 200
         mock_resp.data = b'"a"'
-        mock_resp.getheaders.return_value = {}
-        mock_resp.getheader = (
-            lambda name: "application/json" if name == "content-type" else Mock()
-        )
+        mock_resp.headers = {}
         with patch(
             "petstore_api.api_client.ApiClient.call_api", return_value=mock_resp
         ):


### PR DESCRIPTION
openapi-generator still uses methods that have been removed from urllib3 v2.6.0. The solution is as described in urllib3's changelog:

> Removed the HTTPResponse.getheaders() method in favor of
> HTTPResponse.headers. Removed the HTTPResponse.getheader(name,
> default) method in favor of HTTPResponse.headers.get(name, default).
> (#3622)

See https://urllib3.readthedocs.io/en/latest/changelog.html

Close #22514