### PR TITLE
[R] fix set[object] deserialization

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -365,7 +365,7 @@ ApiClient <- R6::R6Class(
         })
         names(return_obj) <- names(obj)
       } else if (startsWith(return_type, "collection[")) {
-        # To handle the "array" or "set" types
+        # To handle the "array" and "set" types
         inner_return_type <- regmatches(return_type,
                                         regexec(pattern = "collection\\[(.*)\\]", return_type))[[1]][2]
         if (c(inner_return_type) %in% primitive_types) {

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -363,6 +363,11 @@ ApiClient  <- R6::R6Class(
       return_obj <- NULL
       primitive_types <- c("character", "numeric", "integer", "logical", "complex")
 
+      # for deserialization, uniqueness requirements do not matter
+      return_type <- gsub(pattern = "^(set|array)\\[",
+                          replacement = "collection\\[",
+                          x = return_type)
+
       # To handle the "map" type
       if (startsWith(return_type, "map(")) {
         inner_return_type <- regmatches(return_type,
@@ -371,10 +376,10 @@ ApiClient  <- R6::R6Class(
           self$deserializeObj(obj[[name]], inner_return_type, pkg_env)
         })
         names(return_obj) <- names(obj)
-      } else if (startsWith(return_type, "array[")) {
-        # To handle the "array" type
+      } else if (startsWith(return_type, "collection[")) {
+        # To handle the "array" and "set" types
         inner_return_type <- regmatches(return_type,
-                                        regexec(pattern = "array\\[(.*)\\]", return_type))[[1]][2]
+                                        regexec(pattern = "collection\\[(.*)\\]", return_type))[[1]][2]
         if (c(inner_return_type) %in% primitive_types) {
           return_obj <- vector("list", length = length(obj))
           if (length(obj) > 0) {
@@ -383,6 +388,9 @@ ApiClient  <- R6::R6Class(
             }
           }
         } else {
+          if (is.list(obj) && length(obj) == 1 && is.data.frame(obj[[1]])) {
+            obj <- obj[[1]]
+          }
           if (!is.null(nrow(obj))) {
             return_obj <- vector("list", length = nrow(obj))
             if (nrow(obj) > 0) {

--- a/samples/client/echo_api/r/R/api_client.R
+++ b/samples/client/echo_api/r/R/api_client.R
@@ -317,7 +317,7 @@ ApiClient <- R6::R6Class(
         })
         names(return_obj) <- names(obj)
       } else if (startsWith(return_type, "collection[")) {
-        # To handle the "array" or "set" types
+        # To handle the "array" and "set" types
         inner_return_type <- regmatches(return_type,
                                         regexec(pattern = "collection\\[(.*)\\]", return_type))[[1]][2]
         if (c(inner_return_type) %in% primitive_types) {

--- a/samples/client/petstore/R-httr2-wrapper/R/api_client.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_client.R
@@ -352,6 +352,11 @@ ApiClient  <- R6::R6Class(
       return_obj <- NULL
       primitive_types <- c("character", "numeric", "integer", "logical", "complex")
 
+      # for deserialization, uniqueness requirements do not matter
+      return_type <- gsub(pattern = "^(set|array)\\[",
+                          replacement = "collection\\[",
+                          x = return_type)
+
       # To handle the "map" type
       if (startsWith(return_type, "map(")) {
         inner_return_type <- regmatches(return_type,
@@ -360,10 +365,10 @@ ApiClient  <- R6::R6Class(
           self$deserializeObj(obj[[name]], inner_return_type, pkg_env)
         })
         names(return_obj) <- names(obj)
-      } else if (startsWith(return_type, "array[")) {
-        # To handle the "array" type
+      } else if (startsWith(return_type, "collection[")) {
+        # To handle the "array" and "set" types
         inner_return_type <- regmatches(return_type,
-                                        regexec(pattern = "array\\[(.*)\\]", return_type))[[1]][2]
+                                        regexec(pattern = "collection\\[(.*)\\]", return_type))[[1]][2]
         if (c(inner_return_type) %in% primitive_types) {
           return_obj <- vector("list", length = length(obj))
           if (length(obj) > 0) {
@@ -372,6 +377,9 @@ ApiClient  <- R6::R6Class(
             }
           }
         } else {
+          if (is.list(obj) && length(obj) == 1 && is.data.frame(obj[[1]])) {
+            obj <- obj[[1]]
+          }
           if (!is.null(nrow(obj))) {
             return_obj <- vector("list", length = nrow(obj))
             if (nrow(obj) > 0) {

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -352,6 +352,11 @@ ApiClient  <- R6::R6Class(
       return_obj <- NULL
       primitive_types <- c("character", "numeric", "integer", "logical", "complex")
 
+      # for deserialization, uniqueness requirements do not matter
+      return_type <- gsub(pattern = "^(set|array)\\[",
+                          replacement = "collection\\[",
+                          x = return_type)
+
       # To handle the "map" type
       if (startsWith(return_type, "map(")) {
         inner_return_type <- regmatches(return_type,
@@ -360,10 +365,10 @@ ApiClient  <- R6::R6Class(
           self$deserializeObj(obj[[name]], inner_return_type, pkg_env)
         })
         names(return_obj) <- names(obj)
-      } else if (startsWith(return_type, "array[")) {
-        # To handle the "array" type
+      } else if (startsWith(return_type, "collection[")) {
+        # To handle the "array" and "set" types
         inner_return_type <- regmatches(return_type,
-                                        regexec(pattern = "array\\[(.*)\\]", return_type))[[1]][2]
+                                        regexec(pattern = "collection\\[(.*)\\]", return_type))[[1]][2]
         if (c(inner_return_type) %in% primitive_types) {
           return_obj <- vector("list", length = length(obj))
           if (length(obj) > 0) {
@@ -372,6 +377,9 @@ ApiClient  <- R6::R6Class(
             }
           }
         } else {
+          if (is.list(obj) && length(obj) == 1 && is.data.frame(obj[[1]])) {
+            obj <- obj[[1]]
+          }
           if (!is.null(nrow(obj))) {
             return_obj <- vector("list", length = nrow(obj))
             if (nrow(obj) > 0) {

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -346,7 +346,7 @@ ApiClient <- R6::R6Class(
         })
         names(return_obj) <- names(obj)
       } else if (startsWith(return_type, "collection[")) {
-        # To handle the "array" or "set" types
+        # To handle the "array" and "set" types
         inner_return_type <- regmatches(return_type,
                                         regexec(pattern = "collection\\[(.*)\\]", return_type))[[1]][2]
         if (c(inner_return_type) %in% primitive_types) {


### PR DESCRIPTION
@Ramanth, @saigiridhar21, @wing328

This PR handles 2 related issues pertaining to deserializing responses in generated R clients.

1. Previously the `deserializeObj()` method of the API client only supported `array[...]` types, not `set[...]` types. That is fixed here by collapsing both to a temporary `collection[...]` type which is only used for a regex to identify collections and pull out the inner type.
2. The `jsonlite` library will sometimes parse nested JSON arrays as an R `data.frame` nested within an R `list`. I've provided an example as a comment near the change. This PR handles this case so that nested objects are correctly parsed into the target R6 objects. Current behavior is that they are returned, unexpectedly, as data frames.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deserialization in generated R clients. Adds support for set[...] and correctly parses nested arrays from jsonlite so APIs return proper R6 objects instead of data.frames.

- **Bug Fixes**
  - Treat set[...] the same as array[...] by normalizing to collection[...] when extracting inner types.
  - Unwrap list-wrapped data.frames before deserializing nested objects to R6 classes.

<sup>Written for commit 511f575a3e95f6fa6458b19e8867bf8ec38f24ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

