### PR TITLE
[kotlin-spring] Revert nested property placeholder in @RequestMapping that Spring cannot resolve

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache
@@ -30,9 +30,6 @@ import org.springframework.validation.annotation.Validated
 {{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-{{#useRequestMappingOnController}}
-import {{#apiPackage}}{{.}}.{{/apiPackage}}{{classname}}Controller.Companion.BASE_PATH
-{{/useRequestMappingOnController}}
 
 {{#useBeanValidation}}
 import {{javaxPackage}}.validation.Valid
@@ -60,9 +57,7 @@ import kotlin.collections.Map
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}
 {{#useRequestMappingOnController}}
-{{=<% %>=}}
-@RequestMapping("\${openapi.<%title%>.base-path:\${api.base-path:$BASE_PATH}}")
-<%={{ }}=%>
+@RequestMapping("\${api.base-path:{{contextPath}}}")
 {{/useRequestMappingOnController}}
 {{#operations}}
 class {{classname}}Controller({{#serviceInterface}}@Autowired(required = true) val service: {{classname}}Service{{/serviceInterface}}) {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
@@ -3,17 +3,12 @@ package {{package}}
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-{{#useRequestMappingOnController}}
-import {{#apiPackage}}{{.}}.{{/apiPackage}}{{classname}}Controller.Companion.BASE_PATH
-{{/useRequestMappingOnController}}
 
 {{>generatedAnnotation}}
 
 @Controller{{#beanQualifiers}}("{{package}}.{{classname}}Controller"){{/beanQualifiers}}
 {{#useRequestMappingOnController}}
-{{=<% %>=}}
-@RequestMapping("\${openapi.<%title%>.base-path:\${api.base-path:$BASE_PATH}}")
-<%={{ }}=%>
+@RequestMapping("\${api.base-path:{{contextPath}}}")
 {{/useRequestMappingOnController}}
 {{#operations}}
 class {{classname}}Controller(

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache
@@ -35,9 +35,6 @@ import org.springframework.validation.annotation.Validated
 {{/useBeanValidation}}
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-{{#useRequestMappingOnInterface}}
-import {{#apiPackage}}{{.}}.{{/apiPackage}}{{classname}}.Companion.BASE_PATH
-{{/useRequestMappingOnInterface}}
 
 {{#useBeanValidation}}
 import {{javaxPackage}}.validation.constraints.DecimalMax
@@ -67,9 +64,7 @@ import kotlin.collections.Map
 @Api(value = "{{{baseName}}}", description = "The {{{baseName}}} API")
 {{/swagger1AnnotationLibrary}}
 {{#useRequestMappingOnInterface}}
-{{=<% %>=}}
-@RequestMapping("\${openapi.<%title%>.base-path:\${api.base-path:$BASE_PATH}}")
-<%={{ }}=%>
+@RequestMapping("\${api.base-path:{{contextPath}}}")
 {{/useRequestMappingOnInterface}}
 {{#operations}}
 interface {{classname}} {

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/apiInterface.mustache
@@ -6,9 +6,6 @@ package {{package}}
 
 {{#imports}}import {{import}}
 {{/imports}}
-{{#useRequestMappingOnInterface}}
-import {{#apiPackage}}{{.}}.{{/apiPackage}}{{classname}}.Companion.BASE_PATH
-{{/useRequestMappingOnInterface}}
 
 {{#swagger2AnnotationLibrary}}
 import io.swagger.v3.oas.annotations.*
@@ -51,9 +48,7 @@ import kotlin.collections.List
 import kotlin.collections.Map
 
 {{#useRequestMappingOnInterface}}
-{{=<% %>=}}
-@HttpExchange("\${openapi.<%title%>.base-path:\${api.base-path:$BASE_PATH}}")
-<%={{ }}=%>
+@HttpExchange("\${api.base-path:{{contextPath}}}")
 {{/useRequestMappingOnInterface}}
 {{#useBeanValidation}}
 @Validated

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java
@@ -141,9 +141,11 @@ public class KotlinSpringServerCodegenTest {
                 "@RequestMapping(\"\\${"
         );
         // Check that the @RequestMapping annotation is generated in the ApiController file
+        // Note: We use simple ${api.base-path:<default>} syntax because Spring's @RequestMapping
+        // doesn't properly resolve nested ${outer:${inner:default}} property placeholder syntax
         assertFileContains(
                 Paths.get(output + "/src/main/kotlin/org/openapitools/api/PetApiController.kt"),
-                "@RequestMapping(\"\\${openapi.openAPIPetstore.base-path:\\${api.base-path:$BASE_PATH}}\")",
+                "@RequestMapping(\"\\${api.base-path:/v2}\")",
                 "    companion object {\n"
                 + "    //for your own safety never directly reuse these path definitions in tests\n"
                 + "        const val BASE_PATH: String = \"/v2\"\n"
@@ -156,9 +158,11 @@ public class KotlinSpringServerCodegenTest {
         File output = generatePetstoreWithRequestMappingMode(KotlinSpringServerCodegen.RequestMappingMode.api_interface);
 
         // Check that the @RequestMapping annotation is generated in the Api file
+        // Note: We use simple ${api.base-path:<default>} syntax because Spring's @RequestMapping
+        // doesn't properly resolve nested ${outer:${inner:default}} property placeholder syntax
         assertFileContains(
                 Paths.get(output + "/src/main/kotlin/org/openapitools/api/PetApi.kt"),
-                "@RequestMapping(\"\\${openapi.openAPIPetstore.base-path:\\${api.base-path:$BASE_PATH}}\")",
+                "@RequestMapping(\"\\${api.base-path:/v2}\")",
                 "    companion object {\n"
                 + "        //for your own safety never directly reuse these path definitions in tests\n"
                 + "        const val BASE_PATH: String = \"/v2\""
@@ -1310,11 +1314,11 @@ public class KotlinSpringServerCodegenTest {
         generator.opts(input).generate();
 
         Path path = Paths.get(outputPath + "/src/main/kotlin/org/openapitools/api/StoreApiClient.kt");
+        // Note: We use simple ${api.base-path:<default>} syntax because Spring's @HttpExchange
+        // doesn't properly resolve nested ${outer:${inner:default}} property placeholder syntax
         assertFileContains(
                 path,
-                "@HttpExchange(\n"
-                + "\"\\${openapi.openAPIPetstore.base-path:\\${api.base-path:$BASE_PATH}}\"\n"
-                + ")",
+                "@HttpExchange(\"\\${api.base-path:/v2}\")",
                 "    fun getInventory(\n"
                 + "    ): Map<String, kotlin.Int>",
                 "    fun deleteOrder(\n"

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/FakeApiController.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/FakeApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.FakeApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class FakeApiController() {
 
     @Operation(

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController() {
 
     @Operation(

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController() {
 
     @Operation(

--- a/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-spring-default/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController() {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/api/TestApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-bigdecimal-default/src/main/kotlin/org/openapitools/api/TestApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.TestApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.demo.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:}")
 class TestApiController() {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/api/PetApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/api/PetApi.kt
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApi.Companion.BASE_PATH
 
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
@@ -37,7 +36,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 interface PetApi {
 
     fun getDelegate(): PetApiDelegate

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/api/StoreApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/api/StoreApi.kt
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApi.Companion.BASE_PATH
 
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
@@ -36,7 +35,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 interface StoreApi {
 
     fun getDelegate(): StoreApiDelegate

--- a/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/api/UserApi.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate-nodefaults/src/main/kotlin/org/openapitools/api/UserApi.kt
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApi.Companion.BASE_PATH
 
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
@@ -36,7 +35,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 interface UserApi {
 
     fun getDelegate(): UserApiDelegate

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -3,11 +3,10 @@ package org.openapitools.api
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.19.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(
         private val delegate: PetApiDelegate
 ) : PetApi {

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -3,11 +3,10 @@ package org.openapitools.api
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.19.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(
         private val delegate: StoreApiDelegate
 ) : StoreApi {

--- a/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-include-http-request-context-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -3,11 +3,10 @@ package org.openapitools.api
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.19.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(
         private val delegate: UserApiDelegate
 ) : UserApi {

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-multipart-request-model/src/main/kotlin/org/openapitools/api/MultipartMixedApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-multipart-request-model/src/main/kotlin/org/openapitools/api/MultipartMixedApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.MultipartMixedApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.multipartFileTest.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:}")
 class MultipartMixedApiController() {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -3,11 +3,10 @@ package org.openapitools.api
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.19.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(
         delegate: PetApiDelegate?
 ) : PetApi {

--- a/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -3,11 +3,10 @@ package org.openapitools.api
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.19.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(
         delegate: StoreApiDelegate?
 ) : StoreApi {

--- a/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -3,11 +3,10 @@ package org.openapitools.api
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.Optional
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 @javax.annotation.Generated(value = ["org.openapitools.codegen.languages.KotlinSpringServerCodegen"], comments = "Generator version: 7.19.0-SNAPSHOT")
 @Controller
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(
         delegate: UserApiDelegate?
 ) : UserApi {

--- a/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -26,7 +25,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)

--- a/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -25,7 +24,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-no-response-entity/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -25,7 +24,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
     @ResponseStatus(HttpStatus.OK)

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -33,7 +32,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive-without-flow/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -33,7 +32,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-reactive/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -35,7 +34,7 @@ import kotlin.collections.Map
 @RestController
 @Validated
 @Api(value = "pet", description = "The pet API")
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -34,7 +33,7 @@ import kotlin.collections.Map
 @RestController
 @Validated
 @Api(value = "store", description = "The store API")
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -34,7 +33,7 @@ import kotlin.collections.Map
 @RestController
 @Validated
 @Api(value = "user", description = "The user API")
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -32,7 +31,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -31,7 +30,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
     @Operation(

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -35,7 +34,7 @@ import kotlin.collections.Map
 @RestController
 @Validated
 @Api(value = "pet", description = "The pet API")
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -34,7 +33,7 @@ import kotlin.collections.Map
 @RestController
 @Validated
 @Api(value = "store", description = "The store API")
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -34,7 +33,7 @@ import kotlin.collections.Map
 @RestController
 @Validated
 @Api(value = "user", description = "The user API")
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.PetApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -27,7 +26,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class PetApiController(@Autowired(required = true) val service: PetApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.StoreApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -26,7 +25,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class StoreApiController(@Autowired(required = true) val service: StoreApiService) {
 
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.openapitools.api.UserApiController.Companion.BASE_PATH
 
 import javax.validation.Valid
 import javax.validation.constraints.DecimalMax
@@ -26,7 +25,7 @@ import kotlin.collections.Map
 
 @RestController
 @Validated
-@RequestMapping("\${openapi.openAPIPetstore.base-path:\${api.base-path:$BASE_PATH}}")
+@RequestMapping("\${api.base-path:/v2}")
 class UserApiController(@Autowired(required = true) val service: UserApiService) {
 
 


### PR DESCRIPTION
## Summary

Fixes a regression (#22609) by reverting the nested property placeholder syntax introduced in #22377 back to the simple `${api.base-path:<default>}` syntax that worked in version 7.17.0.

**Before (7.18.0 - broken):**
```kotlin
@RequestMapping("${openapi.openAPIPetstore.base-path:${api.base-path:/v2}}")
```

**After (this fix - same as 7.17.0):**
```kotlin
@RequestMapping("${api.base-path:/v2}")
```

## Problem

Spring's `@RequestMapping` annotation processing does not properly resolve nested `${outer:${inner:default}}` property placeholder syntax. While the Kotlin string interpolation of `$BASE_PATH` works correctly at compile time (verified via `javap`), the nested placeholder structure causes Spring to fail to apply the base path at runtime.

This results in API endpoints being mounted at incorrect paths (e.g., `/gateways/...` instead of `/api/v1/devices/gateways/...`), causing 404 errors when clients call the expected URLs.

Setting properties explicitly in `application.properties` does not resolve the issue, confirming that Spring's `@RequestMapping` annotation processing doesn't support nested placeholder syntax.

## Solution

Reverted to the simple property placeholder syntax from version 7.17.0:
```kotlin
@RequestMapping("${api.base-path:/v2}")
```

This:
- Uses the OpenAPI spec's server URL as the default value (inlined at generation time)
- Is fully backward compatible with 7.17.0 behavior
- Properly resolves at runtime

## Per-API Base Path Configuration

For users who need different base paths for different APIs (the feature that #22377 attempted to provide), this can be achieved programmatically using Spring's `WebMvcConfigurer`:

```kotlin
@Configuration
class ApiPathConfiguration : WebMvcConfigurer {

    @Value("\${my-petstore-api.base-path:/v2}")
    private lateinit var petstoreBasePath: String

    @Value("\${my-store-api.base-path:/v3}")
    private lateinit var storeBasePath: String

    override fun configurePathMatch(configurer: PathMatchConfigurer) {
        // Configure different base paths for different API controllers
        configurer.addPathPrefix(petstoreBasePath) { clazz ->
            clazz.packageName.contains("petstore")
        }
        configurer.addPathPrefix(storeBasePath) { clazz ->
            clazz.packageName.contains("store")
        }
    }
}
```

This approach:
- Allows fully customizable property names
- Supports multiple APIs with different base paths
- Works reliably with Spring's property resolution
- Can use package names, annotations, or any other criteria to match controllers

## Files Changed

### Templates
- `modules/openapi-generator/src/main/resources/kotlin-spring/api.mustache`
- `modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache`
- `modules/openapi-generator/src/main/resources/kotlin-spring/apiInterface.mustache`
- `modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-declarative-http-interface/apiInterface.mustache`
- `modules/openapi-generator/src/main/resources/kotlin-spring/libraries/spring-boot/application.mustache`

### Tests
- `modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/spring/KotlinSpringServerCodegenTest.java`

## Related Issues

Fixes #22609

## Testing

- Updated existing tests to verify the reverted pattern
- All 3 affected tests pass:
  - `testNoRequestMappingAnnotationController`
  - `testNoRequestMappingAnnotationApiInterface`
  - `generateHttpInterface`

## Technical Committee

cc @dr4ke616 (Kotlin Spring Boot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts Kotlin Spring @RequestMapping from nested property placeholders to the simple ${api.base-path:<default>} so Spring resolves base paths correctly at runtime. Restores 7.17.0 behavior and prevents endpoints mounting at wrong paths.

- **Bug Fixes**
  - Use @RequestMapping("${api.base-path:{{contextPath}}}") in Kotlin Spring and @HttpExchange("${api.base-path:{{contextPath}}}") in declarative HTTP interface templates.
  - Update tests to expect the simple placeholder; all passing.
  - Align sample controllers with the new syntax.

<sup>Written for commit c9ce72ab6baaa6ad0def95c63f953975dac52606. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

