### PR TITLE
[BUG][Typescript] Fix isRelativeUrl incorrectly detecting URLs containing @, -, ~, . as not relative.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/URLPathUtils.java
@@ -235,7 +235,7 @@ public class URLPathUtils {
     public static boolean isRelativeUrl(List<Server> servers) {
         if (servers != null && servers.size() > 0) {
             final Server firstServer = servers.get(0);
-            return Pattern.matches("^(\\/[\\w\\d]+)+", firstServer.getUrl());
+            return Pattern.matches("^(\\/[\\w\\d.~@-]+)+", firstServer.getUrl());
         }
         return false;
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultGeneratorTest.java
@@ -672,6 +672,32 @@ public class DefaultGeneratorTest {
     }
 
     @Test
+    public void testHandlesRelativeUrlsWithSpecialChars() {
+        final Map<String, String> specToBasePath = Map.of(
+          "src/test/resources/3_0/relative-url-point.yaml", "/api/v4.0",
+          "src/test/resources/3_0/relative-url-dash.yaml", "/api-v3",
+          "src/test/resources/3_0/relative-url-tilde.yaml", "/~api/v5",
+          "src/test/resources/3_0/relative-url-at.yaml", "/api/@6"
+        );
+
+        specToBasePath.forEach((spec, expectedBasePath) -> {
+            OpenAPI openAPI = TestUtils.parseFlattenSpec(spec);
+            ClientOptInput opts = new ClientOptInput();
+            opts.openAPI(openAPI);
+            DefaultCodegen config = new DefaultCodegen();
+            config.setStrictSpecBehavior(false);
+            opts.config(config);
+            final DefaultGenerator generator = new DefaultGenerator();
+            generator.opts(opts);
+            generator.configureGeneratorProperties();
+
+            Map<String, Object> bundle = generator.buildSupportFileBundle(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+            final String actualBasePath = (String) bundle.get("basePath");
+            Assert.assertEquals(actualBasePath, expectedBasePath);
+        });
+    }
+
+    @Test
     public void testHandlesRelativeUrlsInServers() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_10056.yaml");
         ClientOptInput opts = new ClientOptInput();

--- a/modules/openapi-generator/src/test/resources/3_0/relative-url-at.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/relative-url-at.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "sample spec"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: /api/@6
+tags: []
+paths: {}
+components:
+  schemas: {}
+  securitySchemes: {}

--- a/modules/openapi-generator/src/test/resources/3_0/relative-url-dash.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/relative-url-dash.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "sample spec"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: /api-v3
+tags: []
+paths: {}
+components:
+  schemas: {}
+  securitySchemes: {}

--- a/modules/openapi-generator/src/test/resources/3_0/relative-url-point.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/relative-url-point.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "sample spec"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: /api/v4.0
+tags: []
+paths: {}
+components:
+  schemas: {}
+  securitySchemes: {}

--- a/modules/openapi-generator/src/test/resources/3_0/relative-url-tilde.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/relative-url-tilde.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.1
+info:
+  title: OpenAPI Petstore
+  description: "sample spec"
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: /~api/v5
+tags: []
+paths: {}
+components:
+  schemas: {}
+  securitySchemes: {}


### PR DESCRIPTION
Fixes #22767

Updated the regex with additional symbols. 
Added test to validate: org.openapitools.codegen.DefaultGeneratorTest#testHandlesRelativeUrlsWithSpecialChars.
 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #22767 by updating isRelativeUrl to accept ., ~, @, and - in path segments. Relative server URLs like /api/v4.0, /api-v3, /~api/v5, and /api/@6 are now detected correctly, ensuring the right basePath.

<sup>Written for commit 29344853a4ed8c8b165501eb0cf3c87f186cf235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

