### PR TITLE
Philipp guertler keen bugfix/22198 oneof checks unserialized object

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -47,7 +47,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         return json;
     }
     {{/-first}}
-    if (instanceOf{{{.}}}(json)) {
+    if (instanceOf{{{.}}}({{{.}}}FromJSONTyped(json, true))) {
         return {{{.}}}FromJSONTyped(json, true);
     }
     {{/oneOfModels}}
@@ -56,7 +56,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     if (Array.isArray(json)) {
         if (json.every(item => typeof item === 'object')) {
     {{/-first}}
-            if (json.every(item => instanceOf{{{.}}}(item))) {
+            if (json.every(item => instanceOf{{{.}}}({{{.}}}FromJSONTyped(item, true)))) {
                 return json.map(value => {{{.}}}FromJSONTyped(value, true));
             }
     {{#-last}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix oneOf checks in the TypeScript Fetch generator to validate against the deserialized model instead of the raw JSON. This makes oneOf selection reliable for objects and arrays.

- **Bug Fixes**
  - In modelOneOf.mustache, wrap inputs with {Model}FromJSONTyped(..., true) before instanceOf checks, including array items, to avoid false mismatches.

<sup>Written for commit 7b6873b57af0c85103ecbfa2619499503a900751. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

