### PR TITLE
fix: Fix rust-server model generation following serde_valid upgrade

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -106,6 +106,17 @@ impl std::ops::DerefMut for {{{classname}}} {
     }
 }
 
+{{^hasConflictingModelNames}}
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for {{{classname}}} {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
+{{/hasConflictingModelNames}}
 {{#exts.x-to-string-support}}
 {{#exts.x-is-string}}
 impl std::fmt::Display for {{{classname}}} {
@@ -364,13 +375,13 @@ pub struct {{{classname}}} {
         )]
 {{/hasConflictingModelNames}}
 {{/hasValidation}}
+{{#required}}
 {{^hasConflictingModelNames}}{{>validate}}{{/hasConflictingModelNames}}
 {{^hasConflictingModelNames}}
 {{#exts.x-needs-nested-validation}}
-    #[cfg_attr(feature = "validate", validate)]
+    {{^minLength}}{{^maxLength}}{{^minItems}}{{^maxItems}}#[cfg_attr(feature = "validate", validate)]{{/maxItems}}{{/minItems}}{{/maxLength}}{{/minLength}}
 {{/exts.x-needs-nested-validation}}
 {{/hasConflictingModelNames}}
-{{#required}}
     pub {{{name}}}: {{{dataType}}},
 {{/required}}
 {{^required}}
@@ -378,9 +389,10 @@ pub struct {{{classname}}} {
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
 {{/isNullable}}
+{{^hasConflictingModelNames}}{{>validate}}{{/hasConflictingModelNames}}
 {{^hasConflictingModelNames}}
 {{#exts.x-needs-nested-validation}}
-    #[cfg_attr(feature = "validate", validate)]
+    {{^minLength}}{{^maxLength}}{{^minItems}}{{^maxItems}}#[cfg_attr(feature = "validate", validate)]{{/maxItems}}{{/minItems}}{{/maxLength}}{{/minLength}}
 {{/exts.x-needs-nested-validation}}
 {{/hasConflictingModelNames}}
     #[serde(skip_serializing_if="Option::is_none")]

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
@@ -14,7 +14,6 @@ pub struct MultipartRelatedRequest {
     #[serde(rename = "object_field")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub object_field: Option<models::MultipartRequestObjectField>,
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -290,9 +290,9 @@ impl AdditionalPropertiesWithList {
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AdditionalPropertiesWithNullable {
     #[serde(rename = "nullableString")]
-
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_string: Option<swagger::Nullable<String>>,
 
@@ -3446,30 +3446,30 @@ pub struct NullableTest {
     pub nullable: swagger::Nullable<String>,
 
     #[serde(rename = "nullableWithNullDefault")]
-
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_null_default: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableWithPresentDefault")]
-
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_present_default: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableWithNoDefault")]
-
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_no_default: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableArray")]
-
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_array: Option<swagger::Nullable<Vec<String>>>,
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -1097,13 +1097,11 @@ pub struct ArrayTest {
     #[serde(rename = "array_array_of_model")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_of_model: Option<Vec<Vec<models::ReadOnlyFirst>>>,
 
     #[serde(rename = "array_of_enum")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_of_enum: Option<Vec<models::MapTestMapMapOfEnumValueValue>>,
@@ -2642,20 +2640,17 @@ pub struct EnumArrays {
     #[serde(rename = "just_symbol")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub just_symbol: Option<models::EnumArraysJustSymbol>,
 
     #[serde(rename = "array_enum")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_enum: Option<Vec<models::EnumArraysArrayEnumInner>>,
 
     #[serde(rename = "array_array_enum")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_enum: Option<Vec<Vec<models::EnumArraysArrayArrayEnumInnerInner>>>,
@@ -3330,7 +3325,6 @@ pub struct EnumTest {
     #[serde(rename = "enum_string")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub enum_string: Option<models::EnumTestEnumString>,
 
@@ -3342,20 +3336,17 @@ pub struct EnumTest {
     #[serde(rename = "enum_integer")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub enum_integer: Option<models::EnumTestEnumInteger>,
 
     #[serde(rename = "enum_number")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub enum_number: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
 
     #[serde(rename = "outerEnum")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub outer_enum: Option<models::OuterEnum>,
@@ -4664,13 +4655,11 @@ pub struct MapTest {
     #[serde(rename = "map_map_of_enum")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_map_of_enum: Option<std::collections::HashMap<String, std::collections::HashMap<String, models::MapTestMapMapOfEnumValueValue>>>,
 
     #[serde(rename = "map_of_enum_string")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_of_enum_string: Option<std::collections::HashMap<String, models::MapTestMapMapOfEnumValueValue>>,
@@ -4980,7 +4969,6 @@ pub struct MixedPropertiesAndAdditionalPropertiesClass {
 
     #[serde(rename = "map")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub map: Option<std::collections::HashMap<String, models::Animal>>,
@@ -5736,7 +5724,6 @@ pub struct ObjectContainingObjectWithOnlyAdditionalProperties {
     #[serde(rename = "inner")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::ObjectWithOnlyAdditionalProperties>,
 
@@ -5930,6 +5917,15 @@ impl std::ops::DerefMut for ObjectWithOnlyAdditionalProperties {
     }
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for ObjectWithOnlyAdditionalProperties {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the ObjectWithOnlyAdditionalProperties value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -6064,7 +6060,6 @@ pub struct Order {
 
     #[serde(rename = "status")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<models::OrderStatus>,
@@ -6442,6 +6437,15 @@ impl std::ops::DerefMut for OuterBoolean {
     }
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for OuterBoolean {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the OuterBoolean value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -6914,6 +6918,15 @@ impl std::ops::DerefMut for OuterNumber {
     }
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for OuterNumber {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the OuterNumber value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -7056,6 +7069,15 @@ impl std::ops::DerefMut for OuterString {
     }
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for OuterString {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
 impl std::fmt::Display for OuterString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.clone())
@@ -7168,7 +7190,6 @@ pub struct Pet {
     #[serde(rename = "category")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub category: Option<models::Category>,
 
@@ -7183,13 +7204,11 @@ pub struct Pet {
     #[serde(rename = "tags")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<models::Tag>>,
 
     #[serde(rename = "status")]
 
-    #[cfg_attr(feature = "validate", validate)]
     #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<models::PetStatus>,

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -12,9 +12,9 @@ use serde_valid::Validate;
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ANullableContainer {
     #[serde(rename = "NullableThing")]
-
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_thing: Option<swagger::Nullable<String>>,
 
@@ -214,6 +214,15 @@ impl std::ops::DerefMut for AdditionalPropertiesObject {
     }
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for AdditionalPropertiesObject {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the AdditionalPropertiesObject value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer
@@ -997,7 +1006,6 @@ pub struct ObjectOfObjects {
     #[serde(rename = "inner")]
 
     #[cfg_attr(feature = "validate", validate)]
-    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::ObjectOfObjectsInner>,
 
@@ -1525,6 +1533,15 @@ impl std::ops::DerefMut for UnnamedReference {
     }
 }
 
+#[cfg(feature = "validate")]
+impl serde_valid::validation::ValidateCompositedMinLength for UnnamedReference {
+    fn validate_composited_min_length(
+        &self,
+        _min_length: usize,
+    ) -> Result<(), serde_valid::validation::Composited<serde_valid::validation::error::MinLengthError>> {
+        Ok(())
+    }
+}
 /// Converts the UnnamedReference value to the Query Parameters representation (style=form, explode=false)
 /// specified in <https://swagger.io/docs/specification/serialization/>
 /// Should be implemented in a serde serializer


### PR DESCRIPTION
Add additional models to rust-server validation support following the upgrade to serde_valid 2.0. Also remove some duplicate `#[cfg_attr(feature = "validate", validate)]` .

I've attempted to reconcile the whitespace differences but leaving as I've not got further time to spend on this. I don't think they result in any functional changes. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10) @dsteeley (2025/07)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rust-server model generation after upgrading to serde_valid 2.0 by adding required composited validation support and removing duplicate validate attributes. Restores clean compilation and tidier generated code.

- **Bug Fixes**
  - Implemented serde_valid::validation::ValidateCompositedMinLength for newtype models when the validate feature is enabled.
  - Prevented duplicate #[cfg_attr(feature = "validate", validate)] on fields by guarding nested validation emission and placing the validate partial once for both required and optional fields.
  - Regenerated rust-server samples; removes duplicate validate attributes and includes minor whitespace-only changes.

<sup>Written for commit 0554ae7cb8f0ab844826af6a6168374b5f529532. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

