### PR TITLE
Fix output of `bin/generate-samples.sh` in tmux

### DIFF
--- a/bin/generate-samples.sh
+++ b/bin/generate-samples.sh
@@ -47,24 +47,26 @@ For example:
 
 echo "$header"
 
-if [[ ${#files[@]} -eq 1 && "${files[0]}" != *'*'* ]]; then
-    # shellcheck disable=SC2086
-    # shellcheck disable=SC2068
-    java ${JAVA_OPTS} -jar "$executable" generate -c ${files[0]} ${args[@]}
-else
-    if [ ${#files[@]} -eq 0 ]; then
-      files=("${root}"/bin/configs/*.yaml)
-    fi
+tmpfile=$(mktemp)
+trap "rm -f $tmpfile" EXIT
 
-    # shellcheck disable=SC2086
-    # shellcheck disable=SC2068
-    if java ${JAVA_OPTS} -jar "$executable" batch ${BATCH_OPTS} --includes-base-dir "${root}" --fail-fast  -- ${files[@]} 2>&1 | tee /dev/pts/0 | grep -q -i "exception"; then
-      echo "Found exception(s) when running the generator(s) to update the samples."
-      export GENERATE_ERROR=1
-    fi
+if [[ ${#files[@]} -eq 1 && "${files[0]}" != *'*'* ]]; then
+  # shellcheck disable=SC2086
+  # shellcheck disable=SC2068
+  java ${JAVA_OPTS} -jar "$executable" generate -c ${files[0]} ${args[@]} 2>&1 | tee "$tmpfile"
+  retcode=${PIPESTATUS[0]}
+else
+  if [ ${#files[@]} -eq 0 ]; then
+    files=("${root}"/bin/configs/*.yaml)
+  fi
+
+  # shellcheck disable=SC2086
+  # shellcheck disable=SC2068
+  java ${JAVA_OPTS} -jar "$executable" batch ${BATCH_OPTS} --includes-base-dir "${root}" --fail-fast  -- ${files[@]} 2>&1 | tee "$tmpfile"
+  retcode=${PIPESTATUS[0]}
 fi
 
-if [[ -n "$GENERATE_ERROR" ]]; then
+if [[ $retcode -ne 0 ]] || grep -q -i "exception" "$tmpfile"; then
   echo "Found exception(s) when running the generator(s) to update the samples."
   exit 1
 fi


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Commit 23dae2bcd8c9 reworked this script to start capturing exceptions but the mechanism used was crude and broke output on tmux, since `/dev/pts/0` is hardcoded to a specific pseudo-terminal but each tmux pane gets its own pts. Rework this to use files instead.

While here, we also align some indentation with the rest of the file and remove a `sleep` statement that has been commented out for a few years.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix generate-samples.sh output in tmux by logging to a temp file instead of /dev/pts/0. The script now correctly detects exceptions and non-zero exit codes.

- **Bug Fixes**
  - Use mktemp + tee for output and clean up via trap, which works across tmux panes.
  - Check PIPESTATUS for the Java process and grep the log for “exception” to fail reliably.
  - Remove the stale “press CTRL+C” sleep warning.

<sup>Written for commit 588b3a9ce0e5ccf8d0fe42b672ad3a138b7b1ab4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

