### PR TITLE
[swift6][client] Remove unnecessary Combine checks

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift6/api.mustache
+++ b/modules/openapi-generator/src/main/resources/swift6/api.mustache
@@ -8,9 +8,7 @@
 import Foundation{{#usePromiseKit}}
 @preconcurrency import PromiseKit{{/usePromiseKit}}{{#useRxSwift}}
 @preconcurrency import RxSwift{{/useRxSwift}}{{#useCombine}}
-#if canImport(Combine)
-import Combine
-#endif{{/useCombine}}{{#useVapor}}
+import Combine{{/useCombine}}{{#useVapor}}
 import Vapor{{/useVapor}}{{#swiftUseApiNamespace}}
 
 extension {{projectName}}API {
@@ -161,7 +159,6 @@ extension {{projectName}}API {
      - parameter apiConfiguration: The configuration for the http request.{{/apiStaticMethod}}
      - returns: AnyPublisher<{{{returnType}}}{{#returnType}}{{#isResponseOptional}}?{{/isResponseOptional}}{{/returnType}}{{^returnType}}Void{{/returnType}}, Error>
      */
-    #if canImport(Combine)
     {{#isDeprecated}}
     @available(*, deprecated, message: "This operation is deprecated.")
     {{/isDeprecated}}
@@ -194,7 +191,6 @@ extension {{projectName}}API {
         .eraseToAnyPublisher()
         {{/combineDeferred}}
     }
-    #endif
 {{/useCombine}}
 {{#useAsyncAwait}}
 

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/AnotherFakeAPI.swift
@@ -8,9 +8,7 @@
 import Foundation
 @preconcurrency import PromiseKit
 @preconcurrency import RxSwift
-#if canImport(Combine)
 import Combine
-#endif
 
 open class AnotherFakeAPI {
     public let apiConfiguration: PetstoreClientAPIConfiguration
@@ -86,7 +84,6 @@ open class AnotherFakeAPI {
      - parameter body: (body) client model 
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open func call123testSpecialTags(body: Client) -> AnyPublisher<Client, Error> {
         let requestBuilder = call123testSpecialTagsWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -108,7 +105,6 @@ open class AnotherFakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test special tags

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeAPI.swift
@@ -8,9 +8,7 @@
 import Foundation
 @preconcurrency import PromiseKit
 @preconcurrency import RxSwift
-#if canImport(Combine)
 import Combine
-#endif
 
 open class FakeAPI {
     public let apiConfiguration: PetstoreClientAPIConfiguration
@@ -82,7 +80,6 @@ open class FakeAPI {
      - parameter body: (body) Input boolean as post body (optional)
      - returns: AnyPublisher<Bool, Error>
      */
-    #if canImport(Combine)
     open func fakeOuterBooleanSerialize(body: Bool? = nil) -> AnyPublisher<Bool, Error> {
         let requestBuilder = fakeOuterBooleanSerializeWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -104,7 +101,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
 
@@ -220,7 +216,6 @@ open class FakeAPI {
      - parameter body: (body) Input composite as post body (optional)
      - returns: AnyPublisher<OuterComposite, Error>
      */
-    #if canImport(Combine)
     open func fakeOuterCompositeSerialize(body: OuterComposite? = nil) -> AnyPublisher<OuterComposite, Error> {
         let requestBuilder = fakeOuterCompositeSerializeWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -242,7 +237,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
 
@@ -358,7 +352,6 @@ open class FakeAPI {
      - parameter body: (body) Input number as post body (optional)
      - returns: AnyPublisher<Double, Error>
      */
-    #if canImport(Combine)
     open func fakeOuterNumberSerialize(body: Double? = nil) -> AnyPublisher<Double, Error> {
         let requestBuilder = fakeOuterNumberSerializeWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -380,7 +373,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
 
@@ -496,7 +488,6 @@ open class FakeAPI {
      - parameter body: (body) Input string as post body (optional)
      - returns: AnyPublisher<String, Error>
      */
-    #if canImport(Combine)
     open func fakeOuterStringSerialize(body: String? = nil) -> AnyPublisher<String, Error> {
         let requestBuilder = fakeOuterStringSerializeWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -518,7 +509,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
 
@@ -634,7 +624,6 @@ open class FakeAPI {
      - parameter body: (body)  
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testBodyWithFileSchema(body: FileSchemaTestClass) -> AnyPublisher<Void, Error> {
         let requestBuilder = testBodyWithFileSchemaWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -656,7 +645,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
 
@@ -776,7 +764,6 @@ open class FakeAPI {
      - parameter body: (body)  
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testBodyWithQueryParams(query: String, body: User) -> AnyPublisher<Void, Error> {
         let requestBuilder = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body)
         let requestTask = requestBuilder.requestTask
@@ -798,7 +785,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
 
@@ -923,7 +909,6 @@ open class FakeAPI {
      - parameter body: (body) client model 
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open func testClientModel(body: Client) -> AnyPublisher<Client, Error> {
         let requestBuilder = testClientModelWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -945,7 +930,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test \"client\" model
@@ -1120,7 +1104,6 @@ open class FakeAPI {
      - parameter callback: (form) None (optional)
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: Data? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil) -> AnyPublisher<Void, Error> {
         let requestBuilder = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback)
         let requestTask = requestBuilder.requestTask
@@ -1142,7 +1125,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -1420,7 +1402,6 @@ open class FakeAPI {
      - parameter enumFormString: (form) Form parameter enum test (string) (optional, default to .efg)
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil) -> AnyPublisher<Void, Error> {
         let requestBuilder = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString)
         let requestTask = requestBuilder.requestTask
@@ -1442,7 +1423,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test enum parameters
@@ -1620,7 +1600,6 @@ open class FakeAPI {
      - parameter int64Group: (query) Integer in group parameters (optional)
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil) -> AnyPublisher<Void, Error> {
         let requestBuilder = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group)
         let requestTask = requestBuilder.requestTask
@@ -1642,7 +1621,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Fake endpoint to test group parameters (optional)
@@ -1787,7 +1765,6 @@ open class FakeAPI {
      - parameter param: (body) request body 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testInlineAdditionalProperties(param: [String: String]) -> AnyPublisher<Void, Error> {
         let requestBuilder = testInlineAdditionalPropertiesWithRequestBuilder(param: param)
         let requestTask = requestBuilder.requestTask
@@ -1809,7 +1786,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      test inline additionalProperties
@@ -1935,7 +1911,6 @@ open class FakeAPI {
      - parameter param2: (form) field2 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func testJsonFormData(param: String, param2: String) -> AnyPublisher<Void, Error> {
         let requestBuilder = testJsonFormDataWithRequestBuilder(param: param, param2: param2)
         let requestTask = requestBuilder.requestTask
@@ -1957,7 +1932,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      test json serialization of form data

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/FakeClassnameTags123API.swift
@@ -8,9 +8,7 @@
 import Foundation
 @preconcurrency import PromiseKit
 @preconcurrency import RxSwift
-#if canImport(Combine)
 import Combine
-#endif
 
 open class FakeClassnameTags123API {
     public let apiConfiguration: PetstoreClientAPIConfiguration
@@ -86,7 +84,6 @@ open class FakeClassnameTags123API {
      - parameter body: (body) client model 
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open func testClassname(body: Client) -> AnyPublisher<Client, Error> {
         let requestBuilder = testClassnameWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -108,7 +105,6 @@ open class FakeClassnameTags123API {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test class name in snake case

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/PetAPI.swift
@@ -8,9 +8,7 @@
 import Foundation
 @preconcurrency import PromiseKit
 @preconcurrency import RxSwift
-#if canImport(Combine)
 import Combine
-#endif
 
 open class PetAPI {
     public let apiConfiguration: PetstoreClientAPIConfiguration
@@ -86,7 +84,6 @@ open class PetAPI {
      - parameter body: (body) Pet object that needs to be added to the store 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func addPet(body: Pet) -> AnyPublisher<Void, Error> {
         let requestBuilder = addPetWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -108,7 +105,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Add a new pet to the store
@@ -240,7 +236,6 @@ open class PetAPI {
      - parameter apiKey: (header)  (optional)
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func deletePet(petId: Int64, apiKey: String? = nil) -> AnyPublisher<Void, Error> {
         let requestBuilder = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey)
         let requestTask = requestBuilder.requestTask
@@ -262,7 +257,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Deletes a pet
@@ -402,7 +396,6 @@ open class PetAPI {
      - parameter status: (query) Status values that need to be considered for filter 
      - returns: AnyPublisher<[Pet], Error>
      */
-    #if canImport(Combine)
     open func findPetsByStatus(status: [Status_findPetsByStatus]) -> AnyPublisher<[Pet], Error> {
         let requestBuilder = findPetsByStatusWithRequestBuilder(status: status)
         let requestTask = requestBuilder.requestTask
@@ -424,7 +417,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Finds Pets by status
@@ -555,7 +547,6 @@ open class PetAPI {
      - parameter tags: (query) Tags to filter by 
      - returns: AnyPublisher<[Pet], Error>
      */
-    #if canImport(Combine)
     @available(*, deprecated, message: "This operation is deprecated.")
     open func findPetsByTags(tags: [String]) -> AnyPublisher<[Pet], Error> {
         let requestBuilder = findPetsByTagsWithRequestBuilder(tags: tags)
@@ -578,7 +569,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Finds Pets by tags
@@ -710,7 +700,6 @@ open class PetAPI {
      - parameter petId: (path) ID of pet to return 
      - returns: AnyPublisher<Pet, Error>
      */
-    #if canImport(Combine)
     open func getPetById(petId: Int64) -> AnyPublisher<Pet, Error> {
         let requestBuilder = getPetByIdWithRequestBuilder(petId: petId)
         let requestTask = requestBuilder.requestTask
@@ -732,7 +721,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Find pet by ID
@@ -861,7 +849,6 @@ open class PetAPI {
      - parameter body: (body) Pet object that needs to be added to the store 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func updatePet(body: Pet) -> AnyPublisher<Void, Error> {
         let requestBuilder = updatePetWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -883,7 +870,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Update an existing pet
@@ -1016,7 +1002,6 @@ open class PetAPI {
      - parameter status: (form) Updated status of the pet (optional)
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil) -> AnyPublisher<Void, Error> {
         let requestBuilder = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status)
         let requestTask = requestBuilder.requestTask
@@ -1038,7 +1023,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Updates a pet in the store with form data
@@ -1186,7 +1170,6 @@ open class PetAPI {
      - parameter file: (form) file to upload (optional)
      - returns: AnyPublisher<ApiResponse, Error>
      */
-    #if canImport(Combine)
     open func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: Data? = nil) -> AnyPublisher<ApiResponse, Error> {
         let requestBuilder = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file)
         let requestTask = requestBuilder.requestTask
@@ -1208,7 +1191,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      uploads an image
@@ -1356,7 +1338,6 @@ open class PetAPI {
      - parameter additionalMetadata: (form) Additional data to pass to server (optional)
      - returns: AnyPublisher<ApiResponse, Error>
      */
-    #if canImport(Combine)
     open func uploadFileWithRequiredFile(petId: Int64, requiredFile: Data, additionalMetadata: String? = nil) -> AnyPublisher<ApiResponse, Error> {
         let requestBuilder = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata)
         let requestTask = requestBuilder.requestTask
@@ -1378,7 +1359,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      uploads an image (required)

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/StoreAPI.swift
@@ -8,9 +8,7 @@
 import Foundation
 @preconcurrency import PromiseKit
 @preconcurrency import RxSwift
-#if canImport(Combine)
 import Combine
-#endif
 
 open class StoreAPI {
     public let apiConfiguration: PetstoreClientAPIConfiguration
@@ -86,7 +84,6 @@ open class StoreAPI {
      - parameter orderId: (path) ID of the order that needs to be deleted 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func deleteOrder(orderId: String) -> AnyPublisher<Void, Error> {
         let requestBuilder = deleteOrderWithRequestBuilder(orderId: orderId)
         let requestTask = requestBuilder.requestTask
@@ -108,7 +105,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Delete purchase order by ID
@@ -230,7 +226,6 @@ open class StoreAPI {
      
      - returns: AnyPublisher<[String: Int], Error>
      */
-    #if canImport(Combine)
     open func getInventory() -> AnyPublisher<[String: Int], Error> {
         let requestBuilder = getInventoryWithRequestBuilder()
         let requestTask = requestBuilder.requestTask
@@ -252,7 +247,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Returns pet inventories by status
@@ -375,7 +369,6 @@ open class StoreAPI {
      - parameter orderId: (path) ID of pet that needs to be fetched 
      - returns: AnyPublisher<Order, Error>
      */
-    #if canImport(Combine)
     open func getOrderById(orderId: Int64) -> AnyPublisher<Order, Error> {
         let requestBuilder = getOrderByIdWithRequestBuilder(orderId: orderId)
         let requestTask = requestBuilder.requestTask
@@ -397,7 +390,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Find purchase order by ID
@@ -523,7 +515,6 @@ open class StoreAPI {
      - parameter body: (body) order placed for purchasing the pet 
      - returns: AnyPublisher<Order, Error>
      */
-    #if canImport(Combine)
     open func placeOrder(body: Order) -> AnyPublisher<Order, Error> {
         let requestBuilder = placeOrderWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -545,7 +536,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Place an order for a pet

--- a/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift6/apiNonStaticMethod/Sources/PetstoreClient/APIs/UserAPI.swift
@@ -8,9 +8,7 @@
 import Foundation
 @preconcurrency import PromiseKit
 @preconcurrency import RxSwift
-#if canImport(Combine)
 import Combine
-#endif
 
 open class UserAPI {
     public let apiConfiguration: PetstoreClientAPIConfiguration
@@ -86,7 +84,6 @@ open class UserAPI {
      - parameter body: (body) Created user object 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func createUser(body: User) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUserWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -108,7 +105,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Create user
@@ -231,7 +227,6 @@ open class UserAPI {
      - parameter body: (body) List of user object 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func createUsersWithArrayInput(body: [User]) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUsersWithArrayInputWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -253,7 +248,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Creates list of users with given input array
@@ -375,7 +369,6 @@ open class UserAPI {
      - parameter body: (body) List of user object 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func createUsersWithListInput(body: [User]) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUsersWithListInputWithRequestBuilder(body: body)
         let requestTask = requestBuilder.requestTask
@@ -397,7 +390,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Creates list of users with given input array
@@ -519,7 +511,6 @@ open class UserAPI {
      - parameter username: (path) The name that needs to be deleted 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func deleteUser(username: String) -> AnyPublisher<Void, Error> {
         let requestBuilder = deleteUserWithRequestBuilder(username: username)
         let requestTask = requestBuilder.requestTask
@@ -541,7 +532,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Delete user
@@ -667,7 +657,6 @@ open class UserAPI {
      - parameter username: (path) The name that needs to be fetched. Use user1 for testing. 
      - returns: AnyPublisher<User, Error>
      */
-    #if canImport(Combine)
     open func getUserByName(username: String) -> AnyPublisher<User, Error> {
         let requestBuilder = getUserByNameWithRequestBuilder(username: username)
         let requestTask = requestBuilder.requestTask
@@ -689,7 +678,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Get user by user name
@@ -818,7 +806,6 @@ open class UserAPI {
      - parameter password: (query) The password for login in clear text 
      - returns: AnyPublisher<String, Error>
      */
-    #if canImport(Combine)
     open func loginUser(username: String, password: String) -> AnyPublisher<String, Error> {
         let requestBuilder = loginUserWithRequestBuilder(username: username, password: password)
         let requestTask = requestBuilder.requestTask
@@ -840,7 +827,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Logs user into the system
@@ -966,7 +952,6 @@ open class UserAPI {
      
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func logoutUser() -> AnyPublisher<Void, Error> {
         let requestBuilder = logoutUserWithRequestBuilder()
         let requestTask = requestBuilder.requestTask
@@ -988,7 +973,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Logs out current logged in user session
@@ -1111,7 +1095,6 @@ open class UserAPI {
      - parameter body: (body) Updated user object 
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open func updateUser(username: String, body: User) -> AnyPublisher<Void, Error> {
         let requestBuilder = updateUserWithRequestBuilder(username: username, body: body)
         let requestTask = requestBuilder.requestTask
@@ -1133,7 +1116,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Updated user

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/AnotherFakeAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class AnotherFakeAPI {
 
@@ -19,7 +17,6 @@ open class AnotherFakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open class func call123testSpecialTags(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Client, Error> {
         let requestBuilder = call123testSpecialTagsWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -41,7 +38,6 @@ open class AnotherFakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test special tags

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class FakeAPI {
 
@@ -18,7 +16,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Bool, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterBooleanSerialize(body: Bool? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Bool, Error> {
         let requestBuilder = fakeOuterBooleanSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -40,7 +37,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/boolean
@@ -73,7 +69,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<OuterComposite, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<OuterComposite, Error> {
         let requestBuilder = fakeOuterCompositeSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -95,7 +90,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/composite
@@ -128,7 +122,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Double, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterNumberSerialize(body: Double? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Double, Error> {
         let requestBuilder = fakeOuterNumberSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -150,7 +143,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/number
@@ -183,7 +175,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<String, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterStringSerialize(body: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<String, Error> {
         let requestBuilder = fakeOuterStringSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -205,7 +196,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/string
@@ -238,7 +228,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testBodyWithFileSchema(body: FileSchemaTestClass, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testBodyWithFileSchemaWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -260,7 +249,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - PUT /fake/body-with-file-schema
@@ -294,7 +282,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testBodyWithQueryParams(query: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -316,7 +303,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - PUT /fake/body-with-query-params
@@ -353,7 +339,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open class func testClientModel(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Client, Error> {
         let requestBuilder = testClientModelWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -375,7 +360,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test \"client\" model
@@ -423,7 +407,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -445,7 +428,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -588,7 +570,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -610,7 +591,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test enum parameters
@@ -671,7 +651,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -693,7 +672,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Fake endpoint to test group parameters (optional)
@@ -740,7 +718,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testInlineAdditionalProperties(param: [String: String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testInlineAdditionalPropertiesWithRequestBuilder(param: param, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -762,7 +739,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      test inline additionalProperties
@@ -797,7 +773,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testJsonFormData(param: String, param2: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testJsonFormDataWithRequestBuilder(param: param, param2: param2, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -819,7 +794,6 @@ open class FakeAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      test json serialization of form data

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/FakeClassnameTags123API.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class FakeClassnameTags123API {
 
@@ -19,7 +17,6 @@ open class FakeClassnameTags123API {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open class func testClassname(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Client, Error> {
         let requestBuilder = testClassnameWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -41,7 +38,6 @@ open class FakeClassnameTags123API {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test class name in snake case

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/PetAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class PetAPI {
 
@@ -19,7 +17,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func addPet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = addPetWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -41,7 +38,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Add a new pet to the store
@@ -82,7 +78,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func deletePet(petId: Int64, apiKey: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -104,7 +99,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Deletes a pet
@@ -154,7 +148,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<[Pet], Error>
      */
-    #if canImport(Combine)
     open class func findPetsByStatus(status: [Status_findPetsByStatus], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<[Pet], Error> {
         let requestBuilder = findPetsByStatusWithRequestBuilder(status: status, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -176,7 +169,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Finds Pets by status
@@ -217,7 +209,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<[Pet], Error>
      */
-    #if canImport(Combine)
     @available(*, deprecated, message: "This operation is deprecated.")
     open class func findPetsByTags(tags: [String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<[Pet], Error> {
         let requestBuilder = findPetsByTagsWithRequestBuilder(tags: tags, apiConfiguration: apiConfiguration)
@@ -240,7 +231,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Finds Pets by tags
@@ -282,7 +272,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Pet, Error>
      */
-    #if canImport(Combine)
     open class func getPetById(petId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Pet, Error> {
         let requestBuilder = getPetByIdWithRequestBuilder(petId: petId, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -304,7 +293,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Find pet by ID
@@ -345,7 +333,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func updatePet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = updatePetWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -367,7 +354,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Update an existing pet
@@ -406,7 +392,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -428,7 +413,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Updates a pet in the store with form data
@@ -478,7 +462,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<ApiResponse, Error>
      */
-    #if canImport(Combine)
     open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<ApiResponse, Error> {
         let requestBuilder = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -500,7 +483,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      uploads an image
@@ -550,7 +532,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<ApiResponse, Error>
      */
-    #if canImport(Combine)
     open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<ApiResponse, Error> {
         let requestBuilder = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -572,7 +553,6 @@ open class PetAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      uploads an image (required)

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/StoreAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class StoreAPI {
 
@@ -19,7 +17,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func deleteOrder(orderId: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = deleteOrderWithRequestBuilder(orderId: orderId, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -41,7 +38,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Delete purchase order by ID
@@ -78,7 +74,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<[String: Int], Error>
      */
-    #if canImport(Combine)
     open class func getInventory(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<[String: Int], Error> {
         let requestBuilder = getInventoryWithRequestBuilder(apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -100,7 +95,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Returns pet inventories by status
@@ -137,7 +131,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Order, Error>
      */
-    #if canImport(Combine)
     open class func getOrderById(orderId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Order, Error> {
         let requestBuilder = getOrderByIdWithRequestBuilder(orderId: orderId, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -159,7 +152,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Find purchase order by ID
@@ -197,7 +189,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Order, Error>
      */
-    #if canImport(Combine)
     open class func placeOrder(body: Order, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Order, Error> {
         let requestBuilder = placeOrderWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -219,7 +210,6 @@ open class StoreAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Place an order for a pet

--- a/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift6/combineDeferredLibrary/PetstoreClient/Classes/OpenAPIs/APIs/UserAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class UserAPI {
 
@@ -19,7 +17,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func createUser(body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUserWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -41,7 +38,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Create user
@@ -76,7 +72,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func createUsersWithArrayInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUsersWithArrayInputWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -98,7 +93,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Creates list of users with given input array
@@ -132,7 +126,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func createUsersWithListInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUsersWithListInputWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -154,7 +147,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Creates list of users with given input array
@@ -188,7 +180,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func deleteUser(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = deleteUserWithRequestBuilder(username: username, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -210,7 +201,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Delete user
@@ -248,7 +238,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<User, Error>
      */
-    #if canImport(Combine)
     open class func getUserByName(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<User, Error> {
         let requestBuilder = getUserByNameWithRequestBuilder(username: username, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -270,7 +259,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Get user by user name
@@ -308,7 +296,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<String, Error>
      */
-    #if canImport(Combine)
     open class func loginUser(username: String, password: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<String, Error> {
         let requestBuilder = loginUserWithRequestBuilder(username: username, password: password, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -330,7 +317,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Logs user into the system
@@ -369,7 +355,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func logoutUser(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = logoutUserWithRequestBuilder(apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -391,7 +376,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Logs out current logged in user session
@@ -425,7 +409,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func updateUser(username: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = updateUserWithRequestBuilder(username: username, body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -447,7 +430,6 @@ open class UserAPI {
         }
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Updated user

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/AnotherFakeAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/AnotherFakeAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class AnotherFakeAPI {
 
@@ -19,7 +17,6 @@ open class AnotherFakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open class func call123testSpecialTags(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Client, Error> {
         let requestBuilder = call123testSpecialTagsWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -39,7 +36,6 @@ open class AnotherFakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test special tags

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/FakeAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/FakeAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class FakeAPI {
 
@@ -18,7 +16,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Bool, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterBooleanSerialize(body: Bool? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Bool, Error> {
         let requestBuilder = fakeOuterBooleanSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -38,7 +35,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/boolean
@@ -71,7 +67,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<OuterComposite, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterCompositeSerialize(body: OuterComposite? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<OuterComposite, Error> {
         let requestBuilder = fakeOuterCompositeSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -91,7 +86,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/composite
@@ -124,7 +118,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Double, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterNumberSerialize(body: Double? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Double, Error> {
         let requestBuilder = fakeOuterNumberSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -144,7 +137,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/number
@@ -177,7 +169,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<String, Error>
      */
-    #if canImport(Combine)
     open class func fakeOuterStringSerialize(body: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<String, Error> {
         let requestBuilder = fakeOuterStringSerializeWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -197,7 +188,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - POST /fake/outer/string
@@ -230,7 +220,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testBodyWithFileSchema(body: FileSchemaTestClass, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testBodyWithFileSchemaWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -250,7 +239,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - PUT /fake/body-with-file-schema
@@ -284,7 +272,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testBodyWithQueryParams(query: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testBodyWithQueryParamsWithRequestBuilder(query: query, body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -304,7 +291,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      - PUT /fake/body-with-query-params
@@ -341,7 +327,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open class func testClientModel(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Client, Error> {
         let requestBuilder = testClientModelWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -361,7 +346,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test \"client\" model
@@ -409,7 +393,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testEndpointParameters(number: Double, double: Double, patternWithoutDelimiter: String, byte: Data, integer: Int? = nil, int32: Int? = nil, int64: Int64? = nil, float: Float? = nil, string: String? = nil, binary: URL? = nil, date: Date? = nil, dateTime: Date? = nil, password: String? = nil, callback: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testEndpointParametersWithRequestBuilder(number: number, double: double, patternWithoutDelimiter: patternWithoutDelimiter, byte: byte, integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -429,7 +412,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
@@ -572,7 +554,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testEnumParameters(enumHeaderStringArray: [EnumHeaderStringArray_testEnumParameters]? = nil, enumHeaderString: EnumHeaderString_testEnumParameters? = nil, enumQueryStringArray: [EnumQueryStringArray_testEnumParameters]? = nil, enumQueryString: EnumQueryString_testEnumParameters? = nil, enumQueryInteger: EnumQueryInteger_testEnumParameters? = nil, enumQueryDouble: EnumQueryDouble_testEnumParameters? = nil, enumFormStringArray: [EnumFormStringArray_testEnumParameters]? = nil, enumFormString: EnumFormString_testEnumParameters? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testEnumParametersWithRequestBuilder(enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -592,7 +573,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test enum parameters
@@ -653,7 +633,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testGroupParameters(requiredStringGroup: Int, requiredBooleanGroup: Bool, requiredInt64Group: Int64, stringGroup: Int? = nil, booleanGroup: Bool? = nil, int64Group: Int64? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testGroupParametersWithRequestBuilder(requiredStringGroup: requiredStringGroup, requiredBooleanGroup: requiredBooleanGroup, requiredInt64Group: requiredInt64Group, stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -673,7 +652,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Fake endpoint to test group parameters (optional)
@@ -720,7 +698,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testInlineAdditionalProperties(param: [String: String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testInlineAdditionalPropertiesWithRequestBuilder(param: param, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -740,7 +717,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      test inline additionalProperties
@@ -775,7 +751,6 @@ open class FakeAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func testJsonFormData(param: String, param2: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = testJsonFormDataWithRequestBuilder(param: param, param2: param2, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -795,7 +770,6 @@ open class FakeAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      test json serialization of form data

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/FakeClassnameTags123API.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/FakeClassnameTags123API.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class FakeClassnameTags123API {
 
@@ -19,7 +17,6 @@ open class FakeClassnameTags123API {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Client, Error>
      */
-    #if canImport(Combine)
     open class func testClassname(body: Client, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Client, Error> {
         let requestBuilder = testClassnameWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -39,7 +36,6 @@ open class FakeClassnameTags123API {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      To test class name in snake case

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/PetAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/PetAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class PetAPI {
 
@@ -19,7 +17,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func addPet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = addPetWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -39,7 +36,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Add a new pet to the store
@@ -80,7 +76,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func deletePet(petId: Int64, apiKey: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = deletePetWithRequestBuilder(petId: petId, apiKey: apiKey, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -100,7 +95,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Deletes a pet
@@ -150,7 +144,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<[Pet], Error>
      */
-    #if canImport(Combine)
     open class func findPetsByStatus(status: [Status_findPetsByStatus], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<[Pet], Error> {
         let requestBuilder = findPetsByStatusWithRequestBuilder(status: status, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -170,7 +163,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Finds Pets by status
@@ -211,7 +203,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<[Pet], Error>
      */
-    #if canImport(Combine)
     @available(*, deprecated, message: "This operation is deprecated.")
     open class func findPetsByTags(tags: [String], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<[Pet], Error> {
         let requestBuilder = findPetsByTagsWithRequestBuilder(tags: tags, apiConfiguration: apiConfiguration)
@@ -232,7 +223,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Finds Pets by tags
@@ -274,7 +264,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Pet, Error>
      */
-    #if canImport(Combine)
     open class func getPetById(petId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Pet, Error> {
         let requestBuilder = getPetByIdWithRequestBuilder(petId: petId, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -294,7 +283,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Find pet by ID
@@ -335,7 +323,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func updatePet(body: Pet, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = updatePetWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -355,7 +342,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Update an existing pet
@@ -394,7 +380,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func updatePetWithForm(petId: Int64, name: String? = nil, status: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = updatePetWithFormWithRequestBuilder(petId: petId, name: name, status: status, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -414,7 +399,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Updates a pet in the store with form data
@@ -464,7 +448,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<ApiResponse, Error>
      */
-    #if canImport(Combine)
     open class func uploadFile(petId: Int64, additionalMetadata: String? = nil, file: URL? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<ApiResponse, Error> {
         let requestBuilder = uploadFileWithRequestBuilder(petId: petId, additionalMetadata: additionalMetadata, file: file, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -484,7 +467,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      uploads an image
@@ -534,7 +516,6 @@ open class PetAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<ApiResponse, Error>
      */
-    #if canImport(Combine)
     open class func uploadFileWithRequiredFile(petId: Int64, requiredFile: URL, additionalMetadata: String? = nil, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<ApiResponse, Error> {
         let requestBuilder = uploadFileWithRequiredFileWithRequestBuilder(petId: petId, requiredFile: requiredFile, additionalMetadata: additionalMetadata, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -554,7 +535,6 @@ open class PetAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      uploads an image (required)

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/StoreAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/StoreAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class StoreAPI {
 
@@ -19,7 +17,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func deleteOrder(orderId: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = deleteOrderWithRequestBuilder(orderId: orderId, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -39,7 +36,6 @@ open class StoreAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Delete purchase order by ID
@@ -76,7 +72,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<[String: Int], Error>
      */
-    #if canImport(Combine)
     open class func getInventory(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<[String: Int], Error> {
         let requestBuilder = getInventoryWithRequestBuilder(apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -96,7 +91,6 @@ open class StoreAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Returns pet inventories by status
@@ -133,7 +127,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Order, Error>
      */
-    #if canImport(Combine)
     open class func getOrderById(orderId: Int64, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Order, Error> {
         let requestBuilder = getOrderByIdWithRequestBuilder(orderId: orderId, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -153,7 +146,6 @@ open class StoreAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Find purchase order by ID
@@ -191,7 +183,6 @@ open class StoreAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Order, Error>
      */
-    #if canImport(Combine)
     open class func placeOrder(body: Order, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Order, Error> {
         let requestBuilder = placeOrderWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -211,7 +202,6 @@ open class StoreAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Place an order for a pet

--- a/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/UserAPI.swift
+++ b/samples/client/petstore/swift6/combineLibrary/Sources/CombineLibrary/APIs/UserAPI.swift
@@ -6,9 +6,7 @@
 //
 
 import Foundation
-#if canImport(Combine)
 import Combine
-#endif
 
 open class UserAPI {
 
@@ -19,7 +17,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func createUser(body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUserWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -39,7 +36,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Create user
@@ -74,7 +70,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func createUsersWithArrayInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUsersWithArrayInputWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -94,7 +89,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Creates list of users with given input array
@@ -128,7 +122,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func createUsersWithListInput(body: [User], apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = createUsersWithListInputWithRequestBuilder(body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -148,7 +141,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Creates list of users with given input array
@@ -182,7 +174,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func deleteUser(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = deleteUserWithRequestBuilder(username: username, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -202,7 +193,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Delete user
@@ -240,7 +230,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<User, Error>
      */
-    #if canImport(Combine)
     open class func getUserByName(username: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<User, Error> {
         let requestBuilder = getUserByNameWithRequestBuilder(username: username, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -260,7 +249,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Get user by user name
@@ -298,7 +286,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<String, Error>
      */
-    #if canImport(Combine)
     open class func loginUser(username: String, password: String, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<String, Error> {
         let requestBuilder = loginUserWithRequestBuilder(username: username, password: password, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -318,7 +305,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Logs user into the system
@@ -357,7 +343,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func logoutUser(apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = logoutUserWithRequestBuilder(apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -377,7 +362,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Logs out current logged in user session
@@ -411,7 +395,6 @@ open class UserAPI {
      - parameter apiConfiguration: The configuration for the http request.
      - returns: AnyPublisher<Void, Error>
      */
-    #if canImport(Combine)
     open class func updateUser(username: String, body: User, apiConfiguration: PetstoreClientAPIConfiguration = PetstoreClientAPIConfiguration.shared) -> AnyPublisher<Void, Error> {
         let requestBuilder = updateUserWithRequestBuilder(username: username, body: body, apiConfiguration: apiConfiguration)
         let requestTask = requestBuilder.requestTask
@@ -431,7 +414,6 @@ open class UserAPI {
         })
         .eraseToAnyPublisher()
     }
-    #endif
 
     /**
      Updated user


### PR DESCRIPTION
[swift6][client] Remove unnecessary Combine checks

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed redundant #if canImport(Combine) checks in the Swift 6 client generator and samples, always importing Combine when useCombine is enabled. This simplifies the code and ensures Combine publisher APIs are consistently available.

- **Refactors**
  - Unconditionally import Combine in api.mustache when useCombine is true.
  - Removed #if/#endif guards around Combine publisher methods.
  - Regenerated Swift 6 samples to match the updated template.

<sup>Written for commit 7b9979c186d0b26dc8a29de83b313b63d9934212. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

