### PR TITLE
[BUG][JAVA][SPRING] api util must test variable nullity 

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/apiUtil.mustache
@@ -21,9 +21,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-interface/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof-sealed/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledExcp/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-api-response-examples/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-api-response-examples/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-builtin-validation/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-file-delegate-optional/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-file-delegate-optional/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-lombok-data/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-lombok-tostring/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-petstore-with-api-response-examples/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/ApiUtil.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/api/ApiUtil.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/api/ApiUtil.java
@@ -9,9 +9,11 @@ public class ApiUtil {
     public static void setExampleResponse(NativeWebRequest req, String contentType, String example) {
         try {
             HttpServletResponse res = req.getNativeResponse(HttpServletResponse.class);
-            res.setCharacterEncoding("UTF-8");
-            res.addHeader("Content-Type", contentType);
-            res.getWriter().print(example);
+            if (res != null) {
+                res.setCharacterEncoding("UTF-8");
+                res.addHeader("Content-Type", contentType);
+                res.getWriter().print(example);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
based on #22603 with resolved merge conflicts

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a null check for HttpServletResponse in ApiUtil.setExampleResponse to prevent NullPointerException in generated Spring projects. Updates all Spring samples to reflect the change.

- **Bug Fixes**
  - Guard req.getNativeResponse(HttpServletResponse.class) with a null check and no-op when null.
  - Updated JavaSpring apiUtil.mustache and regenerated Spring samples.

<sup>Written for commit 7d0994f061daca63a4c5802f55337ecd1ad31234. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

