### PR TITLE
Revert "[kotlin] fix query parameter encoding"

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
@@ -4,9 +4,8 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestClient
-import org.springframework.web.util.UriComponentsBuilder
+import org.springframework.http.ResponseEntity
 import org.springframework.util.LinkedMultiValueMap
 
 {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}open class ApiClient(protected val client: RestClient) {
@@ -36,13 +35,12 @@ import org.springframework.util.LinkedMultiValueMap
     private fun <I> RestClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
-    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
-        val uriComponentsBuilder = UriComponentsBuilder.fromPath(requestConfig.path)
-        requestConfig.query.forEach { key, values ->
-            uriComponentsBuilder.queryParam(key, "{$key}")
+    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
+        uri(requestConfig.path) { builder ->
+            builder
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
-        return uri(uriComponentsBuilder.encode().buildAndExpand(requestConfig.query + requestConfig.params).toUri())
-    }
 
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -4,9 +4,8 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestClient
-import org.springframework.web.util.UriComponentsBuilder
+import org.springframework.http.ResponseEntity
 import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
@@ -36,13 +35,12 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
-    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
-        val uriComponentsBuilder = UriComponentsBuilder.fromPath(requestConfig.path)
-        requestConfig.query.forEach { key, values ->
-            uriComponentsBuilder.queryParam(key, "{$key}")
+    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
+        uri(requestConfig.path) { builder ->
+            builder
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
-        return uri(uriComponentsBuilder.encode().buildAndExpand(requestConfig.query + requestConfig.params).toUri())
-    }
 
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -4,9 +4,8 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestClient
-import org.springframework.web.util.UriComponentsBuilder
+import org.springframework.http.ResponseEntity
 import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
@@ -36,13 +35,12 @@ open class ApiClient(protected val client: RestClient) {
     private fun <I> RestClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
-    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>): RestClient.RequestBodySpec {
-        val uriComponentsBuilder = UriComponentsBuilder.fromPath(requestConfig.path)
-        requestConfig.query.forEach { key, values ->
-            uriComponentsBuilder.queryParam(key, "{$key}")
+    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
+        uri(requestConfig.path) { builder ->
+            builder
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
-        return uri(uriComponentsBuilder.encode().buildAndExpand(requestConfig.query + requestConfig.params).toUri())
-    }
 
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }


### PR DESCRIPTION
Reverts OpenAPITools/openapi-generator#22512

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Kotlin Spring RestClient query parameter encoding change and restores the previous URI-building logic. This brings back the earlier behavior for how query params are added and encoded in generated clients.

- **Bug Fixes**
  - Switch back to RestClient.uri(path) with builder.queryParams(LinkedMultiValueMap(...)).build(params) instead of UriComponentsBuilder.encode().buildAndExpand(...).
  - Update the generator template and the echo_api and petstore samples to match.

<sup>Written for commit 71f1ddbc77337212a8b86bbd2f9447e37cc7e1db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

