### PR TITLE
Improve aliases for Pydantic models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -908,7 +908,8 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
 
                 // field
                 if (cp.baseName != null && !cp.baseName.equals(cp.name)) { // base name not the same as name
-                    fields.add(String.format(Locale.ROOT, "alias=\"%s\"", cp.baseName));
+                    fields.add(String.format(Locale.ROOT, "validation_alias=\"%s\"", cp.baseName));
+                    fields.add(String.format(Locale.ROOT, "serialization_alias=\"%s\"", cp.baseName));
                 }
 
                 if (!StringUtils.isEmpty(cp.description)) { // has description


### PR DESCRIPTION
The pydantic models generated include field aliases for fields that use camel case as opposed to snake case (customary in Python). The alias definitions are compatible with python's builtin dataclasses and are correctly detected by LSPs, however in the same models the `populate_by_name` option is set to True. This option allows the instantiotion using the actual field names (snake case) instead of the defined alias (camcel case). This options is not correctly recognized by most LSP and therefore results in two warnings per field. The first warning states that hte snake case version of the field is not a valid argument, and the second warning states that the camcel case version of the argument is missing.

Exampel:

```python
class WebSessionInfo(BaseModel):
    model_config = {
        "populate_by_name": True,
    }

    session_id: str = Field(alias="sessionID")
```

The above model can be instantiated like so:
`WebSessionInfo(session_id='abc')`, however this results in two warnings (`session_id` is not a valid argument, and `sessionID` is missing).

Settings `validation_alias` and `serialization_alias` results in the exact same behavior as far as validation and serialization are concerned, however they are not standard dataclass options and are therefore not recognized by LSPs. This removes the warnings.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch generated Pydantic v1 fields to use validation_alias and serialization_alias instead of alias to prevent LSP warnings when populate_by_name=True. Validation and serialization behavior is unchanged; snake_case init and camelCase I/O still work.

- **Bug Fixes**
  - For fields where baseName != name, emit validation_alias and serialization_alias in Field() within AbstractPythonPydanticV1Codegen.

<sup>Written for commit ba30bdc39d27f62cc468006fd7b9886b60613617. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

