### PR TITLE
[Kotlin][Client] Migrate Enum.values() to Enum.entities

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/data_class.mustache
@@ -176,7 +176,7 @@ import {{packageName}}.infrastructure.ITransformForStorage
 
         override fun deserialize(decoder: Decoder): {{nameInPascalCase}} {
             val value = decoder.decodeSerializableValue({{^isContainer}}{{dataType}}{{/isContainer}}{{#isContainer}}kotlin.String{{/isContainer}}.serializer())
-            return {{nameInPascalCase}}.values().firstOrNull { it.value == value }
+            return {{nameInPascalCase}}.entries.firstOrNull { it.value == value }
                 ?: {{nameInPascalCase}}.{{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}
         }
 
@@ -360,14 +360,14 @@ import {{packageName}}.infrastructure.ITransformForStorage
             {{#isEnum}}
             {{#required}}
             // validate the required field `{{{baseName}}}`
-            require({{{datatypeWithEnum}}}.values().any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
+            require({{{datatypeWithEnum}}}.entries.any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
                 String.format("Expected the field `{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}` to be valid `{{{datatypeWithEnum}}}` enum value in the JSON string but got `%s`", jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].toString())
             }
             {{/required}}
             {{^required}}
             // validate the optional field `{{{baseName}}}`
             if (jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] != null && !jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].isJsonNull) {
-                require({{{datatypeWithEnum}}}.values().any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
+                require({{{datatypeWithEnum}}}.entries.any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
                     String.format("Expected the field `{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}` to be valid `{{{datatypeWithEnum}}}` enum value in the JSON string but got `%s`", jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].toString())
                 }
             }
@@ -376,14 +376,14 @@ import {{packageName}}.infrastructure.ITransformForStorage
             {{#isEnumRef}}
             {{#required}}
             // validate the required field `{{{baseName}}}`
-            require({{{dataType}}}.values().any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
+            require({{{dataType}}}.entries.any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
                 String.format("Expected the field `{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}` to be valid `{{{dataType}}}` enum value in the JSON string but got `%s`", jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].toString())
             }
             {{/required}}
             {{^required}}
             // validate the optional field `{{{baseName}}}`
             if (jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"] != null && !jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].isJsonNull) {
-                require({{{dataType}}}.values().any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
+                require({{{dataType}}}.entries.any { it.value == jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].asString }) {
                     String.format("Expected the field `{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}` to be valid `{{{dataType}}}` enum value in the JSON string but got `%s`", jsonObj["{{#lambda.escapeDollar}}{{baseName}}{{/lambda.escapeDollar}}"].toString())
                 }
             }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/enum_class.mustache
@@ -109,7 +109,7 @@ import kotlinx.serialization.*
 {{^jackson}}
         {{^nonPublicApi}}{{#explicitApi}}public {{/explicitApi}}{{/nonPublicApi}}fun decode(data: kotlin.Any?): {{classname}}? = data?.let {
           val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
+          entries.firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }
@@ -127,7 +127,7 @@ import kotlinx.serialization.*
 {{/isNullable}}
           }
           val normalizedData = "$data".lowercase()
-          return values().firstOrNull { value ->
+          return entries.firstOrNull { value ->
             data == value || normalizedData == "$value".lowercase()
           }{{#isNullable}}{{/isNullable}}{{^isNullable}}{{#enumUnknownDefaultCase}}
             ?: {{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}{{/enumUnknownDefaultCase}}{{^enumUnknownDefaultCase}}
@@ -142,7 +142,7 @@ internal object {{classname}}Serializer : KSerializer<{{classname}}> {
 
     override fun deserialize(decoder: Decoder): {{classname}} {
         val value = decoder.decodeSerializableValue({{{dataType}}}.serializer())
-        return {{classname}}.values().firstOrNull { it.value == value }
+        return {{classname}}.entries.firstOrNull { it.value == value }
             {{#isString}}
             ?: {{classname}}.{{#allowableValues}}{{#enumVars}}{{#-last}}{{&name}}{{/-last}}{{/enumVars}}{{/allowableValues}}
             {{/isString}}
@@ -162,7 +162,7 @@ internal object {{classname}}Serializer : KSerializer<{{classname}}> {
 
     override fun deserialize(decoder: Decoder): {{classname}} {
         val value = decoder.decodeSerializableValue({{{dataType}}}.serializer())
-        return {{classname}}.values().firstOrNull { it.value == value }
+        return {{classname}}.entries.firstOrNull { it.value == value }
             ?: throw IllegalArgumentException("Unknown enum value: $value")
     }
 

--- a/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-okhttp/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
@@ -57,7 +57,7 @@ enum class ApiStringEnumRef(val value: kotlin.String) {
          */
         fun decode(data: kotlin.Any?): ApiStringEnumRef? = data?.let {
           val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
+          entries.firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -67,7 +67,7 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
             throw IllegalArgumentException("Value for StringEnumRef cannot be null")
           }
           val normalizedData = "$data".lowercase()
-          return values().firstOrNull { value ->
+          return entries.firstOrNull { value ->
             data == value || normalizedData == "$value".lowercase()
           }
             ?: unknown_default_open_api

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/StringEnumRef.kt
@@ -67,7 +67,7 @@ enum class StringEnumRef(@get:JsonValue val value: kotlin.String) {
             throw IllegalArgumentException("Value for StringEnumRef cannot be null")
           }
           val normalizedData = "$data".lowercase()
-          return values().firstOrNull { value ->
+          return entries.firstOrNull { value ->
             data == value || normalizedData == "$value".lowercase()
           }
             ?: unknown_default_open_api

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiStringEnumRef.kt
@@ -55,7 +55,7 @@ enum class ApiStringEnumRef(val value: kotlin.String) {
          */
         fun decode(data: kotlin.Any?): ApiStringEnumRef? = data?.let {
           val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
+          entries.firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/models/Code.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/models/Code.kt
@@ -54,7 +54,7 @@ enum class Code(val value: kotlin.Int) {
          */
         fun decode(data: kotlin.Any?): Code? = data?.let {
           val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
+          entries.firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }

--- a/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/models/StringCode.kt
+++ b/samples/client/others/kotlin-integer-enum/src/main/kotlin/org/openapitools/client/models/StringCode.kt
@@ -54,7 +54,7 @@ enum class StringCode(val value: kotlin.String) {
          */
         fun decode(data: kotlin.Any?): StringCode? = data?.let {
           val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
+          entries.firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -81,7 +81,7 @@ data class Order (
 
         override fun deserialize(decoder: Decoder): Status {
             val value = decoder.decodeSerializableValue(kotlin.String.serializer())
-            return Status.values().firstOrNull { it.value == value }
+            return Status.entries.firstOrNull { it.value == value }
                 ?: Status.unknown_default_open_api
         }
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -83,7 +83,7 @@ data class Pet (
 
         override fun deserialize(decoder: Decoder): Status {
             val value = decoder.decodeSerializableValue(kotlin.String.serializer())
-            return Status.values().firstOrNull { it.value == value }
+            return Status.entries.firstOrNull { it.value == value }
                 ?: Status.unknown_default_open_api
         }
 

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiOrder.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiOrder.kt
@@ -135,7 +135,7 @@ data class ApiOrder (
             }
             // validate the optional field `status`
             if (jsonObj["status"] != null && !jsonObj["status"].isJsonNull) {
-                require(Status.values().any { it.value == jsonObj["status"].asString }) {
+                require(Status.entries.any { it.value == jsonObj["status"].asString }) {
                     String.format("Expected the field `status` to be valid `Status` enum value in the JSON string but got `%s`", jsonObj["status"].toString())
                 }
             }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiPet.kt
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/src/main/kotlin/org/openapitools/client/models/ApiPet.kt
@@ -183,7 +183,7 @@ data class ApiPet (
             }
             // validate the optional field `status`
             if (jsonObj["status"] != null && !jsonObj["status"].isJsonNull) {
-                require(Status.values().any { it.value == jsonObj["status"].asString }) {
+                require(Status.entries.any { it.value == jsonObj["status"].asString }) {
                     String.format("Expected the field `status` to be valid `Status` enum value in the JSON string but got `%s`", jsonObj["status"].toString())
                 }
             }

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/models/PetEnum.kt
@@ -62,7 +62,7 @@ enum class PetEnum(val value: kotlin.String) {
          */
         fun decode(data: kotlin.Any?): PetEnum? = data?.let {
           val normalizedData = "$it".lowercase()
-          values().firstOrNull { value ->
+          entries.firstOrNull { value ->
             it == value || normalizedData == "$value".lowercase()
           }
         }
@@ -74,7 +74,7 @@ internal object PetEnumSerializer : KSerializer<PetEnum> {
 
     override fun deserialize(decoder: Decoder): PetEnum {
         val value = decoder.decodeSerializableValue(kotlin.String.serializer())
-        return PetEnum.values().firstOrNull { it.value == value }
+        return PetEnum.entries.firstOrNull { it.value == value }
             ?: PetEnum.UNKNOWN_DEFAULT_OPEN_API
     }
 


### PR DESCRIPTION
[Kotlin][Client] Migrate Enum.values() to Enum.entities

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06) @e5l (2024/10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Kotlin client enum handling from Enum.values() to Enum.entries to use the modern API, cut allocations, and slightly improve performance. Updates the generator templates and regenerated samples; behavior stays the same.

- **Refactors**
  - Switched to entries for enum decode/deserialize and JSON validation in kotlin-client templates.
  - Regenerated Kotlin sample clients to reflect the change.

- **Migration**
  - Ensure your Kotlin stdlib supports Enum.entries (e.g., Kotlin 1.9+).

<sup>Written for commit e555956fb86ba98bea49ff9a589d1fda3190cf4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

