### PR TITLE
[csharp][generichost] Added xml comments and restrict some access

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/RateLimitProvider`1.mustache
@@ -16,7 +16,11 @@ namespace {{packageName}}.{{clientPackage}}
     /// <typeparam name="TTokenBase"></typeparam>
     {{>visibility}} class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new{{^net70OrLater}} Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>{{/net70OrLater}}();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new{{^net70OrLater}} Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>{{/net70OrLater}}();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -85,7 +89,7 @@ namespace {{packageName}}.{{clientPackage}}
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default{{^netstandard20OrLater}}(global::System.Threading.CancellationToken){{/netstandard20OrLater}})
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default{{^netstandard20OrLater}}(global::System.Threading.CancellationToken){{/netstandard20OrLater}})
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>{{nrt?}} tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/TokenBase.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/TokenBase.mustache
@@ -19,7 +19,16 @@ namespace {{packageName}}.{{clientPackage}}
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler{{nrt?}} TokenBecameAvailable;
 
 

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/TokenProvider`1.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/TokenProvider`1.mustache
@@ -16,6 +16,12 @@ namespace {{packageName}}
     /// </summary>
     {{>visibility}} abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default{{^netstandard20OrLater}}(global::System.Threading.CancellationToken){{/netstandard20OrLater}});
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default{{^netstandard20OrLater}}(global::System.Threading.CancellationToken){{/netstandard20OrLater}});
     }
 }

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/ComposedEnum/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/HelloWorld/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/InlineEnumAnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/OneOfList/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -22,7 +22,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -74,7 +78,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/latest/Tags/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -22,6 +22,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -73,7 +77,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -73,7 +77,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/SourceGeneration/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net10/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.7/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -45,7 +49,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net4.8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -73,7 +77,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -73,7 +77,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net8/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AllOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/AnyOfNoCompare/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/FormModels/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -73,7 +77,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/NullReferenceTypes/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/OneOf/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -73,7 +77,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/SourceGeneration/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -21,7 +21,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -47,7 +51,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase>? tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -17,7 +17,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler? TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/net9/UseDateTimeForDate/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -21,6 +21,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/RateLimitProvider`1.cs
@@ -19,7 +19,11 @@ namespace Org.OpenAPITools.Client
     /// <typeparam name="TTokenBase"></typeparam>
     public class RateLimitProvider<TTokenBase> : TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
+        /// <summary>
+        /// Dictionary mapping header names to channels of available tokens for rate limiting.
+        /// Each channel buffers tokens that have become available and are ready for use.
+        /// </summary>
+        protected internal Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>> AvailableTokens { get; } = new Dictionary<string, global::System.Threading.Channels.Channel<TTokenBase>>();
 
         /// <summary>
         /// Instantiates a ThrottledTokenProvider. Your tokens will be rate limited based on the token's timeout.
@@ -71,7 +75,7 @@ namespace Org.OpenAPITools.Client
         }
 
         /// <inheritdoc/>
-        public override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
+        protected internal override async System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default)
         {
             if (!AvailableTokens.TryGetValue(header, out global::System.Threading.Channels.Channel<TTokenBase> tokens))
                 throw new KeyNotFoundException($"Could not locate a token for header '{header}'.");

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/TokenBase.cs
@@ -15,7 +15,16 @@ namespace Org.OpenAPITools.Client
 
 
         internal TimeSpan? Timeout { get; set; }
+
+        /// <summary>
+        /// Delegate for token availability notification events.
+        /// </summary>
+        /// <param name="sender">The token that became available.</param>
         public delegate void TokenBecameAvailableEventHandler(object sender);
+
+        /// <summary>
+        /// Event raised when a rate-limited token becomes available for use.
+        /// </summary>
         public event TokenBecameAvailableEventHandler TokenBecameAvailable;
 
 

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Client/TokenProvider`1.cs
@@ -19,6 +19,12 @@ namespace Org.OpenAPITools
     /// </summary>
     public abstract class TokenProvider<TTokenBase> where TTokenBase : TokenBase
     {
-        public abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
+        /// <summary>
+        /// Gets a token asynchronously for the specified header.
+        /// </summary>
+        /// <param name="header">The header name to retrieve a token for. Empty string for non-API-key authentication schemes.</param>
+        /// <param name="cancellation">Cancellation token for the asynchronous operation.</param>
+        /// <returns>A task that returns the requested token.</returns>
+        protected internal abstract System.Threading.Tasks.ValueTask<TTokenBase> GetAsync(string header = "", System.Threading.CancellationToken cancellation = default);
     }
 }


### PR DESCRIPTION
@EraYaN please let me know if this causes an issue. Your [pr](https://github.com/OpenAPITools/openapi-generator/pull/22233#event-22212599629) created some warnings, and some of the public things I think can be protected internal.

## C# GenericHost: Add XML documentation and refine access levels for token infrastructure

This PR adds comprehensive XML documentation to the token provider classes and refines access levels to properly restrict internal implementation details while supporting extensibility.

### Changes

**Added XML Documentation**:
- `TokenBecameAvailableEventHandler` delegate - documents the event handler signature for token availability notifications
- `TokenBecameAvailable` event - documents when and why the event is raised
- `TokenProvider<T>.GetAsync()` - documents the token retrieval contract with parameter and return value descriptions
- `RateLimitProvider<T>.AvailableTokens` - documents the internal token buffering dictionary and its purpose

**Access Level Changes**:
- `TokenProvider<T>.GetAsync()`: Changed from `public abstract` to `protected internal abstract` - restricts direct external calls while allowing internal library infrastructure and derived implementations
- `RateLimitProvider<T>.AvailableTokens`: Changed from `public` to `protected internal` - hides implementation detail from external consumers while allowing derived classes to access it
- `RateLimitProvider<T>.GetAsync()`: Changed from `public override` to `protected internal override` - matches the base class access level and restricts visibility


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added XML documentation to the C# GenericHost templates and tightened access on internal token APIs to improve IntelliSense and reduce accidental misuse.

- **Refactors**
  - Added XML docs for TokenBase events/delegates, TokenProvider.GetAsync, and RateLimitProvider.AvailableTokens.
  - Changed TokenProvider<T>.GetAsync from public abstract to protected internal abstract.
  - Changed RateLimitProvider<T>.AvailableTokens from public to protected internal.
  - Updated generated samples to reflect these changes.

- **Migration**
  - If you were calling GetAsync directly or accessing AvailableTokens, move to the public authentication APIs or subclass the provider as needed.

<sup>Written for commit bf90de6dd6666636c02b1dbee828cecb2caef2d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

