### PR TITLE
[swift6][client] improve swift 6 thread safety

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/Models.mustache
@@ -70,7 +70,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum ErrorResponse: Error, @unchecked Sendable {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -82,7 +82,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     case requestMissingURL
 }
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/alamofireLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -70,7 +70,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -82,7 +82,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -70,7 +70,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -82,7 +82,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/asyncAwaitLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/default/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/objcCompatible/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/oneOf/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/resultLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-internal enum ErrorResponse: Error, @unchecked Sendable {
+internal enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ internal enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-internal enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+internal enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/urlsessionLibrary/Sources/PetstoreClient/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode

--- a/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
+++ b/samples/client/petstore/swift6/validation/PetstoreClient/Classes/OpenAPIs/Infrastructure/Models.swift
@@ -69,7 +69,7 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 }
 
-public enum ErrorResponse: Error, @unchecked Sendable {
+public enum ErrorResponse: Error, Sendable {
     case error(Int, Data?, URLResponse?, Error)
 }
 
@@ -81,7 +81,7 @@ public enum DownloadException: Error, Sendable {
     case requestMissingURL
 }
 
-public enum DecodableRequestBuilderError: Error, @unchecked Sendable {
+public enum DecodableRequestBuilderError: Error, Sendable {
     case emptyDataResponse
     case nilHTTPResponse
     case unsuccessfulHTTPStatusCode


### PR DESCRIPTION
[swift6][client] improve swift 6 thread safety

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Swift 6 client thread safety by making ErrorResponse and DecodableRequestBuilderError conform to Sendable (removing @unchecked). Updates the Swift 6 generator template and all sample clients to align with Swift concurrency checks.

<sup>Written for commit d63a3c22cb6f02b1fde11eed390783a5faf35998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

