### PR TITLE
[rust] fix #22147 handle rust generating null

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -308,6 +308,9 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
                     // In-placed type (primitive), because there is no mapping or ref for it.
                     // use camelized `title` if present, otherwise use `type`
                     String oneOfName = Optional.ofNullable(schema.getTitle()).orElseGet(schema::getType);
+                    if (oneOfName == null) {
+                        oneOfName = "Variant" + i;
+                    }
                     oneOf.setName(toModelName(oneOfName));
                 }
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/rust/RustClientCodegenTest.java
@@ -271,4 +271,22 @@ public class RustClientCodegenTest {
         TestUtils.assertFileExists(outputPath);
         TestUtils.assertFileContains(outputPath, enumSpec);
     }
+
+    @Test
+    public void testAnonymousOneOfGeneratesRustModel() throws IOException {
+        Path target = Files.createTempDirectory("test_anonymous_one_of");
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("rust")
+                .setInputSpec("src/test/resources/3_0/rust/rust-anonymous-oneof-model.yaml")
+                .setOutputDir(target.toAbsolutePath().toString().replace("\\", "/"));
+
+        try {
+            List<File> files = new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+            files.forEach(File::deleteOnExit);
+            Path outputPath = Path.of(target.toString(), "/src/models/custom_fields_attributes.rs");
+            TestUtils.assertFileExists(outputPath);
+        } finally {
+            target.toFile().deleteOnExit();
+        }
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/rust/rust-anonymous-oneof-model.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust/rust-anonymous-oneof-model.yaml
@@ -1,0 +1,50 @@
+openapi: 3.1.0
+info:
+  title: Rust Anonymous OneOf Model
+  version: 1.0.0
+paths:
+  /example:
+    patch:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                custom_fields_attributes:
+                  $ref: "#/components/schemas/custom_fields_attributes"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+components:
+  schemas:
+    custom_fields_attributes:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: object
+            properties:
+              id:
+                type:
+                  - integer
+                  - string
+              value:
+                type: string
+            required:
+              - id
+              - value
+        - type: array
+          items:
+            type: object
+            properties:
+              id:
+                type:
+                  - integer
+                  - string
+              value:
+                type: string


### PR DESCRIPTION
- avoid using null values for further processing
- this resolves #22147 
- I added the API spec from the issue to the Test suite

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Rust codegen for anonymous oneOf variants that were generating null names, so models build correctly. Fixes #22147.

- **Bug Fixes**
  - Use "Variant{i}" when a oneOf schema has no title or type, avoiding null variant names.
  - Added a test with the issue’s API spec (rust-anonymous-oneof-model.yaml) to verify model generation.

<sup>Written for commit cfeea187f4814cdccfd81fe2816cfc3d00b5a372. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

