### PR TITLE
feat: Make model property generation deterministic by sorting alphabetically

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -723,3 +723,10 @@ Into this securityScheme:
       scheme: bearer
       type: http
 ```
+
+- `SORT_MODEL_PROPERTIES`: When set to true, model properties will be sorted alphabetically by name. This ensures deterministic code generation output regardless of property ordering in the source spec.
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o /tmp/java-okhttp/ --openapi-normalizer SORT_MODEL_PROPERTIES=true
+```


### PR DESCRIPTION
## Summary

added `SORT_MODEL_PROPERTIES` rule to the OpenAPI Normalizer that sorts schema properties alphabetically by name. This ensures deterministic code generation output regardless of property ordering in the source spec, preventing unnecessary diffs like:

```diff
-    'paged'?: boolean;
     'unpaged'?: boolean;
+    'paged'?: boolean;
```

this PR was generated by claude opus 4.5

## Changes

1. **OpenAPINormalizer.java**: Added new `SORT_MODEL_PROPERTIES` rule that:
   - Uses TreeMap to sort properties by natural string order
   - Applies at the OpenAPI normalization stage, working for all generators
   - Is opt-in (defaults to false) to maintain backward compatibility

2. **docs/customization.md**: Added documentation for the new rule

3. **OpenAPINormalizerTest.java**: Added tests for:
   - Verifying properties are sorted when rule is enabled
   - Verifying properties retain original order when rule is disabled (default)

## Usage

```bash
openapi-generator generate \
  -g java \
  -i petstore.yaml \
  -o /tmp/java-client/ \
  --openapi-normalizer SORT_MODEL_PROPERTIES=true
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
