### PR TITLE
Fix release

### DIFF
--- a/modules/openapi-generator-mill-plugin/pom.xml
+++ b/modules/openapi-generator-mill-plugin/pom.xml
@@ -137,8 +137,29 @@
                         <goals>
                             <goal>compile</goal>
                             <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <!-- see https://github.com/davidB/scala-maven-plugin/issues/604 why a workaround is needed -->
+                        <id>attach-javadocs</id>
+                        <goals>
                             <goal>doc-jar</goal>
                         </goals>
+                        <configuration>
+                            <scaladocClassName>dotty.tools.scaladoc.Main</scaladocClassName>
+                            <sourceDir>${project.build.outputDirectory}</sourceDir>
+                            <args>-nobootcp</args>
+                            <includes>
+                                <include>**/*.tasty</include>
+                            </includes>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.scala-lang</groupId>
+                                    <artifactId>scaladoc_3</artifactId>
+                                    <version>3.7.4</version>
+                                </dependency>
+                            </dependencies>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
adding workaround for scaladoc and scala 3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Scala 3 scaladoc workaround to generate and attach a javadoc jar for openapi-generator-mill-plugin. This fixes failed doc generation in scala-maven-plugin and unblocks releases.

- **Bug Fixes**
  - Add scala-maven-plugin execution to run doc-jar with dotty.tools.scaladoc.Main.
  - Generate docs from compiled TASTy files (-nobootcp) and include org.scala-lang:scaladoc_3:3.7.4.

<sup>Written for commit 3eb82c14e17150d99f55770e50ae87d2658999f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

