### PR TITLE
[Core] Fix isDouble flag not being set for 'type: number' without format

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3002,7 +3002,9 @@ public class DefaultCodegen implements CodegenConfig {
         model.isNumeric = Boolean.TRUE;
         if (ModelUtils.isFloatSchema(schema)) { // float
             model.isFloat = Boolean.TRUE;
-        } else if (ModelUtils.isDoubleSchema(schema)) { // double
+        } else {
+            // Set isDouble for explicit "format: double" OR when no format is specified
+            // (since "type: number" without format defaults to Double in most languages)
             model.isDouble = Boolean.TRUE;
         }
     }
@@ -3886,7 +3888,9 @@ public class DefaultCodegen implements CodegenConfig {
         property.isNumeric = Boolean.TRUE;
         if (ModelUtils.isFloatSchema(p)) { // float
             property.isFloat = Boolean.TRUE;
-        } else if (ModelUtils.isDoubleSchema(p)) { // double
+        } else {
+            // Set isDouble for explicit "format: double" OR when no format is specified
+            // (since "type: number" without format defaults to Double in most languages)
             property.isDouble = Boolean.TRUE;
         }
     }


### PR DESCRIPTION
Potentially fixes - https://github.com/OpenAPITools/openapi-generator/issues/22624
When a schema has 'type: number' without an explicit 'format: double', the isDouble flag was not being set even though the dataType correctly resolves to Double. This caused Swift6 (and potentially other generators) to incorrectly add ParameterConvertible conformance to number enums.

The fix ensures isDouble is set to true for all number types that are not explicitly float, matching the behavior of the type mapping.

Affected methods:
- updateModelForNumber (for standalone enum models)
- updatePropertyForNumber (for inline enum properties)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed isDouble not being set for type: number without format. This aligns flags with Double type mapping and prevents Swift6 from adding ParameterConvertible to number enums.

- **Bug Fixes**
  - Set isDouble=true for non-float number schemas in updateModelForNumber and updatePropertyForNumber.
  - Covers both explicit format: double and no-format cases to keep generator behavior consistent.

<sup>Written for commit 349158b155bf716b37f7bda69838f150511fb87c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

