### PR TITLE
[kotlin-client] Fix enum @JsonCreator to throw for unknown values instead of null, fixes #22662

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -106,14 +106,34 @@ import kotlinx.serialization.*
         /**
          * Returns a valid [{{classname}}] for [data], null otherwise.
          */
-        {{#jackson}}@JvmStatic
-        @JsonCreator
-        {{/jackson}}{{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decode(data: kotlin.Any?): {{classname}}? = data?.let {
+{{^jackson}}
+        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decode(data: kotlin.Any?): {{classname}}? = data?.let {
           val normalizedData = "$it".lowercase()
           values().firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }
+{{/jackson}}
+{{#jackson}}
+        @JvmStatic
+        @JsonCreator
+        {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decode(data: kotlin.Any?): {{classname}}{{#isNullable}}?{{/isNullable}} {
+          if (data == null) {
+{{#isNullable}}
+            return null
+{{/isNullable}}
+{{^isNullable}}
+            throw IllegalArgumentException("Value for {{classname}} cannot be null")
+{{/isNullable}}
+          }
+          val normalizedData = "$data".lowercase()
+          return values().firstOrNull { value ->
+            data == value || normalizedData == "$value".lowercase()
+          }{{#isNullable}}{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}
+            ?: {{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}
+            ?: throw IllegalArgumentException("Unknown {{classname}} value: $data"){{/enumUnknownDefaultCase}}{{/isNullable}}
+        }
+{{/jackson}}
     }
 }
 {{#kotlinx_serialization}}{{#enumUnknownDefaultCase}}

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -62,11 +62,15 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
          */
         @JvmStatic
         @JsonCreator
-        fun decode(data: kotlin.Any?): StringEnumRef? = data?.let {
-          val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
-            it == value || normalizedData == "$value".lowercase()
+        fun decode(data: kotlin.Any?): StringEnumRef {
+          if (data == null) {
+            throw IllegalArgumentException("Value for StringEnumRef cannot be null")
           }
+          val normalizedData = "$data".lowercase()
+          return values().firstOrNull { value ->
+            data == value || normalizedData == "$value".lowercase()
+          }
+            ?: unknown_default_open_api
         }
     }
 }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -62,11 +62,15 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
          */
         @JvmStatic
         @JsonCreator
-        fun decode(data: kotlin.Any?): StringEnumRef? = data?.let {
-          val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
-            it == value || normalizedData == "$value".lowercase()
+        fun decode(data: kotlin.Any?): StringEnumRef {
+          if (data == null) {
+            throw IllegalArgumentException("Value for StringEnumRef cannot be null")
           }
+          val normalizedData = "$data".lowercase()
+          return values().firstOrNull { value ->
+            data == value || normalizedData == "$value".lowercase()
+          }
+            ?: unknown_default_open_api
         }
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.  (tagging Kotlin technical committee @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10))
--




## Summary
- Fix enum `decode()` function with `@JsonCreator` to throw `IllegalArgumentException` for unknown enum values
- This regression was introduced in v7.18.0 via PR #22535
- The fix matches Java client and kotlin-spring generator behavior

## Changes
- Modified `enum_class.mustache` to throw for unknown values when using Jackson
- Added unit tests for the new behavior
- Respects `enumUnknownDefaultCase` option

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Kotlin client enum deserialization with Jackson: decode(@JsonCreator) now throws IllegalArgumentException for unknown values (and for null when non-nullable). Restores pre-7.18.0 behavior and matches Java client and kotlin-spring; fixes #22662.

- **Bug Fixes**
  - Update enum_class.mustache to throw for unknown values; still honors enumUnknownDefaultCase for a default fallback and supports nullable enums.
  - Add tests to verify throwing behavior and the enumUnknownDefaultCase path.
  - Refresh Kotlin samples (spring-restclient and spring-webclient) to reflect the new decode logic.
  - Notes regression origin in v7.18.0 (PR #22535).

<sup>Written for commit c97a63107909c9d9c7298306020fff7713f9f00b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

