### PR TITLE
Fix Swift oneOf discriminator decoding with enumUnknownDefaultCase

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/modelOneOf.mustache
@@ -19,16 +19,15 @@
         {{/oneOfUnknownDefaultCase}}
         }
     }
+{{#discriminator}}
 
-    {{#discriminator}}
     private enum DiscriminatorCodingKey: String, CodingKey {
         case {{discriminator.propertyName}} = "{{discriminator.propertyBaseName}}"
     }
-    {{/discriminator}}
+{{/discriminator}}
 
     public init(from decoder: Decoder) throws {
-        {{#discriminator}}
-        let keyedContainer = try decoder.container(keyedBy: DiscriminatorCodingKey.self)
+{{#discriminator}}        let keyedContainer = try decoder.container(keyedBy: DiscriminatorCodingKey.self)
         let discriminatorValue = try keyedContainer.decode(String.self, forKey: .{{discriminator.propertyName}})
 
         switch discriminatorValue {
@@ -49,9 +48,7 @@
             )
             {{/oneOfUnknownDefaultCase}}
         }
-        {{/discriminator}}
-        {{^discriminator}}
-        let container = try decoder.singleValueContainer()
+{{/discriminator}}{{^discriminator}}        let container = try decoder.singleValueContainer()
         {{#oneOf}}
         {{#-first}}
         if let value = try? container.decode({{.}}.self) {
@@ -69,6 +66,5 @@
             throw DecodingError.typeMismatch(Self.Type.self, .init(codingPath: decoder.codingPath, debugDescription: "Unable to decode instance of {{classname}}"))
             {{/oneOfUnknownDefaultCase}}
         }
-        {{/discriminator}}
-    }
+{{/discriminator}}    }
 }

--- a/modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache
@@ -19,16 +19,15 @@
         {{/oneOfUnknownDefaultCase}}
         }
     }
+{{#discriminator}}
 
-    {{#discriminator}}
     private enum DiscriminatorCodingKey: String, CodingKey {
         case {{discriminator.propertyName}} = "{{discriminator.propertyBaseName}}"
     }
-    {{/discriminator}}
+{{/discriminator}}
 
     public init(from decoder: Decoder) throws {
-        {{#discriminator}}
-        let keyedContainer = try decoder.container(keyedBy: DiscriminatorCodingKey.self)
+{{#discriminator}}        let keyedContainer = try decoder.container(keyedBy: DiscriminatorCodingKey.self)
         let discriminatorValue = try keyedContainer.decode(String.self, forKey: .{{discriminator.propertyName}})
 
         switch discriminatorValue {
@@ -49,9 +48,7 @@
             )
             {{/oneOfUnknownDefaultCase}}
         }
-        {{/discriminator}}
-        {{^discriminator}}
-        let container = try decoder.singleValueContainer()
+{{/discriminator}}{{^discriminator}}        let container = try decoder.singleValueContainer()
         {{#oneOf}}
         {{#-first}}
         if let value = try? container.decode({{.}}.self) {
@@ -69,6 +66,5 @@
             throw DecodingError.typeMismatch(Self.Type.self, .init(codingPath: decoder.codingPath, debugDescription: "Unable to decode instance of {{classname}}"))
             {{/oneOfUnknownDefaultCase}}
         }
-        {{/discriminator}}
-    }
+{{/discriminator}}    }
 }

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models/Fruit.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models/Fruit.swift
@@ -27,7 +27,6 @@ public enum Fruit: Codable, JSONEncodable, Hashable {
         }
     }
 
-
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let value = try? container.decode(Apple.self) {

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Models/Fruit.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Models/Fruit.swift
@@ -24,7 +24,6 @@ public enum Fruit: Sendable, Codable, ParameterConvertible, Hashable {
         }
     }
 
-
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let value = try? container.decode(Apple.self) {


### PR DESCRIPTION
## Description

This PR implements discriminator-first decoding for oneOf schemas in Swift5 and Swift6 generators to fix issue #7549 where `enumUnknownDefaultCase=true` breaks discriminator-based routing.

### Problem

When `enumUnknownDefaultCase=true` is set, discriminator fields in variant types have an `unknownDefaultOpenApi` fallback case. With the previous sequential `try?` decoding approach:

1. Decoder tries the first variant (e.g., `PredicateBetween`)
2. The discriminator field `type` doesn't match (e.g., "matchesAny" ≠ "between")
3. BUT the `unknownDefaultOpenApi` fallback accepts it - decode succeeds!
4. Wrong variant is selected with corrupted data
5. Correct variant (e.g., `PredicateMatchesAny`) is never tried

### Solution

Implement discriminator-first decoding:

1. **When discriminator exists**: Read discriminator value FIRST using a keyed container, then switch on it to route directly to the correct variant
2. **When no discriminator**: Use the original sequential `try?` approach (backward compatible)

### Changes

**Templates Modified:**
- `modules/openapi-generator/src/main/resources/swift5/modelOneOf.mustache`
- `modules/openapi-generator/src/main/resources/swift6/modelOneOf.mustache`

**Key Implementation Details:**
- Added `DiscriminatorCodingKey` enum for reading discriminator field
- Conditional logic: discriminator-first vs sequential try?
- Improved error messages that include actual discriminator value
- Fixed encoding bug: removed unused parameter from `unknownDefaultOpenApi` case
- Updated samples to reflect template changes

**Example Generated Code (with discriminator):**
```swift
public init(from decoder: Decoder) throws {
    // Discriminator-based decoding: read discriminator value first
    let keyedContainer = try decoder.container(keyedBy: DiscriminatorCodingKey.self)
    let discriminatorValue = try keyedContainer.decode(String.self, forKey: .type)

    switch discriminatorValue {
    case "between":
        self = .typePredicateBetween(try PredicateBetween(from: decoder))
    case "matchesAny":
        self = .typePredicateMatchesAny(try PredicateMatchesAny(from: decoder))
    default:
        throw DecodingError.dataCorrupted(...)
    }
}
```


### Benefits

- ✅ Fixes discriminator-based oneOf decoding when `enumUnknownDefaultCase=true`
- ✅ Better performance: O(1) switch vs O(n) sequential tries
- ✅ Clearer error messages with actual discriminator values
- ✅ No breaking changes - backward compatible for non-discriminator schemas
- ✅ Follows Swift best practices for Codable

### PR Checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md)
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work
- [x] Regenerated samples:
  ```
  ./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true
  ./bin/generate-samples.sh bin/configs/swift5-oneOf.yaml
  ./bin/generate-samples.sh bin/configs/swift6-oneOf.yaml
  ```
  Committed all changed files including updated samples
- [x] Filed PR against the correct branch: `master` (non-breaking change)
- [x] PR solves a reported issue: fixes #7549
- [x] Mentioning technical committee: @4brunu

cc @4brunu - This PR implements discriminator support for Swift oneOf schemas as discussed in #7549. The implementation uses discriminator-first decoding to avoid the bug where `unknownDefaultOpenApi` fallback cases break discriminator routing. Backward compatibility is maintained for non-discriminator oneOf schemas.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Swift oneOf decoding when enumUnknownDefaultCase=true by reading the discriminator first and routing to the correct variant. Keeps non-discriminator schemas using the original sequential decoding; fixes #7549.

- **Bug Fixes**
  - Decode the discriminator via a keyed container and switch directly to the mapped variant.
  - Use sequential try? only when no discriminator is present.
  - For unknown discriminator values, return unknownDefaultOpenApi (if enabled) or throw with clearer error messages.
  - Remove the unused payload from unknownDefaultOpenApi during encoding.
  - Update Swift5/Swift6 modelOneOf templates and refresh samples.
  - Add tests for Swift5/Swift6 verifying discriminator-first decoding is generated.

<sup>Written for commit 74aa7438c111acafc9a45959e1e3cb163f5d8218. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



