### PR TITLE
Fix DevContainer by switching from moby to docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "ghcr.io/snebjorn/devcontainer-feature/chromium:latest": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",
-      "moby": true
+      "moby": false
     }
   },
   // Configure tool-specific properties.


### PR DESCRIPTION
If you currently try to open the repo in a DevContainer or a Github Codespace the creation of the container fails:

```text
(!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution.
(!) To continue, either set the feature option '"moby": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04').
```

This PR fixes this by disabling moby and using docker instead. Other potential fixes seemed not be fine to me:

* Using `debian:bookworm`: trixie is stable since August 2025. We should use the most recent stable Debian
* Using `ubuntu-24.04`: Would still be the recent release, however, not for long anymore. But the actual issue is, that the DevContainer feature `ghcr.io/snebjorn/devcontainer-feature/chromium:latest` does only seem to work on Debian. The creation with Ubuntu failed.

After disabling moby, the DevContainer worked for me as expected. Also docker-in-docker just worked. The script `run-in-docker.sh` can be run successfully. I’m not aware of what else relies on the docker-in-docker feature, as the commit (1ce95ff41e16a704a1ab5efa16c15aa0e81a1101/#17095) that introduced it does not explain why it was added in the first place. It’s possible that something is broken due to the switch from moby to docker, but at least the container is functioning again instead of failing to start altogether.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix DevContainer and Codespaces startup on Debian trixie by switching the docker-in-docker feature from Moby to Docker.

- **Bug Fixes**
  - Set "moby": false in .devcontainer/devcontainer.json so the container builds and docker-in-docker works (run-in-docker.sh succeeds).

<sup>Written for commit db9932fa126f7c71d60c89b31f3bcce0bff0be24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

