### PR TITLE
[BUG] [Groovy] Fix client to work with services that support other formats in addition to JSON

### DIFF
--- a/bin/configs/groovy.yaml
+++ b/bin/configs/groovy.yaml
@@ -3,4 +3,5 @@ outputDir: samples/client/petstore/groovy
 inputSpec: modules/openapi-generator/src/test/resources/3_0/groovy/petstore.yaml
 templateDir: modules/openapi-generator/src/main/resources/Groovy
 additionalProperties:
+  enumPropertyNaming: "original"
   hideGenerationTimestamp: "true"

--- a/modules/openapi-generator/src/main/resources/Groovy/ApiUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/ApiUtils.mustache
@@ -1,10 +1,15 @@
 package {{invokerPackage}}
 
+{{#withXml}}
+import java.io.StringReader
+import {{javaxPackage}}.xml.bind.JAXB
+{{/withXml}}
 import groovy.json.JsonBuilder
 import groovy.json.JsonGenerator
 import groovyx.net.http.ChainedHttpConfig
 import groovyx.net.http.ContentTypes
 import groovyx.net.http.NativeHandlers
+import groovyx.net.http.FromServer
 import groovyx.net.http.ToServer
 
 import static groovyx.net.http.HttpBuilder.configure
@@ -18,24 +23,42 @@ class ApiUtils {
             }
             .build()
 
-    void invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType, method, container, type)  {
+    void invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType, method, container, type)  {
         def (url, uriPath) = buildUrlAndUriPath(basePath, versionPath, resourcePath)
         println "url=$url uriPath=$uriPath"
         def http = configure {
             request.uri = url
             request.uri.path = uriPath
             request.encoder(ContentTypes.JSON, { final ChainedHttpConfig config, final ToServer ts ->
-                final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest();
+                final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest()
                 if (NativeHandlers.Encoders.handleRawUpload(config, ts)) {
-                    return;
+                    return
                 }
 
-                final Object body = NativeHandlers.Encoders.checkNull(request.actualBody());
+                final Object body = NativeHandlers.Encoders.checkNull(request.actualBody())
                 final String json = ((body instanceof String || body instanceof GString)
                         ? body.toString()
-                        : new JsonBuilder(body, jsonGenerator).toString());
-                ts.toServer(NativeHandlers.Encoders.stringToStream(json, request.actualCharset()));
+                        : new JsonBuilder(body, jsonGenerator).toString())
+                ts.toServer(NativeHandlers.Encoders.stringToStream(json, request.actualCharset()))
             })
+            {{#withXml}}
+            request.encoder(ContentTypes.XML, { final ChainedHttpConfig config, final ToServer ts ->
+                final ChainedHttpConfig.ChainedRequest request = config.getChainedRequest()
+                if (NativeHandlers.Encoders.handleRawUpload(config, ts)) {
+                    return
+                }
+
+                final Object body = NativeHandlers.Encoders.checkNull(request.actualBody())
+                String xml
+                if (body instanceof String || body instanceof GString) {
+                    xml = body.toString()
+                } else {
+                    StringWriter writer = new StringWriter()
+                    JAXB.marshal(body, writer)
+                    xml = writer.toString()
+                }
+                ts.toServer(NativeHandlers.Encoders.stringToStream(xml, request.actualCharset()))
+            }){{/withXml}}
         }
         .invokeMethod(String.valueOf(method).toLowerCase()) {
             request.uri.query = queryParams
@@ -43,11 +66,16 @@ class ApiUtils {
             if (bodyParams != null) {
                 request.body = bodyParams
             }
+            request.accept = accept
             request.contentType = contentType
-
-            response.success { resp, json ->
+            {{#withXml}}
+            response.parser(ContentTypes.XML) { final ChainedHttpConfig cfg, final FromServer fs ->
+                fs.inputStream.text
+            }
+            {{/withXml}}
+            response.success { resp, body ->
                 if (type != null) {
-                    onSuccess(parse(json, container, type))
+                    onSuccess(parse(resp, body, container, type))
                 }
             }
             response.failure { resp ->
@@ -68,12 +96,24 @@ class ApiUtils {
         [basePath-pathOnly, pathOnly+versionPath+resourcePath]
     }
 
-    private def parse(object, container, clazz) {
+    private def parse(response, object, container, clazz) {
+        {{#withXml}}
+        if (response.getContentType().toLowerCase().contains("xml")) {
+            return JAXB.unmarshal(new StringReader(object), clazz)
+        }
+        {{/withXml}}
         if (container == "array") {
-            return object.collect {parse(it, "", clazz)}
-        }   else {
+            return object.collect { parse(response, it, "", clazz) }
+        } else {
             return clazz.newInstance(object)
         }
     }
 
+    private def selectHeaderAccept(accepts) {
+        def jsonMime = 'application/json'
+        if (accepts.find { it.toLowerCase().startsWith(jsonMime) }) {
+            return [jsonMime]
+        }
+        return accepts
+    }
 }

--- a/modules/openapi-generator/src/main/resources/Groovy/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/api.mustache
@@ -18,6 +18,7 @@ class {{classname}} {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         {{#allParams}}
@@ -71,7 +72,9 @@ class {{classname}} {
         {{/formParams}}
         {{/hasFormParams}}
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([{{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}}])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "{{httpMethod}}", "{{returnContainer}}",
                     {{#returnBaseType}}{{{.}}}.class {{/returnBaseType}}{{^returnBaseType}}null {{/returnBaseType}})
 

--- a/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/build.gradle.mustache
@@ -1,6 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group = '{{groupId}}'
 version = '{{artifactVersion}}'
@@ -18,6 +19,7 @@ buildscript {
     }
     dependencies {
         classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.24.20')
+        classpath('com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:4.0.4')
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/Groovy/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/model.mustache
@@ -4,6 +4,9 @@ import groovy.transform.Canonical
 {{#imports}}
 import {{import}};
 {{/imports}}
+{{#withXml}}
+import {{javaxPackage}}.xml.bind.annotation.*;
+{{/withXml}}
 
 {{#models}}
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelClass.mustache
@@ -1,3 +1,6 @@
+{{#withXml}}
+@XmlAccessorType(XmlAccessType.NONE)
+{{/withXml}}
 @Canonical
 class {{classname}} {
 {{#vars}}
@@ -16,6 +19,12 @@ class {{classname}} {
 
     {{/isEnum}}
     {{#description}}/* {{{.}}} */{{/description}}
+    {{#withXml}}
+    @Xml{{#isXmlAttribute}}Attribute{{/isXmlAttribute}}{{^isXmlAttribute}}Element{{/isXmlAttribute}}(name = "{{items.xmlName}}{{^items.xmlName}}{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}{{/items.xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+        {{#isXmlWrapped}}
+    @XmlElementWrapper(name = "{{xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}"{{#xmlNamespace}}, namespace = "{{.}}"{{/xmlNamespace}})
+        {{/isXmlWrapped}}
+    {{/withXml}}
     {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}
 {{/vars}}
 }

--- a/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/Groovy/modelEnum.mustache
@@ -1,3 +1,6 @@
+{{#withXml}}
+@XmlEnum
+{{/withXml}}
 enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
 {{#allowableValues}}{{#enumVars}}
     {{#enumDescription}}
@@ -5,6 +8,9 @@ enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEn
         * {{.}}
         */
     {{/enumDescription}}
+    {{#withXml}}
+    @XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+    {{/withXml}}
     {{{name}}}({{{value}}}){{^-last}},
     {{/-last}}{{/enumVars}}{{/allowableValues}}
 

--- a/samples/client/petstore/groovy/build.gradle
+++ b/samples/client/petstore/groovy/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'org.openapitools'
 version = '1.0.0'
@@ -18,6 +19,7 @@ buildscript {
     }
     dependencies {
         classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.24.20')
+        classpath('com.github.johnrengelman.shadow:com.github.johnrengelman.shadow.gradle.plugin:4.0.4')
     }
 }
 

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/PetApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/PetApi.groovy
@@ -16,6 +16,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -29,7 +30,9 @@ class PetApi {
         bodyParams = pet
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     Pet.class )
 
@@ -42,6 +45,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -56,7 +60,9 @@ class PetApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "DELETE", "",
                     null )
 
@@ -69,6 +75,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -83,7 +90,9 @@ class PetApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "array",
                     Pet.class )
 
@@ -96,6 +105,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -110,7 +120,9 @@ class PetApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "array",
                     Pet.class )
 
@@ -123,6 +135,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -134,7 +147,9 @@ class PetApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "",
                     Pet.class )
 
@@ -147,6 +162,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -160,7 +176,9 @@ class PetApi {
         bodyParams = pet
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "PUT", "",
                     Pet.class )
 
@@ -173,6 +191,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -188,7 +207,9 @@ class PetApi {
         bodyParams.put("name", name)
         bodyParams.put("status", status)
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     null )
 
@@ -201,6 +222,7 @@ class PetApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -216,7 +238,9 @@ class PetApi {
         bodyParams.put("additionalMetadata", additionalMetadata)
         bodyParams.put("file", _file)
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     ModelApiResponse.class )
 

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/StoreApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/StoreApi.groovy
@@ -15,6 +15,7 @@ class StoreApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -26,7 +27,9 @@ class StoreApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "DELETE", "",
                     null )
 
@@ -39,6 +42,7 @@ class StoreApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
 
@@ -46,7 +50,9 @@ class StoreApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "map",
                     Integer.class )
 
@@ -59,6 +65,7 @@ class StoreApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -70,7 +77,9 @@ class StoreApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "",
                     Order.class )
 
@@ -83,6 +92,7 @@ class StoreApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -96,7 +106,9 @@ class StoreApi {
         bodyParams = order
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     Order.class )
 

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/UserApi.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/api/UserApi.groovy
@@ -15,6 +15,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -28,7 +29,9 @@ class UserApi {
         bodyParams = user
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     null )
 
@@ -41,6 +44,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -54,7 +58,9 @@ class UserApi {
         bodyParams = user
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     null )
 
@@ -67,6 +73,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -80,7 +87,9 @@ class UserApi {
         bodyParams = user
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "POST", "",
                     null )
 
@@ -93,6 +102,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -104,7 +114,9 @@ class UserApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "DELETE", "",
                     null )
 
@@ -117,6 +129,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -128,7 +141,9 @@ class UserApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "",
                     User.class )
 
@@ -141,6 +156,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -162,7 +178,9 @@ class UserApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept(["application/xml", "application/json"])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "",
                     String.class )
 
@@ -175,6 +193,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
 
@@ -182,7 +201,9 @@ class UserApi {
 
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "GET", "",
                     null )
 
@@ -195,6 +216,7 @@ class UserApi {
         def queryParams = [:]
         def headerParams = [:]
         def bodyParams
+        def accept
         def contentType
 
         // verify required params are set
@@ -212,7 +234,9 @@ class UserApi {
         bodyParams = user
 
 
-        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, contentType,
+        accept = apiUtils.selectHeaderAccept([])
+
+        apiUtils.invokeApi(onSuccess, onFailure, basePath, versionPath, resourcePath, queryParams, headerParams, bodyParams, accept, contentType,
                     "PUT", "",
                     null )
 

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Order.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Order.groovy
@@ -17,11 +17,11 @@ class Order {
 
     enum StatusEnum {
     
-        PLACED("placed"),
+        placed("placed"),
         
-        APPROVED("approved"),
+        approved("approved"),
         
-        DELIVERED("delivered")
+        delivered("delivered")
     
         private final String value
     

--- a/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Pet.groovy
+++ b/samples/client/petstore/groovy/src/main/groovy/org/openapitools/model/Pet.groovy
@@ -23,11 +23,11 @@ class Pet {
 
     enum StatusEnum {
     
-        AVAILABLE("available"),
+        available("available"),
         
-        PENDING("pending"),
+        pending("pending"),
         
-        SOLD("sold")
+        sold("sold")
     
         private final String value
     

--- a/samples/client/petstore/groovy/src/test/groovy/openapitools/PetApiTest.groovy
+++ b/samples/client/petstore/groovy/src/test/groovy/openapitools/PetApiTest.groovy
@@ -49,7 +49,7 @@ class PetApiTest extends GroovyTestCase  {
         def pet = new Pet()
         pet.setId(this.petId)
         pet.setName("groovy client updatetest")
-        //pet.setStatus("pending")
+        pet.setStatus(Pet.StatusEnum.pending)
         this.petApi.updatePet(pet) {
         }
         {
@@ -61,7 +61,7 @@ class PetApiTest extends GroovyTestCase  {
             def petGetted = (Pet)it
             assertEquals(this.petId, petGetted.getId())
             assertEquals("groovy client updatetest", petGetted.getName())
-            //assertEquals("pending", petGetted.getStatus())
+            assertEquals(Pet.StatusEnum.pending, petGetted.getStatus())
         }
         {
             statusCode, message ->
@@ -75,16 +75,16 @@ class PetApiTest extends GroovyTestCase  {
                 assertEquals(200, statusCode)
         };
 
-        //this.petApi.getPetById(this.petId) {
-        //    def petGetted = (Pet)it
-        //    assertEquals(this.petId, petGetted.getId())
-        //    assertEquals("groovy client updatetestwithform", petGetted.getName())
-        //    assertEquals("sold", petGetted.getStatus())
-        //}
-        //{
-        //    statusCode, message ->
-        //        assertEquals(200, statusCode)
-        //};
+        this.petApi.getPetById(this.petId) {
+            def petGetted = (Pet)it
+            assertEquals(this.petId, petGetted.getId())
+            assertEquals("groovy client updatetestwithform", petGetted.getName())
+            assertEquals(Pet.StatusEnum.sold, petGetted.getStatus())
+        }
+        {
+            statusCode, message ->
+            assertEquals(200, statusCode)
+        };
 
         this.petApi.deletePet(this.petId, "apiKey") {
         }
@@ -104,17 +104,16 @@ class PetApiTest extends GroovyTestCase  {
 
     }
 
-    //@Ignore("due to illegal argument exception in findPetByStatus")
-    //@Test
-    //void testGetPetByStatus() {
-    //    this.petApi.findPetsByStatus(["sold"]) {
-    //        def listPets = (ArrayList)it
-    //        assertTrue(listPets.size() > 0)
-    //    }
-    //    {
-    //        statusCode, message ->
-    //            assertEquals(200, statusCode)
-    //    };
-    //}
+    @Test
+    void testGetPetByStatus() {
+        this.petApi.findPetsByStatus(["sold"]) {
+            def listPets = (ArrayList)it
+            assertTrue(listPets.size() > 0)
+        }
+        {
+            statusCode, message ->
+                assertEquals(200, statusCode)
+        };
+    }
 
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes the Groovy client to add the Accept header since it only supports JSON wire format as of now.
It also includes some fixes for the sample tests, because the current client implementation doesn't seem to deal with the enum conversion and the redirect from http to https correctly.

You can ensure its behavior as follows:

Build openapi-generator and generate the Groovy sample with JDK 11+:

```
$ ./mvnw clean install
$ bin/generate-samples.sh bin/configs/groovy.yaml
```

Run the sample tests against the generated client with JDK 8:

```
$ cd samples/client/petstore/groovy
$ gradle wrapper
$ ./gradlew clean build --info

(snip)

openapitools.PetApiTest > testGetPetByStatus STANDARD_OUT
    url=https://petstore.swagger.io uriPath=/v2/pet/findByStatus

openapitools.PetApiTest > testGetPetByStatus STANDARD_ERROR
    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

openapitools.PetApiTest > testUpdateOnePet STANDARD_OUT
    url=https://petstore.swagger.io uriPath=/v2/pet
    url=https://petstore.swagger.io uriPath=/v2/pet/10009
    url=https://petstore.swagger.io uriPath=/v2/pet/10009
    url=https://petstore.swagger.io uriPath=/v2/pet/10009
    url=https://petstore.swagger.io uriPath=/v2/pet/10009
    url=https://petstore.swagger.io uriPath=/v2/pet/10009

openapitools.PetApiTest > testAddAndGetPet STANDARD_OUT
    url=https://petstore.swagger.io uriPath=/v2/pet
    url=https://petstore.swagger.io uriPath=/v2/pet/10009

Gradle Test Executor 6 finished executing tests.

(snip)

BUILD SUCCESSFUL in 4s
5 actionable tasks: 5 executed
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
  fixes #22907
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  No one is in the Groovy technical committee as of now, so let me ping @wing328 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Accept header per operation using each operation’s produces list (preferring application/json), and add JAXB-based XML request/response support so Groovy clients work with servers that offer JSON or XML. Fixes #22907.

- **New Features**
  - XML support end-to-end: JAXB annotations in models and XML encode/decode in the client when the spec declares XML.
  - Add Gradle Shadow plugin to generator and samples to produce fat jars.

- **Bug Fixes**
  - Use operation produces to set Accept via selectHeaderAccept and generator templates; prefer application/json when available.
  - Preserve enum names (enumPropertyNaming: original) and update Pet/Order enums and tests to use typed enums.
  - Switch sample base URLs to https to avoid http→https redirects.
  - Add a Groovy-specific petstore.yaml and point groovy.yaml inputSpec to it.

<sup>Written for commit c3fa24709ffc9b22806a5012ae872c75ce73a1da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

