### PR TITLE
[dart-dio] Fix webhook imports generating Map-style strings

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -36,6 +36,7 @@ import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.model.WebhooksMap;
 import org.openapitools.codegen.templating.CommonTemplateContentLocator;
 import org.openapitools.codegen.templating.GeneratorTemplateContentLocator;
 import org.openapitools.codegen.templating.MustacheEngineAdapter;
@@ -649,8 +650,25 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         super.postProcessOperationsWithModels(objs, allModels);
         OperationMap operations = objs.getOperations();
-        List<CodegenOperation> operationList = operations.getOperation();
+        processImports(operations, operations.getOperation());
+        return objs;
+    }
 
+    @Override
+    public WebhooksMap postProcessWebhooksWithModels(WebhooksMap objs, List<ModelMap> allModels) {
+        super.postProcessWebhooksWithModels(objs, allModels);
+        OperationMap operations = objs.getWebhooks();
+        processImports(operations, operations.getOperation());
+        return objs;
+    }
+
+    /**
+     * Processes imports for operations or webhooks, applying the same logic to both.
+     *
+     * @param operations the OperationMap containing the operations
+     * @param operationList the list of CodegenOperation to process
+     */
+    private void processImports(OperationMap operations, List<CodegenOperation> operationList) {
         Set<String> resultImports = new HashSet<>();
 
         for (CodegenOperation op : operationList) {
@@ -687,7 +705,7 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
             if (SERIALIZATION_LIBRARY_JSON_SERIALIZABLE.equals(library)) {
                 // built_value serialization uses Uint8List for all MultipartFile types
                 // in json_serialization, MultipartFile is used as the file parameter type, but
-                // MultipartFile isn't readable, instead we convert this to a Uin8List
+                // MultipartFile isn't readable, instead we convert this to a Uint8List
                 if (op.isResponseFile) {
                     op.imports.add("Uint8List");
                     op.returnType = "Uint8List";
@@ -729,9 +747,7 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
             }
         }
         // for some reason "import" structure is changed ..
-        objs.put("imports", resultImports.stream().sorted().collect(Collectors.toList()));
-
-        return objs;
+        operations.put("imports", resultImports.stream().sorted().collect(Collectors.toList()));
     }
 
     private void addBuiltValueSerializerImport(String type) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/DartDioClientCodegen.java
@@ -650,7 +650,7 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
     public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
         super.postProcessOperationsWithModels(objs, allModels);
         OperationMap operations = objs.getOperations();
-        processImports(operations, operations.getOperation());
+        processImports(operations.getOperation(), imports -> objs.put("imports", imports));
         return objs;
     }
 
@@ -658,17 +658,17 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
     public WebhooksMap postProcessWebhooksWithModels(WebhooksMap objs, List<ModelMap> allModels) {
         super.postProcessWebhooksWithModels(objs, allModels);
         OperationMap operations = objs.getWebhooks();
-        processImports(operations, operations.getOperation());
+        processImports(operations.getOperation(), imports -> objs.put("imports", imports));
         return objs;
     }
 
     /**
      * Processes imports for operations or webhooks, applying the same logic to both.
      *
-     * @param operations the OperationMap containing the operations
      * @param operationList the list of CodegenOperation to process
+     * @param setImports the handler to apply the processed imports
      */
-    private void processImports(OperationMap operations, List<CodegenOperation> operationList) {
+    private void processImports(List<CodegenOperation> operationList, java.util.function.Consumer<List<String>> setImports) {
         Set<String> resultImports = new HashSet<>();
 
         for (CodegenOperation op : operationList) {
@@ -747,7 +747,7 @@ public class DartDioClientCodegen extends AbstractDartCodegen {
             }
         }
         // for some reason "import" structure is changed ..
-        operations.put("imports", resultImports.stream().sorted().collect(Collectors.toList()));
+        setImports.accept(resultImports.stream().sorted().collect(Collectors.toList()));
     }
 
     private void addBuiltValueSerializerImport(String type) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/dart/dio/DartDioClientCodegenTest.java
@@ -146,7 +146,7 @@ public class DartDioClientCodegenTest {
 
         // Bug symptom #22586: Map-style import with HTML entity encoding
         // Before fix: import '{import&#x3D;model.Pet, classname&#x3D;Pet}';
-        // After fix: import 'package:my_package/lib/src/gen/model/pet.dart';
+        // After fix: import 'package:my-package/src/model/pet.dart';
         Assert.assertFalse(apiContent.contains("import '{"),
             "Webhook should not contain Map-style import (bug #22586 symptom)");
         Assert.assertFalse(apiContent.contains("&#x3D;"),


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Webhook operations were generating broken import statements with Map-style representation and HTML entity encoding:
  `import '{import&#x3D;model.Pet, classname&#x3D;Pet}';`

Instead of proper Dart package imports:
  `import 'package:my-package/src/model/pet.dart';`

This occurred because ``DartDioClientCodegen.postProcessOperationsWithModels()`` applied import processing to regular operations, but ``postProcessWebhooksWithModels()`` was missing the same logic.

Fix:
- Extracted shared import processing logic into ``processImports()`` method, just like C#
- Added ``postProcessWebhooksWithModels()`` override to apply same logic
- Both operations and webhooks now use consistent import generation

Test:
- Added ``verifyWebhookImports()`` test using existing ``webhooks.yaml`` resource
- Verifies generated code does not contain Map-style imports
- Verifies generated code does not contain HTML entity encoding

Closes #22586 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Dart Dio webhook imports that were emitted as Map-style, HTML-encoded strings. Webhooks now generate proper package imports and compile correctly. Fixes #22586.

- **Bug Fixes**
  - Extracted shared import logic into processImports() and applied it in postProcessWebhooksWithModels() to mirror operations.
  - Added verifyWebhookImports test to ensure no Map-style or HTML-encoded imports.

<sup>Written for commit 2dd599cef29b9204195fe13817fbae4908560ec9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

