### PR TITLE
[cpp-qt-client]Use currentSecsSinceEpoch instead of currentDateTime().toSecsSinceEpoch()

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.cpp.mustache
@@ -47,7 +47,7 @@ void {{prefix}}HttpRequestInput::add_file(QString variable_name, QString local_f
 
 {{prefix}}HttpRequestWorker::{{prefix}}HttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
-    randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
+    randomGenerator = QRandomGenerator(QDateTime::currentSecsSinceEpoch());
     if (manager == nullptr) {
         manager = new QNetworkAccessManager(this);
     }
@@ -206,7 +206,7 @@ void {{prefix}}HttpRequestWorker::execute({{prefix}}HttpRequestInput *input) {
         // variable layout is MULTIPART
 
         boundary = QString("__-----------------------%1%2")
-                            .arg(QDateTime::currentDateTime().toSecsSinceEpoch())
+                            .arg(QDateTime::currentSecsSinceEpoch())
                             .arg(randomGenerator.generate());
         QString boundary_delimiter = "--";
         QString new_line = "\r\n";

--- a/samples/client/petstore/cpp-qt-addDownloadProgress/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt-addDownloadProgress/client/PFXHttpRequest.cpp
@@ -54,7 +54,7 @@ void PFXHttpRequestInput::add_file(QString variable_name, QString local_filename
 
 PFXHttpRequestWorker::PFXHttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
-    randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
+    randomGenerator = QRandomGenerator(QDateTime::currentSecsSinceEpoch());
     if (manager == nullptr) {
         manager = new QNetworkAccessManager(this);
     }
@@ -213,7 +213,7 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
         // variable layout is MULTIPART
 
         boundary = QString("__-----------------------%1%2")
-                            .arg(QDateTime::currentDateTime().toSecsSinceEpoch())
+                            .arg(QDateTime::currentSecsSinceEpoch())
                             .arg(randomGenerator.generate());
         QString boundary_delimiter = "--";
         QString new_line = "\r\n";

--- a/samples/client/petstore/cpp-qt/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXHttpRequest.cpp
@@ -54,7 +54,7 @@ void PFXHttpRequestInput::add_file(QString variable_name, QString local_filename
 
 PFXHttpRequestWorker::PFXHttpRequestWorker(QObject *parent, QNetworkAccessManager *_manager)
     : QObject(parent), manager(_manager), timeOutTimer(this), isResponseCompressionEnabled(false), isRequestCompressionEnabled(false), httpResponseCode(-1) {
-    randomGenerator = QRandomGenerator(QDateTime::currentDateTime().toSecsSinceEpoch());
+    randomGenerator = QRandomGenerator(QDateTime::currentSecsSinceEpoch());
     if (manager == nullptr) {
         manager = new QNetworkAccessManager(this);
     }
@@ -213,7 +213,7 @@ void PFXHttpRequestWorker::execute(PFXHttpRequestInput *input) {
         // variable layout is MULTIPART
 
         boundary = QString("__-----------------------%1%2")
-                            .arg(QDateTime::currentDateTime().toSecsSinceEpoch())
+                            .arg(QDateTime::currentSecsSinceEpoch())
                             .arg(randomGenerator.generate());
         QString boundary_delimiter = "--";
         QString new_line = "\r\n";


### PR DESCRIPTION
Use QDateTime::currentSecsSinceEpoch instead of QDateTime::currentDateTime().toSecsSinceEpoch()

Recommended by clazy checks

summon @etherealjoy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced QDateTime::currentDateTime().toSecsSinceEpoch() with QDateTime::currentSecsSinceEpoch() in the Qt HTTP request code (generator template and petstore samples). This avoids unnecessary object creation per clazy and updates the RNG seed and multipart boundary to use epoch seconds.

<sup>Written for commit ae03b4661082cd788079657ffc28307ffe23622c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

