### PR TITLE
[C++ Qt Client] Add OneOf/discriminator support with std::variant implementation

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/model-body.mustache
@@ -1,10 +1,11 @@
-{{>licenseInfo}}{{#models}}{{#model}}
+{{>licenseInfo}}{{#models}}{{#model}}{{#discriminator}}{{>model-oneof-body}}{{/discriminator}}{{^discriminator}}
 #include "{{classname}}.h"
 
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QObject>
+#include <QJsonValue>
 
 #include "{{prefix}}Helpers.h"
 
@@ -160,5 +161,5 @@ bool {{classname}}::isValid() const {
 {{#cppNamespaceDeclarations}}
 } // namespace {{this}}
 {{/cppNamespaceDeclarations}}
-{{/model}}
+{{/discriminator}}{{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/model-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/model-header.mustache
@@ -1,5 +1,5 @@
 {{>licenseInfo}}
-{{#models}}{{#model}}/*
+{{#models}}{{#model}}{{#discriminator}}{{>model-oneof}}{{/discriminator}}{{^discriminator}}/*
  * {{classname}}.h
  *
  * {{description}}
@@ -10,6 +10,7 @@
 
 #include <QJsonObject>
 
+{{/discriminator}}
 {{/model}}{{/models}}{{#imports}}{{{import}}}
 {{/imports}}
 
@@ -18,6 +19,7 @@
 
 {{#models}}
 {{#model}}
+{{^discriminator}}
 {{#cppNamespaceDeclarations}}
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
@@ -76,5 +78,6 @@ private:
 Q_DECLARE_METATYPE({{#cppNamespaceDeclarations}}{{this}}::{{/cppNamespaceDeclarations}}{{classname}})
 
 #endif // {{classname}}_H
+{{/discriminator}}
 {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/model-oneof-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/model-oneof-body.mustache
@@ -1,0 +1,142 @@
+#include "{{classname}}.h"
+
+#include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QObject>
+#include <QJsonValue>
+#include <variant>
+#include <memory>
+
+{{#discriminator}}
+{{#mappedModels}}
+#include "{{modelName}}.h"
+{{/mappedModels}}
+{{/discriminator}}
+
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
+{{classname}}::{{classname}}() {
+    this->initializeModel();
+}
+
+{{classname}}::{{classname}}(QString json) {
+    this->initializeModel();
+    this->fromJson(json);
+}
+
+{{classname}}::~{{classname}}() {}
+
+void {{classname}}::initializeModel() {
+    m_actualInstance = std::monostate{};
+    m_discriminatorValue = QString();
+}
+
+void {{classname}}::fromJson(QString jsonString) {
+    QByteArray array(jsonString.toStdString().c_str());
+    QJsonDocument doc = QJsonDocument::fromJson(array);
+    QJsonObject jsonObject = doc.object();
+    this->fromJsonObject(jsonObject);
+}
+
+void {{classname}}::fromJsonObject(QJsonObject json) {
+{{#discriminator}}
+    m_discriminatorValue = json["{{propertyName}}"].toString();
+{{/discriminator}}
+    
+{{#discriminator}}
+{{#mappedModels}}
+    if (m_discriminatorValue == "{{mappingName}}") {
+        auto instance = std::make_shared<{{modelName}}>();
+        instance->fromJsonObject(json);
+        m_actualInstance = instance;
+        return;
+    }
+{{/mappedModels}}
+{{/discriminator}}
+    
+    qWarning() << "{{classname}}: Unknown discriminator value '" << m_discriminatorValue << "'";
+}
+
+QString {{classname}}::asJson() const {
+    return std::visit([](const auto& value) -> QString {
+        using T = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+            return QString();
+        } else {
+            return value->asJson();
+        }
+    }, m_actualInstance);
+}
+
+QJsonObject {{classname}}::asJsonObject() const {
+    return std::visit([this](const auto& value) -> QJsonObject {
+        using T = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+            return QJsonObject();
+        } else {
+            QJsonObject obj = value->asJsonObject();
+{{#discriminator}}
+            if (!m_discriminatorValue.isEmpty()) {
+                obj.insert(QString("{{propertyName}}"), QJsonValue(m_discriminatorValue));
+            }
+{{/discriminator}}
+            return obj;
+        }
+    }, m_actualInstance);
+}
+
+bool {{classname}}::isSet() const {
+    return !std::holds_alternative<std::monostate>(m_actualInstance) && !m_discriminatorValue.isEmpty();
+}
+
+
+bool {{classname}}::isValid() const {
+    return std::visit([](const auto& value) -> bool {
+        using T = std::decay_t<decltype(value)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+            return false;
+        } else {
+            return value->isValid();
+        }
+    }, m_actualInstance);
+}
+
+void {{classname}}::setValue(const {{classname}}::VariantType &value) {
+    m_actualInstance = value;
+    
+    // Determine discriminator value by visiting the variant
+    std::visit([this](const auto& v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+            m_discriminatorValue = QString();
+        } else {
+{{#discriminator}}
+{{#mappedModels}}
+            if constexpr (std::is_same_v<T, std::shared_ptr<{{modelName}}>>) {
+                m_discriminatorValue = "{{mappingName}}";
+            }
+{{/mappedModels}}
+{{/discriminator}}
+        }
+    }, value);
+}
+
+{{#discriminator}}
+{{#mappedModels}}
+bool {{classname}}::is{{modelName}}() const {
+    return std::holds_alternative<std::shared_ptr<{{modelName}}>>(m_actualInstance);
+}
+
+std::shared_ptr<{{modelName}}> {{classname}}::as{{modelName}}() const {
+    auto ptr = std::get_if<std::shared_ptr<{{modelName}}>>(const_cast<VariantType *>(&m_actualInstance));
+    return ptr ? *ptr : nullptr;
+}
+{{/mappedModels}}
+{{/discriminator}}
+
+{{#cppNamespaceDeclarations}}
+} // namespace {{this}}
+{{/cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/model-oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/model-oneof.mustache
@@ -1,0 +1,69 @@
+/*
+ * {{classname}}.h - OneOf Model
+ *
+ * {{description}}
+ */
+
+#ifndef {{classname}}_H
+#define {{classname}}_H
+
+#include <QJsonObject>
+#include <QJsonValue>
+#include <memory>
+#include <QString>
+#include <variant>
+
+#include "{{prefix}}Enum.h"
+#include "{{prefix}}Object.h"
+
+{{#cppNamespaceDeclarations}}
+namespace {{this}} {
+{{/cppNamespaceDeclarations}}
+
+{{#discriminator}}
+{{#mappedModels}}
+class {{modelName}};
+{{/mappedModels}}
+{{/discriminator}}
+
+class {{classname}} : public {{prefix}}Object {
+public:
+    {{classname}}();
+    explicit {{classname}}(QString json);
+    ~{{classname}}() override;
+
+    QString asJson() const override;
+    QJsonObject asJsonObject() const override;
+    void fromJsonObject(QJsonObject json) override;
+    void fromJson(QString jsonString) override;
+
+    virtual bool isSet() const override;
+    virtual bool isValid() const override;
+
+{{#discriminator}}
+    typedef std::variant<std::monostate{{#mappedModels}}, std::shared_ptr<{{modelName}}>{{/mappedModels}}> VariantType;
+    void setValue(const VariantType &value);
+{{/discriminator}}
+
+{{#discriminator}}
+{{#mappedModels}}
+    bool is{{modelName}}() const;
+    std::shared_ptr<{{modelName}}> as{{modelName}}() const;
+{{/mappedModels}}
+{{/discriminator}}
+
+private:
+    void initializeModel();
+{{#discriminator}}
+    VariantType m_actualInstance;
+{{/discriminator}}
+    QString m_discriminatorValue;
+};
+
+{{#cppNamespaceDeclarations}}
+} // namespace {{this}}
+{{/cppNamespaceDeclarations}}
+
+Q_DECLARE_METATYPE({{#cppNamespaceDeclarations}}{{this}}::{{/cppNamespaceDeclarations}}{{classname}})
+
+#endif // {{classname}}_H


### PR DESCRIPTION
# Add OneOf/discriminator support for C++ Qt client generator

## Summary
Adds support for OpenAPI `oneOf` schemas with discriminators in the C++ Qt client generator. This implementation uses C++17 `std::variant` to represent polymorphic types in a type-safe manner.

## Changes Made

### New Template Files
- **model-oneof.mustache** - Header template for oneOf models with discriminator
  - Declares variant type containing all mapped model types
  - Provides type checking methods (`isModelName()`) and conversion methods (`asModelName()`)
  - Uses `std::variant` with `std::monostate` for uninitialized state

- **model-oneof-body.mustache** - Implementation template for oneOf models
  - Implements discriminator-based deserialization from JSON
  - Type-safe variant handling using `std::visit`
  - Automatic discriminator value setting when storing instances
  - Validation that delegates to the actual instance

### Modified Template Files
- **model-body.mustache**
  - Added conditional logic to use oneOf template for models with discriminators
  - Added `#include <QJsonValue>` for JSON handling
  
- **model-header.mustache**
  - Added conditional logic to use oneOf header template for models with discriminators
  - Ensures proper template routing based on discriminator presence

## Key Features
- ✅ Type-safe polymorphic model representation using `std::variant`
- ✅ Automatic discriminator field handling during serialization/deserialization
- ✅ Runtime type checking with `isModelName()` methods
- ✅ Safe type conversion with `asModelName()` methods returning `shared_ptr`
- ✅ Proper validation delegation to actual instance types
- ✅ C++17 compliant implementation

## Technical Details
- Uses `std::variant<std::monostate, shared_ptr<Type1>, shared_ptr<Type2>, ...>` for type safety
- Discriminator property is automatically included in JSON output
- Utilizes `std::visit` for variant pattern matching
- Falls back to warning log for unknown discriminator values

## Related Issue
- #6378

@aminya 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds oneOf/discriminator support to the C++ Qt client generator using C++17 std::variant. Enables type-safe polymorphic models with automatic discriminator handling during JSON (de)serialization. Relates to #6378.

- **New Features**
  - Generate oneOf model templates (model-oneof.mustache, model-oneof-body.mustache).
  - Use std::variant<std::monostate, std::shared_ptr<...>> to store mapped models.
  - Deserialize by discriminator value; serialize with discriminator included.
  - Add isModelName() and asModelName() helpers for runtime type checks.
  - Delegate validation to the active instance.

- **Refactors**
  - Route models with discriminators to oneOf templates in model-header.mustache and model-body.mustache.
  - Add QJsonValue include for JSON handling.

<sup>Written for commit bfce96bf265fbb33ae7105dc817e9c379747a573. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

