### PR TITLE
[BUG][typescript-fetch] Fixed TypeScript code generation for oneOf using arrays

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -70,15 +70,15 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{#items}}
     {{#isDateType}}
     if (Array.isArray(json)) {
-        if (json.every(item => !(isNaN(new Date(json).getTime()))) {
-            return json.map(value => new Date(json);
+        if (json.every(item => !(isNaN(new Date(item).getTime())))) {
+            return json.map(value => new Date(value));
         }
     }
     {{/isDateType}}
     {{#isDateTimeType}}
     if (Array.isArray(json)) {
-        if (json.every(item => !(isNaN(new Date(json).getTime()))) {
-            return json.map(value => new Date(json);
+        if (json.every(item => !(isNaN(new Date(item).getTime())))) {
+            return json.map(value => new Date(value));
         }
     }
     {{/isDateTimeType}}
@@ -188,14 +188,14 @@ export function {{classname}}ToJSONTyped(value?: {{classname}} | null, ignoreDis
     {{#isDateType}}
     if (Array.isArray(value)) {
         if (value.every(item => item instanceof Date) {
-            return value.map(value => value.toISOString().substring(0,10)));
+            return value.map(value => value.toISOString().substring(0,10));
         }
     }
     {{/isDateType}}
     {{#isDateTimeType}}
     if (Array.isArray(value)) {
-        if (value.every(item => item instanceof Date) {
-            return value.map(value => value.toISOString();
+        if (value.every(item => item instanceof Date)) {
+            return value.map(item => item.toISOString());
         }
     }
     {{/isDateTimeType}}


### PR DESCRIPTION
**This PR just fixes the syntax of the generated code**, no opinionated new code, no change of any nature to anything, just some syntax fix.
It fixes issue #22779 

Fix is only about **balancing unbalanced parentheses and using the correct variables, nothing else**.

Again, as this doesn't change anything about anything already functional and being in a kind of a hurry, I haven't walked through the PR checklist, sorry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed TypeScript code generation for oneOf arrays so Date and DateTime arrays parse and serialize correctly. This corrects variable usage and missing parentheses in the template.

- **Bug Fixes**
  - Use item (not json) in json.every and map.
  - Balance missing parentheses in if conditions and map calls.
  - Map to new Date(value) when parsing arrays; serialize Date arrays with toISOString().substring(0,10) and DateTime arrays with item.toISOString().

<sup>Written for commit 785ecb4cbe629cbf8077ae49f4205e3c6e90bc66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

