### PR TITLE
[cpp-qt-client]Prefix signal argument types with namespace

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.h.mustache
@@ -71,7 +71,7 @@ public:
     int  getHttpResponseCode() const;
 
 Q_SIGNALS:
-    void on_execution_finished({{prefix}}HttpRequestWorker *worker);
+    void on_execution_finished({{#cppNamespaceDeclarations}}{{this}}::{{/cppNamespaceDeclarations}}{{prefix}}HttpRequestWorker *worker);
     void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
 
 private:

--- a/samples/client/petstore/cpp-qt-addDownloadProgress/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt-addDownloadProgress/client/PFXHttpRequest.h
@@ -79,7 +79,7 @@ public:
     int  getHttpResponseCode() const;
 
 Q_SIGNALS:
-    void on_execution_finished(PFXHttpRequestWorker *worker);
+    void on_execution_finished(test_namespace::PFXHttpRequestWorker *worker);
     void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
 
 private:

--- a/samples/client/petstore/cpp-qt/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt/client/PFXHttpRequest.h
@@ -79,7 +79,7 @@ public:
     int  getHttpResponseCode() const;
 
 Q_SIGNALS:
-    void on_execution_finished(PFXHttpRequestWorker *worker);
+    void on_execution_finished(test_namespace::PFXHttpRequestWorker *worker);
     void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
 
 private:


### PR DESCRIPTION
For reason see: https://github.com/KDE/clazy/blob/master/docs/checks/README-fully-qualified-moc-types.md

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fully qualify the on_execution_finished signal argument across cpp-qt-client to ensure proper moc type resolution in namespaced builds and satisfy clazy’s fully-qualified moc types check.

- **Bug Fixes**
  - Update HttpRequest.h.mustache to use on_execution_finished({{#cppNamespaceDeclarations}}{{this}}::{{/cppNamespaceDeclarations}}{{prefix}}HttpRequestWorker*).
  - Update generated sample headers to use on_execution_finished(test_namespace::PFXHttpRequestWorker*).

<sup>Written for commit 2d245343e3d289bc6284e4cf23e93c2bd7002c5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

