### PR TITLE
Refresh dependencies in the Rust server generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -101,7 +101,7 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -119,8 +119,8 @@ uuid = { version = "1.18.0", features = ["serde", "v4"]}
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 {{#apiUsesMultipartRelated}}
 mime_multipart = { version = "0.10", optional = true, package = "mime-multipart-hyper1" }
 {{/apiUsesMultipartRelated}}
@@ -138,14 +138,14 @@ tower-service = "0.3.3"
 lazy_static = { version = "1.5", optional = true }
 regex = { version = "1.12", optional = true }
 {{/apiUsesByteArray}}
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 {{#apiHasDeleteMethods}}
 dialoguer = { version = "0.12", optional = true }
 {{/apiHasDeleteMethods}}
@@ -161,12 +161,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -53,7 +53,7 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -63,8 +63,8 @@ multipart = { version = "0.18", default-features = false, optional = true }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 mime_multipart = { version = "0.10", optional = true, package = "mime-multipart-hyper1" }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
@@ -73,14 +73,14 @@ url = { version = "2.5", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.3", optional = true }
@@ -93,12 +93,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -47,7 +47,7 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -56,8 +56,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -67,14 +67,14 @@ tower-service = "0.3.3"
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
 regex = { version = "1.12", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.3", optional = true }
@@ -87,12 +87,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -52,7 +52,7 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -63,8 +63,8 @@ uuid = { version = "1.18.0", features = ["serde", "v4"]}
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -73,14 +73,14 @@ serde_urlencoded = { version = "0.7.1", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.3", optional = true }
@@ -93,12 +93,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -47,7 +47,7 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -56,8 +56,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -67,14 +67,14 @@ tower-service = "0.3.3"
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
 regex = { version = "1.12", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.3", optional = true }
@@ -87,12 +87,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -53,7 +53,7 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -65,8 +65,8 @@ uuid = { version = "1.18.0", features = ["serde", "v4"]}
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -75,14 +75,14 @@ serde_urlencoded = { version = "0.7.1", optional = true }
 tower-service = "0.3.3"
 
 # Server, and client callback-specific
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 dialoguer = { version = "0.12", optional = true }
 
 # Conversion
@@ -96,12 +96,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -47,7 +47,7 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -56,8 +56,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -67,14 +67,14 @@ tower-service = "0.3.3"
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
 regex = { version = "1.12", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.3", optional = true }
@@ -87,12 +87,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -47,7 +47,7 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_valid = { version = "0.16", optional = true }
+serde_valid = { version = "2.0", optional = true }
 
 validator = { version = "0.20", features = ["derive"] }
 
@@ -56,8 +56,8 @@ validator = { version = "0.20", features = ["derive"] }
 # Common between server and client features
 bytes = "1.11"
 http-body-util = "0.1.3"
-hyper = { version = "1.6", features = ["full"], optional = true }
-hyper-util = { version = "0.1.17", features = ["service"] }
+hyper = { version = "1.8", features = ["full"], optional = true }
+hyper-util = { version = "0.1.18", features = ["service"] }
 serde_ignored = { version = "0.1.14", optional = true }
 url = { version = "2.5", optional = true }
 
@@ -67,14 +67,14 @@ tower-service = "0.3.3"
 # Server, and client callback-specific
 lazy_static = { version = "1.5", optional = true }
 regex = { version = "1.12", optional = true }
-percent-encoding = { version = "2.3.1", optional = true }
+percent-encoding = { version = "2.3.2", optional = true }
 
 # CLI-specific
 anyhow = { version = "1", optional = true }
 clap = { version = "4.5", features = ["env"], optional = true }
 clap-verbosity-flag = { version = "3.0", optional = true }
 simple_logger = { version = "5.0", features = ["stderr"], optional = true }
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros"], optional = true }
 
 # Conversion
 frunk = { version = "0.4.3", optional = true }
@@ -87,12 +87,12 @@ frunk-enum-core = { version = "0.3.0", optional = true }
 always_send = "0.1.1"
 clap = "4.5"
 env_logger = "0.11"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
 native-tls = "0.2"
 pin-project = "1.1.10"
 
 # Bearer authentication, used in examples
-jsonwebtoken = "9.3.1"
+jsonwebtoken = {version = "10.0.0", features = ["rust_crypto"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "windows", target_os = "ios")))'.dev-dependencies]
 tokio-openssl = "0.6"


### PR DESCRIPTION
Needed to update `serde_valid` for validation to be compatible with the swagger-rs crate that also uses that dependency. 
Have refreshed a few other dependencies whilst in the area. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh Rust server generator dependencies to resolve serde_valid conflicts with swagger-rs and keep the template current. This ensures generated servers compile cleanly with the latest ecosystem crates.

- **Dependencies**
  - Upgrade serde_valid to 2.0 for compatibility with swagger-rs.
  - Bump hyper to 1.8, hyper-util to 0.1.18, and tokio to 1.49.
  - Update percent-encoding to 2.3.2 and jsonwebtoken to 10.0.0 with rust_crypto.
  - Update Cargo.mustache and regenerate sample Cargo.toml files.

<sup>Written for commit 86dd1475d587afbc6b649594667093e3ac400e2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

