### PR TITLE
Fixed scala-sttp4-jsoniter compilation error: replace .getRight with .orFail

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/api.mustache
@@ -67,7 +67,7 @@ case class {{classname}}[Auth <: {{invokerPackage}}.Authorization] private (base
         {{>paramMultipartCreation}}{{/formParams}}
       ).flatten){{/isMultipart}}{{/formParams.0}}{{#bodyParam}}
       {{^isFile}}.body(asJson({{paramName}})){{/isFile}}{{#isFile}}.fileBody({{paramName}}){{/isFile}}{{/bodyParam}}
-      .response({{#separateErrorChannel}}{{^returnType}}asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))){{/returnType}}{{#fnHandleDownload}}{{#returnType}}asJson[{{>operationReturnType}}]{{/returnType}}{{/fnHandleDownload}}{{/separateErrorChannel}}{{^separateErrorChannel}}{{^returnType}}asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))).getRight{{/returnType}}{{#returnType}}asJson[{{>operationReturnType}}].getRight{{/returnType}}{{/separateErrorChannel}})
+      .response({{#separateErrorChannel}}{{^returnType}}asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))){{/returnType}}{{#fnHandleDownload}}{{#returnType}}asJson[{{>operationReturnType}}]{{/returnType}}{{/fnHandleDownload}}{{/separateErrorChannel}}{{^separateErrorChannel}}{{^returnType}}asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))).orFail{{/returnType}}{{#returnType}}asJson[{{>operationReturnType}}].orFail{{/returnType}}{{/separateErrorChannel}})
 
 {{/operation}}
 {{/operations}}


### PR DESCRIPTION
Fixes #22047

  ## Summary
  The scala-sttp4-jsoniter generator produces non-compiling Scala 3 code when `separateErrorChannel=false` is set. The generated code uses `.getRight` which was removed from STTP4 between versions 4.0.0-M1 and 4.0.0-RC1.

  ## Motivation
  STTP library changed its API between milestone and RC releases:
  - **Removed**: `.getRight` and `.getEither` extension methods
  - **Replaced with**: `.orFail` and `.orFailDeserialization` methods
  - **Reference**: [STTP v3 to v4 Migration Guide](https://sttp.softwaremill.com/en/latest/migrate_v3_v4.html)

  The openapi-generator templates were not updated to reflect this breaking change, causing compilation failures for all generated clients using STTP 4.0.0-RC1+.

  ## Changes
  - Updated `api.mustache` template in `modules/openapi-generator/src/main/resources/scala-sttp4-jsoniter/` and replaced `.getRight` with `.orFail` when `separateErrorChannel=false`
  
  ### Reproduction Steps

  1. Create test spec (`test-api.yaml`):
  ```yaml
  openapi: 3.0.0
  info:
    title: Test API
    version: 1.0.0
  servers:
    - url: https://api.example.com
  paths:
    /test:
      post:
        operationId: testOperation
        responses:
          '204':
            description: No content
          '400':
            description: Bad request
            content:
              application/json:
                schema:
                  type: object
```

  2. Config file (config.yaml):
  ```separateErrorChannel: false```

  3. Generate client:
 ```
openapi-generator generate \
    -i test-api.yaml \
    -g scala-sttp4-jsoniter \
    -o generated \
    -c config.yaml
```

  4. Compile (fails before fix):
 ```cd generated && sbt compile```
