### PR TITLE
Add doc goal for scala-maven-plugin

### DIFF
--- a/modules/openapi-generator-mill-plugin/pom.xml
+++ b/modules/openapi-generator-mill-plugin/pom.xml
@@ -137,6 +137,7 @@
                         <goals>
                             <goal>compile</goal>
                             <goal>testCompile</goal>
+                            <goal>doc-jar</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
should resolve  https://github.com/OpenAPITools/openapi-generator/pull/22652#issuecomment-3767850721


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the doc-jar goal to the scala-maven-plugin for the mill plugin so a ScalaDoc JAR is built during the release. This fixes the missing docs artifact noted in the PR #22652 discussion and unblocks the release.

<sup>Written for commit 5881a3df60336517bb78882c9b1c7a79de3f7a10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

