### PR TITLE
fix scalac compiler deprecation warnings in test for the mill-plugin

### DIFF
--- a/modules/openapi-generator-mill-plugin/src/test/scala/org/openapitools/generator/mill/MillOpenapiModuleTest.scala
+++ b/modules/openapi-generator-mill-plugin/src/test/scala/org/openapitools/generator/mill/MillOpenapiModuleTest.scala
@@ -95,7 +95,7 @@ class MillOpenapiModuleTest extends Matchers {
       eval.apply(MillOpenapiModuleTestRoot.petstoreMicroprofile.compile)
     }
 
-    result shouldBe a[Right[_, _]]
+    result shouldBe a[Right[?, ?]]
   }
 
   @Test
@@ -104,6 +104,6 @@ class MillOpenapiModuleTest extends Matchers {
       // execute 'compile` task
       eval.apply(MillOpenapiModuleTestRoot.petstoreInvalid.compile)
     }
-    result shouldBe a[Left[_, _]]
+    result shouldBe a[Left[?, ?]]
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scalac deprecation warnings in the mill-plugin tests by switching type wildcards in matcher assertions from _ to ? for Either patterns. Test behavior is unchanged.

<sup>Written for commit 24791e44fc2b3dc17f14f7a2931a1346036d84bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

