### PR TITLE
Fix Bitrise CI: Install iOS Simulator runtime

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,15 @@ workflows:
 
             sudo gem install cocoapods
     - script@1.2.0:
+        title: Install iOS Simulator Runtime
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+
+            set -e
+
+            xcodebuild -downloadPlatform iOS
+    - script@1.2.0:
         title: Run Swift6 tests
         inputs:
         - content: |

--- a/samples/client/petstore/swift6/default/Package.swift
+++ b/samples/client/petstore/swift6/default/Package.swift
@@ -1,4 +1,5 @@
 // swift-tools-version:6.0
+// Trigger CI
 
 import PackageDescription
 


### PR DESCRIPTION
## Summary

The Bitrise macOS stack (`osx-xcode-16.3.x`) does not have iOS simulator runtimes pre-installed. This causes Swift tests to fail with:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
        { platform:iOS Simulator, OS:latest, name:iPhone 16 }

    The requested device could not be found because no available devices matched the request.
```

## Fix

Add a step to download the iOS platform/simulator runtime before running Swift tests:

```yaml
- script@1.2.0:
    title: Install iOS Simulator Runtime
    inputs:
    - content: |
        #!/usr/bin/env bash
        set -e
        xcodebuild -downloadPlatform iOS
```

## Test Plan

- [ ] Bitrise CI should now pass for Swift5/Swift6 tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install the iOS Simulator runtime on Bitrise before running Swift tests to fix missing device errors. This prevents xcodebuild failures on the osx-xcode-16.3.x stack and makes Swift5/Swift6 test jobs pass.

<sup>Written for commit 390c509fec9a01cadce960a63b73c74f5cb04b6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

