### PR TITLE
Add support for ApiKey auth to rust-server

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -977,7 +977,6 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
 
             for (CodegenSecurity s : op.authMethods) {
                 if (s.isApiKey && s.isKeyInHeader) {
-                    s.vendorExtensions.put("x-api-key-name", toModelName(s.keyParamName));
                     headerAuthMethods = true;
                 }
 

--- a/modules/openapi-generator/src/main/resources/rust-server/bin-cli.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/bin-cli.mustache
@@ -86,6 +86,12 @@ struct Cli {
     bearer_token: Option<String>,
 {{/hasOAuthMethods}}
 {{/hasHttpBearerMethods}}
+{{#hasApiKeyMethods}}
+
+    /// API key for authentication
+    #[arg(long, env = "{{#lambda.uppercase}}{{externCrateName}}{{/lambda.uppercase}}_API_KEY", hide_env = true)]
+    api_key: Option<String>,
+{{/hasApiKeyMethods}}
 }
 
 #[derive(Parser, Debug)]
@@ -187,6 +193,12 @@ async fn main() -> Result<()> {
         debug!("Using bearer token");
         auth_data = AuthData::bearer(bearer_token);
     }
+{{#hasApiKeyMethods}}
+    if let Some(ref api_key) = args.api_key {
+        debug!("Using API key");
+        auth_data = Some(AuthData::apikey(api_key));
+    }
+{{/hasApiKeyMethods}}
 {{/hasHttpBearerMethods}}
 {{^hasHttpBearerMethods}}
   {{#hasOAuthMethods}}
@@ -196,11 +208,27 @@ async fn main() -> Result<()> {
         debug!("Using bearer token");
         auth_data = AuthData::bearer(bearer_token);
     }
+{{#hasApiKeyMethods}}
+    if let Some(ref api_key) = args.api_key {
+        debug!("Using API key");
+        auth_data = Some(AuthData::apikey(api_key));
+    }
+{{/hasApiKeyMethods}}
   {{/hasOAuthMethods}}
 {{/hasHttpBearerMethods}}
 {{^hasHttpBearerMethods}}
   {{^hasOAuthMethods}}
+{{#hasApiKeyMethods}}
+    let mut auth_data: Option<AuthData> = None;
+
+    if let Some(ref api_key) = args.api_key {
+        debug!("Using API key");
+        auth_data = Some(AuthData::apikey(api_key));
+    }
+{{/hasApiKeyMethods}}
+{{^hasApiKeyMethods}}
     let auth_data: Option<AuthData> = None;
+{{/hasApiKeyMethods}}
   {{/hasOAuthMethods}}
 {{/hasHttpBearerMethods}}
 

--- a/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-operation.mustache
@@ -99,7 +99,6 @@
         #[allow(clippy::collapsible_match)]
         if let Some(auth_data) = Has::<Option<AuthData>>::get(context).as_ref() {
             use headers::authorization::Credentials;
-            {{! Currently only authentication with Basic and Bearer are supported }}
             #[allow(clippy::single_match, clippy::match_single_binding)]
             match auth_data {
             {{#authMethods}}
@@ -135,6 +134,19 @@
                 },
                 {{/isBasicBearer}}
                 {{/isOAuth}}
+                {{#isApiKey}}
+                {{#isKeyInHeader}}
+                AuthData::ApiKey(ref api_key) => {
+                    let header = match HeaderValue::from_str(api_key.as_str()) {
+                        Ok(h) => h,
+                        Err(e) => return Err(ApiError(format!("Unable to create header: {e}")))
+                    };
+                    request.headers_mut().insert(
+                        HeaderName::from_static("{{#lambda.lowercase}}{{{keyParamName}}}{{/lambda.lowercase}}"),
+                        header);
+                },
+                {{/isKeyInHeader}}
+                {{/isApiKey}}
             {{/authMethods}}
                 _ => {}
             }

--- a/modules/openapi-generator/src/main/resources/rust-server/context.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/context.mustache
@@ -142,7 +142,7 @@ impl<T, A, B, C, ReqBody> Service<Request<ReqBody>> for AddContext<T, A>
         {
             use swagger::auth::api_key_from_header;
 
-            if let Some(header) = api_key_from_header(headers, "{{exts.x-key-param-name-lower}}") {
+            if let Some(header) = api_key_from_header(headers, "{{#lambda.lowercase}}{{{keyParamName}}}{{/lambda.lowercase}}") {
                 let auth_data = AuthData::ApiKey(header);
                 let context = context.push(Some(auth_data));
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/bin/cli.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/bin/cli.rs
@@ -97,6 +97,10 @@ struct Cli {
     /// Bearer token if used for authentication
     #[arg(env = "PETSTORE_WITH_FAKE_ENDPOINTS_MODELS_FOR_TESTING_BEARER_TOKEN", hide_env = true)]
     bearer_token: Option<String>,
+
+    /// API key for authentication
+    #[arg(long, env = "PETSTORE_WITH_FAKE_ENDPOINTS_MODELS_FOR_TESTING_API_KEY", hide_env = true)]
+    api_key: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -397,6 +401,10 @@ async fn main() -> Result<()> {
     if let Some(ref bearer_token) = args.bearer_token {
         debug!("Using bearer token");
         auth_data = AuthData::bearer(bearer_token);
+    }
+    if let Some(ref api_key) = args.api_key {
+        debug!("Using API key");
+        auth_data = Some(AuthData::apikey(api_key));
     }
 
     #[allow(trivial_casts)]

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/client/mod.rs
@@ -2476,6 +2476,15 @@ impl<S, C, B> Api<C> for Client<S, C> where
             use headers::authorization::Credentials;
             #[allow(clippy::single_match, clippy::match_single_binding)]
             match auth_data {
+                AuthData::ApiKey(ref api_key) => {
+                    let header = match HeaderValue::from_str(api_key.as_str()) {
+                        Ok(h) => h,
+                        Err(e) => return Err(ApiError(format!("Unable to create header: {e}")))
+                    };
+                    request.headers_mut().insert(
+                        HeaderName::from_static("api_key"),
+                        header);
+                },
                 _ => {}
             }
         }
@@ -2848,6 +2857,15 @@ impl<S, C, B> Api<C> for Client<S, C> where
             use headers::authorization::Credentials;
             #[allow(clippy::single_match, clippy::match_single_binding)]
             match auth_data {
+                AuthData::ApiKey(ref api_key) => {
+                    let header = match HeaderValue::from_str(api_key.as_str()) {
+                        Ok(h) => h,
+                        Err(e) => return Err(ApiError(format!("Unable to create header: {e}")))
+                    };
+                    request.headers_mut().insert(
+                        HeaderName::from_static("api_key"),
+                        header);
+                },
                 _ => {}
             }
         }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/context.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/context.rs
@@ -114,7 +114,7 @@ impl<T, A, B, C, ReqBody> Service<Request<ReqBody>> for AddContext<T, A>
         {
             use swagger::auth::api_key_from_header;
 
-            if let Some(header) = api_key_from_header(headers, "") {
+            if let Some(header) = api_key_from_header(headers, "api_key") {
                 let auth_data = AuthData::ApiKey(header);
                 let context = context.push(Some(auth_data));
 


### PR DESCRIPTION
Add ApiKey auth support to rust-server. This adds support to the client side and fixes the broken server side ApiKey support. 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ApiKey authentication to the rust-server and its generated client. The CLI can pass an API key, the client sends it in the header, and the server now reads it correctly.

- **New Features**
  - CLI support: --api-key and ENV VAR <CRATE_NAME>_API_KEY.
  - Client adds the ApiKey as a header using the security scheme’s keyParamName.

- **Bug Fixes**
  - Server extracts the ApiKey from request headers using the security scheme’s keyParamName (lowercased), restoring header-based ApiKey auth.
  - Removed reliance on a vendor extension for the header name.

<sup>Written for commit ff7f5d17aec306a7accef6c5fc140a00720e225a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

