### PR TITLE
feat: add timeout support to RequestContext and isomorphic-fetch

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/http.mustache
@@ -103,6 +103,7 @@ export class RequestContext {
     private body: RequestBody = undefined;
     private url: URL;
     private signal: AbortSignal | undefined = undefined;
+    private timeout?: number;
     {{#platforms}}
     {{#node}}
     private dispatcher: Dispatcher | undefined = undefined;
@@ -170,6 +171,13 @@ export class RequestContext {
         this.url.searchParams.append(name, value);
     }
 
+    public setTimeout(timeout: number) {
+        this.timeout = timeout;
+    }
+
+    public getTimeout(): number | undefined {
+        return this.timeout;
+    }
     /**
      * Sets a cookie with the name and value. NO check  for duplicate cookies is performed
      *

--- a/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/http/isomorphic-fetch.mustache
@@ -9,13 +9,42 @@ import "whatwg-fetch";
 {{/browser}}
 {{/platforms}}
 
+function withTimeout(fetchFn: any, timeout?: number) {
+  return (url: string, options: any = {}) => {
+    const controller = new AbortController();
+    const userSignal = options.signal as AbortSignal | undefined;
+
+    if (userSignal) {
+      if (userSignal.aborted) {
+        controller.abort();
+      } else {
+        userSignal.addEventListener("abort", () => controller.abort());
+      }
+    }
+
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    if (timeout && timeout > 0) {
+      timeoutId = setTimeout(() => controller.abort(), timeout);
+    }
+
+    return fetchFn(url, { ...options, signal: controller.signal }).finally(
+      () => {
+        if (timeoutId) clearTimeout(timeoutId);
+      }
+    );
+  };
+}
+
+
 export class IsomorphicFetchHttpLibrary implements HttpLibrary {
 
     public send(request: RequestContext): Observable<ResponseContext> {
         let method = request.getHttpMethod().toString();
         let body = request.getBody();
 
-        const resultPromise = fetch(request.getUrl(), {
+        const effectiveFetch = withTimeout(fetch, request.getTimeout?.());
+        const resultPromise = effectiveFetch(request.getUrl(), {
             method: method,
             body: body as any,
             headers: request.getHeaders(),


### PR DESCRIPTION
This PR adds first-class timeout support to the typescript-fetch generator so users can prevent requests from hanging indefinitely.

Why?

The current typescript-fetch client doesn’t offer any way to cancel or fail a request after a specified time.
When Kubernetes or any API becomes slow, consumers have no built-in way to enforce a timeout leading to stalled network calls.

This PR introduces a simple, lightweight solution.

What this PR does
1. Adds a withTimeout() wrapper
-Wraps fetch with an AbortController
-Automatically aborts the request when timeout limit is reached
-Forwards user-provided abort signals correctly

2. Extends RequestContext
-Adds a timeout?: number property
-Ensures timeout travels through the request flow cleanly

3. Integrates timeout into the generated IsomorphicFetchHttpLibrary
-Replaces direct use of fetch
-Uses withTimeout(fetch, request.getTimeout())
so all requests automatically inherit the timeout setting