### PR TITLE
fix(java-webclient): resolve Java 21 this-escape warnings in ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache
@@ -107,7 +107,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         this.dateFormat = createDefaultDateFormat();
         this.objectMapper = createDefaultObjectMapper(this.dateFormat);
         this.webClient = buildWebClient(this.objectMapper);
-        this.init();
+        this.authentications = init();
     }
 
     public ApiClient(WebClient webClient) {
@@ -126,7 +126,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
-        this.init();
+        this.authentications = init();
     }
 
     public static DateFormat createDefaultDateFormat() {
@@ -150,15 +150,15 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         return mapper;
     }
 
-    protected void init() {
+    private static Map<String, Authentication> init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
+        Map<String, Authentication> authentications = new HashMap<String, Authentication>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
         authentications.put("{{name}}", new HttpBasicAuth());{{/isBasicBasic}}{{#isBasicBearer}}
         authentications.put("{{name}}", new HttpBearerAuth("{{scheme}}"));{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
         authentications.put("{{name}}", new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}}, "{{keyParamName}}"));{{/isApiKey}}{{#isOAuth}}
         authentications.put("{{name}}", new OAuth());{{/isOAuth}}{{/authMethods}}
         // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return Collections.unmodifiableMap(authentications);
     }
 
     /**

--- a/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -100,7 +100,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.dateFormat = createDefaultDateFormat();
         this.objectMapper = createDefaultObjectMapper(this.dateFormat);
         this.webClient = buildWebClient(this.objectMapper);
-        this.init();
+        this.authentications = init();
     }
 
     public ApiClient(WebClient webClient) {
@@ -119,7 +119,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
-        this.init();
+        this.authentications = init();
     }
 
     public static DateFormat createDefaultDateFormat() {
@@ -141,11 +141,11 @@ public class ApiClient extends JavaTimeFormatter {
         return mapper;
     }
 
-    protected void init() {
+    private static Map<String, Authentication> init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();
+        Map<String, Authentication> authentications = new HashMap<String, Authentication>();
         // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return Collections.unmodifiableMap(authentications);
     }
 
     /**

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -101,7 +101,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.dateFormat = createDefaultDateFormat();
         this.objectMapper = createDefaultObjectMapper(this.dateFormat);
         this.webClient = buildWebClient(this.objectMapper);
-        this.init();
+        this.authentications = init();
     }
 
     public ApiClient(WebClient webClient) {
@@ -120,7 +120,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
-        this.init();
+        this.authentications = init();
     }
 
     public static DateFormat createDefaultDateFormat() {
@@ -142,16 +142,16 @@ public class ApiClient extends JavaTimeFormatter {
         return mapper;
     }
 
-    protected void init() {
+    private static Map<String, Authentication> init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();
+        Map<String, Authentication> authentications = new HashMap<String, Authentication>();
         authentications.put("petstore_auth", new OAuth());
         authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
         authentications.put("api_key_query", new ApiKeyAuth("query", "api_key_query"));
         authentications.put("http_basic_test", new HttpBasicAuth());
         authentications.put("bearer_test", new HttpBearerAuth("bearer"));
         // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return Collections.unmodifiableMap(authentications);
     }
 
     /**

--- a/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-nullable-arrays/src/main/java/org/openapitools/client/ApiClient.java
@@ -100,7 +100,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.dateFormat = createDefaultDateFormat();
         this.objectMapper = createDefaultObjectMapper(this.dateFormat);
         this.webClient = buildWebClient(this.objectMapper);
-        this.init();
+        this.authentications = init();
     }
 
     public ApiClient(WebClient webClient) {
@@ -119,7 +119,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
-        this.init();
+        this.authentications = init();
     }
 
     public static DateFormat createDefaultDateFormat() {
@@ -141,11 +141,11 @@ public class ApiClient extends JavaTimeFormatter {
         return mapper;
     }
 
-    protected void init() {
+    private static Map<String, Authentication> init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();
+        Map<String, Authentication> authentications = new HashMap<String, Authentication>();
         // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return Collections.unmodifiableMap(authentications);
     }
 
     /**

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -101,7 +101,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.dateFormat = createDefaultDateFormat();
         this.objectMapper = createDefaultObjectMapper(this.dateFormat);
         this.webClient = buildWebClient(this.objectMapper);
-        this.init();
+        this.authentications = init();
     }
 
     public ApiClient(WebClient webClient) {
@@ -120,7 +120,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
-        this.init();
+        this.authentications = init();
     }
 
     public static DateFormat createDefaultDateFormat() {
@@ -142,16 +142,16 @@ public class ApiClient extends JavaTimeFormatter {
         return mapper;
     }
 
-    protected void init() {
+    private static Map<String, Authentication> init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();
+        Map<String, Authentication> authentications = new HashMap<String, Authentication>();
         authentications.put("petstore_auth", new OAuth());
         authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
         authentications.put("api_key_query", new ApiKeyAuth("query", "api_key_query"));
         authentications.put("http_basic_test", new HttpBasicAuth());
         authentications.put("bearer_test", new HttpBearerAuth("bearer"));
         // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return Collections.unmodifiableMap(authentications);
     }
 
     /**

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -101,7 +101,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.dateFormat = createDefaultDateFormat();
         this.objectMapper = createDefaultObjectMapper(this.dateFormat);
         this.webClient = buildWebClient(this.objectMapper);
-        this.init();
+        this.authentications = init();
     }
 
     public ApiClient(WebClient webClient) {
@@ -120,7 +120,7 @@ public class ApiClient extends JavaTimeFormatter {
         this.webClient = webClient;
         this.dateFormat = format;
         this.objectMapper = createDefaultObjectMapper(format);
-        this.init();
+        this.authentications = init();
     }
 
     public static DateFormat createDefaultDateFormat() {
@@ -142,16 +142,16 @@ public class ApiClient extends JavaTimeFormatter {
         return mapper;
     }
 
-    protected void init() {
+    private static Map<String, Authentication> init() {
         // Setup authentications (key: authentication name, value: authentication).
-        authentications = new HashMap<String, Authentication>();
+        Map<String, Authentication> authentications = new HashMap<String, Authentication>();
         authentications.put("petstore_auth", new OAuth());
         authentications.put("api_key", new ApiKeyAuth("header", "api_key"));
         authentications.put("api_key_query", new ApiKeyAuth("query", "api_key_query"));
         authentications.put("http_basic_test", new HttpBasicAuth());
         authentications.put("bearer_test", new HttpBearerAuth("bearer"));
         // Prevent the authentications from being modified.
-        authentications = Collections.unmodifiableMap(authentications);
+        return Collections.unmodifiableMap(authentications);
     }
 
     /**


### PR DESCRIPTION
### Summary

Fixes Java 21 `this-escape` compiler warnings in the generated `ApiClient` class for the **webclient** library. These warnings become build errors when `-Xlint:all -Werror` is used.

fix #17475

### Changes

Changed `init()` from a `protected` instance method to a `private static` factory method that returns the authentications map. Constructors now assign the result directly (`this.authentications = init()`) instead of calling `this.init()`.

This eliminates the `this` escape because a static method has no `this` reference, so there is no possibility of leaking a partially constructed object.

### Files changed

- **Template**: `modules/openapi-generator/src/main/resources/Java/libraries/webclient/ApiClient.mustache`
- **Samples**: Updated all 5 webclient sample `ApiClient.java` files to reflect the generated output

### How to reproduce (before fix)

1. Generate Java webclient code from any OpenAPI spec
2. Compile with JDK 21 using `-Xlint:all -Werror`
3. Build fails with 7 `this-escape` warnings promoted to errors

### How to verify (after fix)

Same steps as above — build succeeds with zero warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Java 21 this-escape warnings in the generated webclient ApiClient by replacing the instance init() with a private static factory that returns an unmodifiable authentications map. Builds now pass under -Xlint:all -Werror.

- **Bug Fixes**
  - Changed init() to private static Map<String, Authentication> init() and assign via constructors (this.authentications = init()) to prevent this escaping during construction.
  - Updated the webclient ApiClient template and regenerated sample clients.

<sup>Written for commit c4eb2fa7207eff3d4d5ad48af6644f713a0eac7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

