### PR TITLE
fix(dart-dio): use enum type for discriminator when property is enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class.mustache
@@ -13,7 +13,6 @@ part '{{classFilename}}.g.dart';
 }
 {{#discriminator}}{{#hasDiscriminatorWithNonEmptyMapping}}
 {{>serialization/built_value/class_discriminator}}
-
 {{/hasDiscriminatorWithNonEmptyMapping}}{{/discriminator}}
 {{>serialization/built_value/class_serializer}}{{#vendorExtensions.x-is-parent}}
 

--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_discriminator.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/serialization/built_value/class_discriminator.mustache
@@ -1,3 +1,4 @@
+{{^discriminator.isEnum}}
 extension {{classname}}DiscriminatorExt on {{classname}} {
     String? get discriminatorValue {
         {{#mappedModels}}
@@ -18,3 +19,26 @@ extension {{classname}}BuilderDiscriminatorExt on {{classname}}Builder {
         return null;
     }
 }
+{{/discriminator.isEnum}}
+{{#discriminator.isEnum}}
+extension {{classname}}DiscriminatorExt on {{classname}} {
+    {{discriminator.propertyType}} get discriminatorValue {
+        {{#mappedModels}}
+        if (this is {{modelName}}) {
+            return {{discriminator.propertyType}}.valueOf(r'{{mappingName}}');
+        }
+        {{/mappedModels}}
+        throw UnsupportedError('Invalid discriminator value for {{classname}}');
+    }
+}
+extension {{classname}}BuilderDiscriminatorExt on {{classname}}Builder {
+    {{discriminator.propertyType}} get discriminatorValue {
+        {{#mappedModels}}
+        if (this is {{modelName}}Builder) {
+            return {{discriminator.propertyType}}.valueOf(r'{{mappingName}}');
+        }
+        {{/mappedModels}}
+        throw UnsupportedError('Invalid discriminator value for {{classname}}Builder');
+    }
+}
+{{/discriminator.isEnum}}

--- a/modules/openapi-generator/src/test/resources/3_0/dart-dio/enum-discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/dart-dio/enum-discriminator.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: Dart Dio Enum Discriminator
+  version: 1.0.0
+paths:
+  /merchant:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MerchantDetailsDto'
+components:
+  schemas:
+    MerchantDetailsDto:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+        merchantType:
+          $ref: '#/components/schemas/MerchantTypeEnum'
+      required:
+        - uuid
+        - merchantType
+      discriminator:
+        propertyName: merchantType
+        mapping:
+          TYPE_A: '#/components/schemas/MerchantDetailsTypeADto'
+          TYPE_B: '#/components/schemas/MerchantDetailsTypeBDto'
+    MerchantDetailsTypeADto:
+      allOf:
+        - $ref: '#/components/schemas/MerchantDetailsDto'
+        - type: object
+          properties:
+            aField:
+              type: string
+    MerchantDetailsTypeBDto:
+      allOf:
+        - $ref: '#/components/schemas/MerchantDetailsDto'
+        - type: object
+          properties:
+            bField:
+              type: string
+    MerchantTypeEnum:
+      type: string
+      enum:
+        - TYPE_A
+        - TYPE_B

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/fruit.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/src/model/fruit.dart
@@ -46,25 +46,25 @@ abstract class Fruit implements Built<Fruit, FruitBuilder> {
 }
 
 extension FruitDiscriminatorExt on Fruit {
-    String? get discriminatorValue {
+    FruitType get discriminatorValue {
         if (this is Apple) {
-            return r'APPLE';
+            return FruitType.valueOf(r'APPLE');
         }
         if (this is Banana) {
-            return r'BANANA';
+            return FruitType.valueOf(r'BANANA');
         }
-        return null;
+        throw UnsupportedError('Invalid discriminator value for Fruit');
     }
 }
 extension FruitBuilderDiscriminatorExt on FruitBuilder {
-    String? get discriminatorValue {
+    FruitType get discriminatorValue {
         if (this is AppleBuilder) {
-            return r'APPLE';
+            return FruitType.valueOf(r'APPLE');
         }
         if (this is BananaBuilder) {
-            return r'BANANA';
+            return FruitType.valueOf(r'BANANA');
         }
-        return null;
+        throw UnsupportedError('Invalid discriminator value for FruitBuilder');
     }
 }
 


### PR DESCRIPTION
When discriminator property references an enum type, use that enum type instead of String for `discriminatorValue` getter/extension. This ensures type safety and proper enum handling in generated Dart code.

Changes:
- Updated `class_discriminator.mustache` to handle enum discriminators
- Use `enum.valueOf()` for enum discriminators, throw error instead of returning null
- Added test case for enum discriminator scenario
- regenerated sample client with correct enum discriminator handling

Fixes #21570

This is a breaking change. When the discriminator property is an enum type, `discriminatorValue` return type changes from `String?` to the actual enum type, and throws an exception instead of returning null. Users who rely on string parsing this return value will need to update their code to handle the new enum type. I am opening to add any config if needed, but the old behaviour is not compilable for resources with discriminator issues, so such this PR's behaviour should be at least set as default.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch discriminatorValue to use the enum type when the discriminator property is an enum in Dart-Dio built_value models. This improves type safety and fixes incorrect string-based handling. Fixes #21570.

- **Bug Fixes**
  - Generate discriminatorValue as the enum type (not String?).
  - Use Enum.valueOf for mapped models; throw UnsupportedError on invalid type.
  - Added test for enum discriminator and regenerated samples.

- **Migration**
  - Use the returned enum directly; stop parsing strings.
  - Remove null checks on discriminatorValue; handle UnsupportedError if needed.

<sup>Written for commit 931346cd46f1271465d27e1eacb0cf175f5908b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

