### PR TITLE
fix: apply integer type fitting for Rust params

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustServerCodegenTest.java
@@ -1,0 +1,62 @@
+package org.openapitools.codegen.rust;
+
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Tests for RustServerCodegen.
+ */
+public class RustServerCodegenTest {
+
+    /**
+     * Test that integer parameters with minimum/maximum constraints are assigned appropriate Rust types.
+     * This tests that integer parameter type fitting logic is applied to CodegenParameter objects.
+     */
+    @Test
+    public void testIntegerParameterTypeFitting() throws IOException {
+        Path target = Files.createTempDirectory("test");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("rust-server")
+                .setInputSpec("src/test/resources/3_0/rust-server/integer-params.yaml")
+                .setSkipOverwrite(false)
+                .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+        List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        Path libPath = Path.of(target.toString(), "/src/lib.rs");
+        TestUtils.assertFileExists(libPath);
+
+        // Verify that parameters with known min/max ranges get appropriate types
+        // age: 0-150 should fit in u8
+        TestUtils.assertFileContains(libPath, "age: u8");
+
+        // temperature: -50 to 50 should fit in i8
+        TestUtils.assertFileContains(libPath, "temperature: i8");
+
+        // count: 0-65535 should fit in u16
+        TestUtils.assertFileContains(libPath, "count: u16");
+
+        // offset: -32768 to 32767 should fit in i16
+        TestUtils.assertFileContains(libPath, "offset: i16");
+
+        // large_unsigned: 0-4294967295 should be u32
+        TestUtils.assertFileContains(libPath, "large_unsigned: u32");
+
+        // Verify integer with int32 format and minimum >= 0 becomes u32
+        TestUtils.assertFileContains(libPath, "positive_int32: u32");
+
+        // Verify integer with int64 format and minimum >= 0 becomes u64
+        TestUtils.assertFileContains(libPath, "positive_int64: u64");
+
+        // Clean up
+        target.toFile().deleteOnExit();
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/integer-params.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/integer-params.yaml
@@ -1,0 +1,82 @@
+
+# Test that integer parameters are generated into the right
+# primitives in Rust code.
+openapi: 3.1.1
+info:
+  title: Integer Parameter Type Fitting Test
+  description: Test spec to verify that integer parameters with minimum/maximum constraints get appropriate Rust types
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080
+paths:
+  /test/integers:
+    get:
+      operationId: testIntegerParameters
+      summary: Test integer parameter type fitting
+      parameters:
+        # age: 0-150 should fit in u8 (unsigned, 8-bit)
+        - name: age
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 150
+        # temperature: -50 to 50 should fit in i8 (signed, 8-bit)
+        - name: temperature
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: -50
+            maximum: 50
+        # count: 0-65535 should fit in u16 (unsigned, 16-bit)
+        - name: count
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 65535
+        # offset: -32768 to 32767 should fit in i16 (signed, 16-bit)
+        - name: offset
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: -32768
+            maximum: 32767
+        # large_unsigned: 0-4294967295 should be u32
+        - name: large_unsigned
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 4294967295
+        # positive_int32: format int32 with min >= 0 should become u32
+        - name: positive_int32
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        # positive_int64: format int64 with min >= 0 should become u64
+        - name: positive_int64
+          in: query
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/bin/cli.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/bin/cli.rs
@@ -154,9 +154,9 @@ enum Operation {
         #[clap(value_parser = parse_json::<swagger::ByteArray>)]
         byte: swagger::ByteArray,
         /// None
-        integer: Option<i32>,
+        integer: Option<u32>,
         /// None
-        int32: Option<i32>,
+        int32: Option<u32>,
         /// None
         int64: Option<i64>,
         /// None
@@ -292,7 +292,7 @@ enum Operation {
     /// Find purchase order by ID
     GetOrderById {
         /// ID of pet that needs to be fetched
-        order_id: i64,
+        order_id: u64,
     },
     /// Create user
     CreateUser {

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/fake_api.md
@@ -278,8 +278,8 @@ Name | Type | Description  | Notes
  **double** | **f64**| None | 
  **pattern_without_delimiter** | **String**| None | 
  **byte** | **swagger::ByteArray**| None | 
- **integer** | **i32**| None | 
- **int32** | **i32**| None | 
+ **integer** | **u32**| None | 
+ **int32** | **u32**| None | 
  **int64** | **i64**| None | 
  **float** | **f32**| None | 
  **string** | **String**| None | 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/store_api.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/docs/store_api.md
@@ -96,7 +96,7 @@ For valid response try integer IDs with value <= 5 or > 10. Other values will ge
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-  **order_id** | **i64**| ID of pet that needs to be fetched | 
+  **order_id** | **u64**| ID of pet that needs to be fetched | 
 
 ### Return type
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
@@ -269,8 +269,8 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         double: f64,
         pattern_without_delimiter: String,
         byte: swagger::ByteArray,
-        integer: Option<i32>,
-        int32: Option<i32>,
+        integer: Option<u32>,
+        int32: Option<u32>,
         int64: Option<i64>,
         float: Option<f32>,
         string: Option<String>,
@@ -458,7 +458,7 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     /// Find purchase order by ID
     async fn get_order_by_id(
         &self,
-        order_id: i64,
+        order_id: u64,
         context: &C) -> Result<GetOrderByIdResponse, ApiError>
     {
         info!("get_order_by_id({}) - X-Span-ID: {:?}", order_id, context.get().0.clone());

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -1208,8 +1208,8 @@ impl<S, C, B> Api<C> for Client<S, C> where
         param_double: f64,
         param_pattern_without_delimiter: String,
         param_byte: swagger::ByteArray,
-        param_integer: Option<i32>,
-        param_int32: Option<i32>,
+        param_integer: Option<u32>,
+        param_int32: Option<u32>,
         param_int64: Option<i64>,
         param_float: Option<f32>,
         param_string: Option<String>,
@@ -3032,7 +3032,7 @@ impl<S, C, B> Api<C> for Client<S, C> where
     #[allow(clippy::vec_init_then_push)]
     async fn get_order_by_id(
         &self,
-        param_order_id: i64,
+        param_order_id: u64,
         context: &C) -> Result<GetOrderByIdResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -380,8 +380,8 @@ pub trait Api<C: Send + Sync> {
         double: f64,
         pattern_without_delimiter: String,
         byte: swagger::ByteArray,
-        integer: Option<i32>,
-        int32: Option<i32>,
+        integer: Option<u32>,
+        int32: Option<u32>,
         int64: Option<i64>,
         float: Option<f32>,
         string: Option<String>,
@@ -501,7 +501,7 @@ pub trait Api<C: Send + Sync> {
     /// Find purchase order by ID
     async fn get_order_by_id(
         &self,
-        order_id: i64,
+        order_id: u64,
         context: &C) -> Result<GetOrderByIdResponse, ApiError>;
 
     /// Create user
@@ -620,8 +620,8 @@ pub trait ApiNoContext<C: Send + Sync> {
         double: f64,
         pattern_without_delimiter: String,
         byte: swagger::ByteArray,
-        integer: Option<i32>,
-        int32: Option<i32>,
+        integer: Option<u32>,
+        int32: Option<u32>,
         int64: Option<i64>,
         float: Option<f32>,
         string: Option<String>,
@@ -741,7 +741,7 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Find purchase order by ID
     async fn get_order_by_id(
         &self,
-        order_id: i64,
+        order_id: u64,
         ) -> Result<GetOrderByIdResponse, ApiError>;
 
     /// Create user
@@ -903,8 +903,8 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         double: f64,
         pattern_without_delimiter: String,
         byte: swagger::ByteArray,
-        integer: Option<i32>,
-        int32: Option<i32>,
+        integer: Option<u32>,
+        int32: Option<u32>,
         int64: Option<i64>,
         float: Option<f32>,
         string: Option<String>,
@@ -1092,7 +1092,7 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     /// Find purchase order by ID
     async fn get_order_by_id(
         &self,
-        order_id: i64,
+        order_id: u64,
         ) -> Result<GetOrderByIdResponse, ApiError>
     {
         let context = self.context().clone();

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -2606,7 +2606,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
                     );
 
                 let param_order_id = match percent_encoding::percent_decode(path_params["order_id"].as_bytes()).decode_utf8() {
-                    Ok(param_order_id) => match param_order_id.parse::<i64>() {
+                    Ok(param_order_id) => match param_order_id.parse::<u64>() {
                         Ok(param_order_id) => param_order_id,
                         Err(e) => return Ok(Response::builder()
                                         .status(StatusCode::BAD_REQUEST)


### PR DESCRIPTION
We already have logic in postProcessModelProperty to fit integer parameters into the correct Rust primitives. However, this doesn't apply to other kinds of parameters so integer-typed parameters which end up in function calls for Api traits in lib.rs are always i32, even when this is improper.

This commit refactors integer type fitting so that we can run it on both processParam and model post-processing.

### Testing

I've included a new `RustServerCodegenTest` file and an `integer-params.yaml` test case to cover the new function (and also checked this locally against the API definition which prompted me to contribute this).

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes integer parameter types in the Rust server generator so API trait, client, and server signatures use the correct Rust integer size and signedness instead of defaulting to i32. Applies integer fitting based on format and min/max to both parameters and model properties, and updates samples.

- **Bug Fixes**
  - Apply integer type fitting to CodegenParameter so generated lib.rs, client, and server use the right Rust integer (including unsigned) rather than i32.
  - Update petstore samples (e.g., integer/int32 -> u32, order_id -> u64).

- **Refactors**
  - Extract applyIntegerTypeFitting and reuse for parameters and properties; supports int32/int64/uint32/uint64 and min/max constraints.
  - Add a focused test and spec to assert fitted types in lib.rs.

<sup>Written for commit a8fe886ac7deb3ca4c977a2989aad66bcc26919d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

