### PR TITLE
fix(python): missing field_validator import for UUID properties with pattern

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -2064,6 +2064,10 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 moduleImports.add("pydantic", "field_validator");
             }
 
+            if (cp.getPattern() != null) {
+                moduleImports.add("pydantic", "field_validator");
+            }
+
             if (cp.getIsArray()) {
                 return arrayType(cp);
             } else if (cp.getIsMap() || cp.getIsFreeFormObject()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/python/PythonClientCodegenTest.java
@@ -660,6 +660,16 @@ public class PythonClientCodegenTest {
         TestUtils.assertFileNotContains(pyprojectPath, "license = { text = \"Apache-2.0\" }");
     }
 
+    @Test(description = "UUID property with pattern should import field_validator")
+    public void testUuidWithPatternImportsFieldValidator() throws IOException {
+        final DefaultCodegen codegen = new PythonClientCodegen();
+        final String outputPath = generateFiles(codegen, "src/test/resources/bugs/issue_uuid_with_pattern.yaml");
+        final Path p = Paths.get(outputPath + "openapi_client/models/uuid_with_pattern.py");
+
+        assertFileExists(p);
+        assertFileContains(p, "from pydantic import BaseModel, ConfigDict, field_validator");
+    }
+
     @Test(description = "Verify non-poetry1 mode uses object notation for license")
     public void testNonPoetry1LicenseFormat() throws IOException {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();

--- a/modules/openapi-generator/src/test/resources/bugs/issue_uuid_with_pattern.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_uuid_with_pattern.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Test UUID with pattern
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    UuidWithPattern:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          pattern: "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"


### PR DESCRIPTION
When an OpenAPI schema property has both `format: uuid` and a `pattern` constraint, the Python client generator emits a `@field_validator` decorator in the generated model but fails to add the corresponding `from pydantic import field_validator` import. This causes a `NameError` at runtime.

**Root cause:** In `AbstractPythonCodegen`, the `PydanticType.fromCommon()` type dispatch is an exclusive if/else chain. UUID is checked before string, so `uuidType()` is called (which doesn't handle patterns) and `stringType()` (which adds the `field_validator` import for patterns) is never reached. Meanwhile, the mustache template emits `@field_validator` based on the `x-regex` vendor extension, which is set independently for any property with a pattern.

**Fix:** Add a type-independent `pattern != null` check in `fromCommon()` before the type dispatch, ensuring `field_validator` is imported for any property type that has a pattern constraint.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix missing pydantic field_validator import in generated Python models when a UUID property also has a pattern, preventing a runtime NameError.

- **Bug Fixes**
  - Always import field_validator when a property has a pattern, regardless of type (added check in fromCommon).
  - Added a test with a UUID + pattern schema to confirm the import is present.

<sup>Written for commit c666f03041683de03f6acf0cd25b5d771fb87d5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

