### PR TITLE
fix: dereference header before normalizing

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -556,10 +556,16 @@ public class OpenAPINormalizer {
             return;
         }
 
-        for (String headerKey : headers.keySet()) {
-            Header h = headers.get(headerKey);
-            Schema updatedHeader = normalizeSchema(h.getSchema(), new HashSet<>());
-            h.setSchema(updatedHeader);
+        for (Header header : headers.values()) {
+            // dereference header
+            if (StringUtils.isNotEmpty(header.get$ref())) {
+                header = ModelUtils.getReferencedHeader(openAPI, header);
+            }
+
+            if (header.getSchema() != null) {
+                Schema<?> updatedHeader = normalizeSchema(header.getSchema(), new HashSet<>());
+                header.setSchema(updatedHeader);
+            }
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -1306,6 +1306,20 @@ public class OpenAPINormalizerTest {
         assertNotNull(inlinePropertyAfter.getProperties().get("nestedNumber"));
     }
 
+    @Test
+    public void testDereferenceHeaderBeforeNormalize() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_22576.yaml");
+
+        Map<String, String> options = new HashMap<>();
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+
+        try {
+            openAPINormalizer.normalize();
+        } catch (Exception e) {
+            fail("Should not have thrown exception", e);
+        }
+    }
+
     public static class RemoveRequiredNormalizer extends OpenAPINormalizer {
 
         public RemoveRequiredNormalizer(OpenAPI openAPI, Map<String, String> inputRules) {

--- a/modules/openapi-generator/src/test/resources/3_1/issue_22576.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_22576.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /test:
+    post:
+      summary: Test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        200:
+          description: OK
+        401:
+          description: Unauthorized
+          headers:
+            WWW-Authenticate:
+              $ref: "#/components/headers/WWWAuthenticate"
+components:
+  headers:
+    WWWAuthenticate:
+      required: false
+      schema:
+        type: string


### PR DESCRIPTION
Fixes null pointer issue within #22576.

Without fix applied:

```
$ java -Dlog.level=warn -jar openapi-generator-cli.jar generate -i containers_4.yaml -g spring -o generated
[main] ERROR o.o.codegen.DefaultGenerator - An exception occurred in OpenAPI Normalizer. Please report the issue via https://github.com/openapitools/openapi-generator/issues/new/:
[main] ERROR o.o.codegen.DefaultGenerator - An exception occurred in OpenAPI Normalizer. Please report the issue via https://github.com/openapitools/openapi-generator/issues/new/:
java.lang.NullPointerException: Cannot invoke "io.swagger.v3.oas.models.media.Schema.get$ref()" because "schema" is null
	at org.openapitools.codegen.OpenAPINormalizer.normalizeSchema(OpenAPINormalizer.java:699)
	at org.openapitools.codegen.OpenAPINormalizer.normalizeHeaders(OpenAPINormalizer.java:561)
	at org.openapitools.codegen.OpenAPINormalizer.normalizeResponse(OpenAPINormalizer.java:545)
	at org.openapitools.codegen.OpenAPINormalizer.normalizeResponses(OpenAPINormalizer.java:533)
	at org.openapitools.codegen.OpenAPINormalizer.normalizePaths(OpenAPINormalizer.java:426)
	at org.openapitools.codegen.OpenAPINormalizer.normalize(OpenAPINormalizer.java:355)
	at org.openapitools.codegen.DefaultGenerator.configureGeneratorProperties(DefaultGenerator.java:266)
	at org.openapitools.codegen.DefaultGenerator.generate(DefaultGenerator.java:1277)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:535)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
[main] WARN  o.o.codegen.utils.ExamplesUtils - No application/json content media type found in response. Response examples can currently only be generated for application/json media type.
############################################################################################
# Thanks for using OpenAPI Generator.                                                      #
# We appreciate your support! Please consider donation to help us maintain this project.   #
# https://opencollective.com/openapi_generator/donate                                      #
############################################################################################
```

With fix applied:

```
$ java -Dlog.level=warn -jar openapi-generator-cli.jar generate -i containers_4.yaml -g spring -o generated
[main] WARN  o.o.codegen.utils.ExamplesUtils - No application/json content media type found in response. Response examples can currently only be generated for application/json media type.
############################################################################################
# Thanks for using OpenAPI Generator.                                                      #
# We appreciate your support! Please consider donation to help us maintain this project.   #
# https://opencollective.com/openapi_generator/donate                                      #
############################################################################################
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dereference header references before normalizing to prevent a NullPointerException when a header schema is missing. Fixes #22576 and stops generator crashes for OAS 3.1 specs with $ref headers.

- **Bug Fixes**
  - In normalizeHeaders, dereference headers with $ref and normalize only when schema exists.
  - Added a unit test and 3.1 spec fixture to confirm normalization runs without exceptions.

<sup>Written for commit 149eca243ecec2f96a62bbf8d2a3aa05ec27be0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

