### PR TITLE
fix(typescript-axios): Ignore unused parameter on JSON serializer replacer function

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -110,7 +110,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/echo_api/typescript-axios/build/common.ts
+++ b/samples/client/echo_api/typescript-axios/build/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/common.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces-and-with-single-request-param/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -97,7 +97,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -96,7 +96,8 @@ export const setSearchParams = function (url: URL, ...objects: any[]) {
  * This function will run for every key-value pair encountered by JSON.stringify while traversing an object.
  * Converting a set to a string will return an empty object, so an intermediate conversion to an array is required.
  */
-export const replaceWithSerializableTypeIfNeeded = function(key: any, value: any) {
+// @ts-ignore
+export const replaceWithSerializableTypeIfNeeded = function(key: string, value: any) {
     if (value instanceof Set) {
         return Array.from(value);
     } else {


### PR DESCRIPTION
The `JSON.stringify` replacer function defines two parameters, though only one is currently used. Since the Typescript compiler may throw errors depending on configured strictness, an annotation has been added to ignore the unused parameter. Purely for correctness, the type of the `key` parameter was also fixed to `string` in accordance with the original interface definition.

Fixes #22798 

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka @joscha

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses TypeScript strict-mode errors in the typescript-axios JSON.stringify replacer and corrects the parameter type to match the official signature. No runtime changes. Fixes #22798.

- **Bug Fixes**
  - Add // @ts-ignore to ignore the unused key parameter in the replacer.
  - Change replacer signature from (key: any) to (key: string).
  - Update the generator template and regenerate affected samples.

<sup>Written for commit 54f9e750d872d1a3e2d70957594a1522297aa0af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

