### PR TITLE
[kotlin] Add integration test for query params

### DIFF
--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.20.0"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.20.0"
     implementation "org.springframework.boot:spring-boot-starter-web:$spring_boot_version"
+    testImplementation "org.springframework.boot:spring-boot-test:$spring_boot_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/test/kotlin/org/openapitools/integration/PetApiTest.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/test/kotlin/org/openapitools/integration/PetApiTest.kt
@@ -1,0 +1,35 @@
+package org.openapitools.integration
+
+import io.kotlintest.matchers.collections.shouldHaveSize
+import io.kotlintest.specs.ShouldSpec
+import org.openapitools.client.apis.PetApi
+import org.springframework.boot.test.web.client.MockServerRestClientCustomizer
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+
+class PetApiTest : ShouldSpec() {
+    init {
+        should("find by status passing a query parameter with a list of values") {
+            val restClientBuilder: RestClient.Builder = RestClient.builder()
+            val mockServer = MockServerRestClientCustomizer().let {
+                it.customize(restClientBuilder)
+                it.getServer(restClientBuilder)
+            }
+            val petApi = PetApi(restClientBuilder.build())
+
+            mockServer.expect(requestTo("/pet/findByStatus?status=pending,available"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("[]", APPLICATION_JSON))
+
+            val response = petApi.findPetsByStatus(listOf(PetApi.StatusFindPetsByStatus.pending, PetApi.StatusFindPetsByStatus.available))
+
+            mockServer.verify()
+
+            response shouldHaveSize 0
+        }
+    }
+}

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/test/kotlin/org/openapitools/integration/UserApiTest.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/test/kotlin/org/openapitools/integration/UserApiTest.kt
@@ -1,0 +1,35 @@
+package org.openapitools.integration
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.ShouldSpec
+import org.openapitools.client.apis.UserApi
+import org.springframework.boot.test.web.client.MockServerRestClientCustomizer
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType.TEXT_PLAIN
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+
+class UserApiTest : ShouldSpec() {
+    init {
+        should("call login user passing a query parameter with a single value") {
+            val restClientBuilder: RestClient.Builder = RestClient.builder()
+            val mockServer = MockServerRestClientCustomizer().let {
+                it.customize(restClientBuilder)
+                it.getServer(restClientBuilder)
+            }
+            val userApi = UserApi(restClientBuilder.build())
+
+            mockServer.expect(requestTo("/user/login?username=myUsername&password=myPassword"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("login response", TEXT_PLAIN))
+
+            val response = userApi.loginUser("myUsername", "myPassword")
+
+            mockServer.verify()
+
+            response shouldBe "login response"
+        }
+    }
+}


### PR DESCRIPTION
This is a test for a regression from #22512 where param values were written as a list.

The test passes when the change to ApiClient.kt is reverted. Fails on the regression:
```
Expected :/pet/findByStatus?status=pending,available
Actual   :/pet/findByStatus?status=%5Bpending%2Cavailable%5D

Expected :/user/login?username=myUsername&password=myPassword
Actual   :/user/login?username=%5BmyUsername%5D&password=%5BmyPassword%5D
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann @Zomzog  @andrewemery  @4brunu  @yutaka0m  @stefankoppier  @e5l

I did not run generators because it fails:
```
[pool-1-thread-14] Generation failed for csharp: (IllegalArgumentException) The input (net10.0) contains Invalid .NET framework version: net10.0. List of supported versions: netstandard1.3, netstandard1.4, netstandard1.5, netstandard1.6, netstandard2.0, netstandard2.1, net47, net48, net8.0, net9.0
java.lang.IllegalArgumentException: The input (net10.0) contains Invalid .NET framework version: net10.0. List of supported versions: netstandard1.3, netstandard1.4, netstandard1.5, netstandard1.6, netstandard2.0, netstandard2.1, net47, net48, net8.0, net9.0
        at org.openapitools.codegen.languages.CSharpClientCodegen.processOpts(CSharpClientCodegen.java:818)

```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kotlin integration tests to verify query parameter encoding in the Spring RestClient and catch the regression from #22512 where values were wrapped as lists. Tests cover PetApi findByStatus (comma-separated list) and UserApi login (single values).

- **Dependencies**
  - Add spring-boot-test for MockServerRestClientCustomizer.

<sup>Written for commit 67676880f7ab4a07e4cc0b4e9ec603c3d761a950. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

